### PR TITLE
feat: blob-URL mapping, agent-push tokens, bats suite (v0.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,180 @@
+# AGENTS.md: the operating layer
+
+> Tool-agnostic front door. Any agent runtime (Claude Code, Codex, Gemini, a
+> human) reads this first to learn how work is done in this repo. It carries the
+> portable operate-contract: what to read, how to run a unit of work, when work
+> is done, and when to stop and ask.
+
+## Enforcement boundary (read this first)
+
+**This file is a contract, not a guardrail.** Enforcement is Claude-Code-only: the
+hooks (safety-gate, push-to-main blocker, anti-rationalization Stop hook, the
+verification pipeline) are what actually block bad outcomes, and they run only
+under Claude Code. Under any other runtime (Codex, Gemini, a bare LLM)
+`AGENTS.md` is **advisory only**: it tells an agent what to do, but nothing
+enforces it. Do not assume the guardrails are portable. They are not, until the
+v3.x multi-runtime agent-hook work lands. See `docs/PHILOSOPHY.md` (honesty rule:
+never over-claim portable enforcement) and `CLAUDE.md` for the CC-specific layer
+(hooks, slash commands, plugin). The full layering contract, which hook
+backstops what and why (hard / advisory / convenience), is
+`docs/architecture.md` "Hook fallback layer".
+
+The rest of this file is four portable zones. The goal-crafter
+(`commands/assign.md`) projects them into a six-section `/goal` (see "How a goal
+is composed" at the end).
+
+---
+
+## 1. Read in this order
+
+Orient before you touch anything. Read top to bottom; stop when you have enough.
+
+1. **AGENTS.md** (this file) - how work is done here; the operate-contract.
+2. **CLAUDE.md** - the Claude-Code layer: stack, structure, rules, hooks, commands, plugin.
+3. **docs/specs/SPEC-NNN-<slug>.md** - the active spec; the shared contract for the cycle. Read its `## Verification` and `## After state` before implementing.
+4. **docs/architecture.md** / **WORKFLOW.md** / **docs/data-flow.md** - reference, not required per task. Read `docs/architecture.md` for how the pieces fit; `docs/data-flow.md` for how DATA moves (the signal path telemetry -> proposal -> board, the ledger write/read paths, the module map); read `WORKFLOW.md` for the lanes and the gate at each phase boundary, and its "Mega-goal delegate execution" section for how a multi-sub-goal mega-goal run dispatches (delegate mode: one fresh headless session per sub-goal; `/goal` stays the official outer loop either way).
+
+## 2. Task loop
+
+How to do one unit of work. The smallest verifiable increment, verified, committed.
+
+0. **Take work.** Handed a task: use it. **Handed a WAVE (2+ items approved in one
+   conversation): enqueue every item as a board row FIRST (queued; the in-flight one
+   executing), then pull them one at a time.** Work that never touches the board is
+   invisible to the board's state machine even when its runs are ledgered, the gap an
+   operator caught live on 2026-06-10 (SPEC-064). Not handed one: pull the board's top queued item,
+   `bash lib/board/backlog.sh next`, claim it (goal-registry) and flip it to `claimed` (the
+   `/kit:assign --next` flow). The BACKLOG is the board; its Status column is the state
+   machine (`queued -> claimed -> speccing -> validated -> executing -> shipped`, + parked/
+   dropped). Operator-named work is unchanged; pull is an additional trigger, never a daemon.
+1. **Classify the type, then size the lane.** `bash lib/classify/task-type-classify.sh classify "<task>"`
+   first: `spec-feature` picks a lane below; any other type (incident / reconcile / operate /
+   planning / learning / eval / research / review / doc / migration / data-tool) runs its TYPE LOOP per
+   `WORKFLOW.md ## Type loops`, with its executor from the registry's `agent` column. The lane
+   is STILL sized for every type (it is the evidence contract ship-gate enforces via the spec's
+   `Lane:` header; the type is the content contract , `WORKFLOW.md ### Lane x type composition`). For code:
+   pick `tiny` / `normal` / `full` / `bug` / `backfill` per `WORKFLOW.md`; when in doubt between
+   two lanes, take the heavier one. **Between classification and done comes the grill** (`/kit:grill`, or its
+   one-question-at-a-time discipline driven inline): interview until the task is actually
+   understood, type-shaped questions, recommended answers, contradictions checked against the
+   repo, answers WRITTEN as they resolve (glossary / sparse ADR / the goal draft's Context).
+   Tiny lane exempt. **Record the grill's disposition either way** (SPEC-063):
+   `bash lib/gate/gate-ledger.sh record <rid> grill ran "<N> branches resolved"`, or, when the
+   conversation already resolved the banks, `... record <rid> grill skipped "<why>"`; a
+   skip without a reason is invisible to telemetry, which defeats the point.
+   **Then phase 0: define the done scenario**
+   (`bash lib/gate/proof-gate.sh contract "<task>"` + the type's test-design dialect,
+   test-design-standard §5b) BEFORE any work runs; the grill's answers are the done's raw
+   material, and the goal draft carries the `Done =` line.
+2. **Read the spec and its acceptance criteria.** For a spec-driven task: the active spec's task row, its AC, its `## Verification`, and its `## After state`. No spec (tiny lane): the one obvious edit.
+3. **Implement the smallest verifiable increment.** One logical change. No speculative features, no premature abstraction; clarity over cleverness.
+4. **Verify.** Run the spec's `## Verification` command (or the lane's check). Do not claim a result you did not run.
+5. **Commit.** Conventional commit, one logical change. No spec/ticket IDs in the subject line.
+
+If you cannot make progress, see zone 4 (Pause if) and stop with a named blocker note. Do not churn.
+
+**One rid per run, derived from the branch (SPEC-070).** `<rid>` everywhere below is `$(bash lib/gate/gate-ledger.sh rid)`: the branch slug (`type/` prefix stripped), the same key `hooks/ship-gate.sh` checks at push, so assign-time records and ship-time enforcement meet with no mirror re-records. Derive it AFTER the work branch exists; the verb refuses master/main/detached.
+
+**Show the road, then your position on it (SPEC-063).** Right after a lane is committed,
+print the checklist the run will walk: `bash lib/gate/gate-ledger.sh plan <lane>`. At each phase
+entry, print where the run stands: `bash lib/gate/gate-ledger.sh progress <rid> <lane>`
+(one status line: `<rid> · <lane> · step k/n (<phase>)` + the ✓/▶/· checklist). For the
+full story of a past or in-flight run: `bash lib/telemetry/lane-telemetry.sh trace <rid>`.
+
+**Escalate the review for enforcement surfaces (SPEC-069).** A run touching `lib/` or
+`hooks/` uses `/kit:review-team` (multi-lens), not a single reviewer.
+
+**Record your gates (ADR-0024).** When you run a phase gate (`/kit:spec`, `/kit:spec-validate`, `/kit:execute`, `/kit:review`, `/kit:docs`, `/kit:ship`, ...), record it so the run is auditable: `bash lib/gate/gate-ledger.sh record <rid> <Phase> ran`; record a deliberate skip as `skipped "<why>"`. The `ship-gate` hook refuses a push whose lane has a required gate with no `ran`/`override` entry. Phase ORDER matters too: the lane plan is the V-model descent order; `bash lib/gate/gate-ledger.sh descent <rid> <lane>` names out-of-order records, surfaced at ship as an advisory (SPEC-076). Full convention + the logged-override path: WORKFLOW.md "## Gate ledger and ship enforcement".
+
+**Gates are also MEASURED, not just recorded (SPEC-129).** Beside `ran`/`skipped`, `bash lib/gate/gate-ledger.sh outcome <rid> <phase> start|end [caught=<bool>]` brackets a gate with a duration and whether it caught a defect, on the same additive marker convention (a fourth `| OUTCOME |` line beside `| GATE | / | DEBT | / | TOKENS |`; existing readers ignore it). The only live emitter today is `hooks/ship-gate.sh` at the ship boundary, HOOK-ENFORCED but ship-boundary-only, not yet per-phase; read it back with `outcome-read`. **A parallel wave closes the SPEC-number race at dispatch, not at spec-time (SPEC-128).** `lib/queue/orchestrate.sh`'s own wavefront dispatch atomically reserves a number per sub-goal via `bash lib/spec/spec-next.sh reserve` (a portable mkdir-mutex over an append-only reservations ledger) before any worker can race `spec-next.sh next`; a standalone session still calls `spec-next.sh next` directly, unaffected. **Generate the confirmation table, never hand-author it (SPEC-132).** `bash lib/gate/proof-table-gen.sh <rid>` renders `docs/verification/generated/<rid>.md` from the same gate/run ledger (surfacing the OUTCOME column above when present); see `docs/verification/README.md` "Generators write run ledgers, never the canonical." Full detail on all three, plus the two advisory measurement gates (coverage-delta, mutation-smoke): WORKFLOW.md "## Gate ledger and ship enforcement" and "## Advisory measurement gates".
+
+## 3. Done means
+
+A task or goal is done only when **its acceptance criteria are met AND the
+verifier actually ran the check**, not when you claim they pass. Self-reported
+"done" is not proof. The check compares against the `Done =` scenario defined at
+phase 0, whatever the work's type (PHILOSOPHY §6 N3): if no done scenario was
+defined before the work ran, the work was not assignable, and "done" has nothing
+to be measured against.
+
+Concretely, done means: **acceptance criteria met, the check actually ran (not
+just asserted), review recorded + report written, and the final response says
+what changed and what was not attempted.** If you could not run the check, report
+that plainly; the anti-rationalization hook is the backstop for premature
+completion under Claude Code, but the honesty obligation is yours under any
+runtime.
+
+**Deployable-done (ADR-0028, reusing ADR-0025).** DEPLOYABLE work is anything that runs
+somewhere , a service, a daemon, a feature behind a flag, or any change `lib/gate/proof-ledger.sh
+classify` puts in its `stateful` class (deploy / rollout / production / migration / schema /
+database / persistent-state signals in the diff or commit subjects). For deployable work,
+`done` = **a deploy-proof + a UAT/acceptance run**: the existing ADR-0025 stateful proof
+shape (a recorded run with `Command:`/`Exit:` AND a `rollback` note or `[UNAVAILABLE:
+reason]`) PLUS a UAT/acceptance line recording that the change was exercised in the target
+environment and accepted. This is enforced at ship by the SAME `hooks/ship-gate.sh` ->
+`proof-ledger.sh check` wall every stateful change already passes through , the ship-gate
+already DETECTS deployability (it classifies `stateful`), so a deployable item marked done
+without the deploy-proof is blocked exactly like any other unproven stateful change, or
+needs a logged override (`proof-ledger.sh override <slug> "<reason>"`). INERT, library,
+refactor, and docs work (the `inert`/`behavioral` classes) is unchanged , it owes no
+deploy-proof or UAT.
+
+**Understanding is a separate, advisory axis (ADR-0031) -- orthogonal to Done means above.**
+A design record (before build) and an explainer + quiz nudge (at merge) gate the human's
+PARTICIPATION and ATTENTION, never correctness: they never change what "done" means here, never
+block a correct build, and are not enforced by any hook the way the verification gates are.
+Full model: `WORKFLOW.md` "## The understanding axis".
+
+## 4. Pause if (ask a human)
+
+Stop and ask a human before acting on any of these. These are decisions with
+direction or irreversible cost that a goal loop must not make on its own.
+
+- **Architecture direction** - a change to how the pieces fit, a new component, an interface or data-model shape.
+- **Source-of-truth hierarchy** - which file or section is canonical when two disagree (for example, moving the operate-contract between `AGENTS.md`, `CLAUDE.md`, and `WORKFLOW.md`).
+- **Validation removal** - weakening, deleting, or bypassing a test, an assertion, a hook, or any guardrail.
+- **Risk-classification change** - moving work to a lighter lane, or narrowing a `full`-lane trigger (auth, authz, hooks, data model, data loss, audit/security, external provider, API contract, migration).
+- **Privacy / security** - secrets, credentials, access scope, anything that touches what data leaves the repo or who can reach it.
+
+When you pause: write the named blocker, state the decision you are not making and why, and stop.
+
+---
+
+## How the kit composes (subsystem modules)
+
+The kit is a **toolbox of self-contained subsystem modules under `lib/<subsystem>/`**
+(board, classify, gate, goal, queue, session, spec, stats, telemetry, plus the ledger
+substrate and single-purpose orphans), not one appliance you switch on. "tool" vs "lib"
+describes a module's SURFACE (leaf/human vs internal-helper), not its location; there is no
+separate `tools/` tree. Each multi-verb subsystem exposes a **standalone `<subsystem> <verb>`
+command** (`board next`, `gate ledger ...`, `classify ...`, `spec ...`, `goal ...`,
+`session ...`) that forwards to the script owning that verb; the internal
+`bash lib/<subsystem>/<file>.sh` form used throughout the task loop still works unchanged.
+There is no `kit` uber-dispatcher, each command's own `--help` is the discovery surface. The
+read plane is **`stats`**: a stateless projection recomputed on demand from the append-only
+ledger, never a persisted second source of truth.
+
+Adoption is **layered, not all-or-nothing**. `install.sh` wires the essential spine
+unconditionally (the SDD ship discipline: safety-gate, ship-gate, spec-drift-guard,
+secrets-guard, commit-format, anti-rationalization) and opt-in modules only when asked
+(`install.sh --with board,session,stats,...`), recording the enabled set in the consumer's
+`kit.toml [modules]` manifest, an install artifact that records the choice, never read at
+runtime. Full adoption model + rationale: `docs/PHILOSOPHY.md` and `README.md`.
+
+---
+
+## How a goal is composed (for `commands/assign.md`)
+
+The goal-crafter projects these four zones into a six-section `/goal`. The mapping
+is a **composition, not 1:1**: two of the six sections come from the active spec,
+not from this file. Keep the four zone names stable; renaming one without updating
+`commands/assign.md` breaks the projection.
+
+| `/goal` section | Source |
+|---|---|
+| Context-to-read | AGENTS.md zone 1 (Read in this order) |
+| Constraints | CLAUDE.md / AGENTS.md rules |
+| Operating rules | AGENTS.md zone 2 (Task loop) |
+| Validation loop | the active spec's `## Verification` |
+| Done-when | AGENTS.md zone 3 (Done means) + the active spec's `## After state` |
+| Pause-if | AGENTS.md zone 4 (Pause if) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.0 (2026-07-16)
+
+- GitHub blob/raw URLs (`github.com/o/r/blob/<ref>/<path>#L<n>`, `/raw/`,
+  `raw.githubusercontent.com`) now open the LOCAL checkout at the line when one
+  resolves (current repo by name, plain resolve chain, `QUICKLOOK_ROOTS/<repo>`);
+  refs containing `/` are handled by successive splits; unresolvable URLs fall
+  back to the browser. `#L42-L60` ranges keep the start line.
+- Agent-push: token priority is `$QUICKLOOK_TOKEN` env > script argument >
+  clipboard, in both actions; `preview` forwards an argument into the pane via
+  `--env`. Agents can now put a file on screen without touching the clipboard.
+- `resolve` always returns an absolute path (fixes a latent bug where a
+  cwd-relative hit failed open-in-viewer's repo-containment check).
+- bats test suite (`bats tests/`) over the resolve chain, token parsing,
+  classification, and priority; shellcheck + bats documented as the dev loop.
+
 ## 0.1.0 (2026-07-16)
 
 Initial release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,12 @@
 Repo rule: commits in this repository carry NO AI-attribution trailers
 (no `Co-Authored-By: Claude ...` or similar). Keep commit messages plain
 Conventional Commits.
+
+<!-- kit:adopt -->
+## Operating layer (dwarves-kit)
+
+@AGENTS.md
+
+Before touching code, classify the lane: `bash /Users/tieubao/.claude/dwarves-kit/bin/classify lane classify "<task>"`.
+A full-lane change records its gates via `/Users/tieubao/.claude/dwarves-kit/bin/gate ledger` or the ship-gate blocks the push.
+<!-- /kit:adopt -->

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ pluck the path, pop the file.
 
 | Clipboard content | What happens |
 |---|---|
-| `https://…` / `http://…` | Opens in your default browser |
+| a GitHub **blob/raw URL** (`github.com/o/r/blob/main/src/x.go#L42`) | Opens the file in your **local checkout** at that line when one exists (current repo, worktrees, `QUICKLOOK_ROOTS/<repo>`); otherwise the browser |
+| any other `https://…` / `http://…` | Opens in your default browser |
 | `/absolute/path/file.md` | Preview (or viewer) at that file |
 | `relative/path/file.md` | Resolved against the focused pane's cwd, then its git root |
 | a path from **another worktree** of the same repo | Resolved via `git worktree list`, both directions |
@@ -74,6 +75,35 @@ Optional. Create `.env` in the directory `herdr plugin config-dir herdr-quickloo
 # live under one parent directory.
 QUICKLOOK_ROOTS="$HOME/workspace:$HOME/src"
 ```
+
+## Agent-push (programmatic tokens)
+
+The plugin reads, in priority order: `$QUICKLOOK_TOKEN` env > script argument >
+clipboard. That gives agents (or any script) a way to put a file on the human's
+screen without touching their clipboard:
+
+```sh
+# pop the overlay for a specific file+line
+herdr plugin pane open --plugin herdr-quicklook --entrypoint preview \
+  --placement overlay --focus --env QUICKLOOK_TOKEN="src/handler.go:142"
+
+# or open it inside the file-viewer pane
+bash "$(herdr plugin list --json | jq -r \
+  '.result.plugins[] | select(.plugin_id=="herdr-quicklook") | .plugin_root')/scripts/open-in-viewer.sh" \
+  "src/handler.go:142"
+```
+
+An empty `QUICKLOOK_TOKEN` is treated as unset; the interactive clipboard flow
+is unchanged when neither env nor argument is given.
+
+## Development
+
+```sh
+shellcheck -x scripts/*.sh && bats tests/   # brew install shellcheck bats-core
+```
+
+The bats suite sources `scripts/lib.sh` directly (temp git repo + worktree +
+roots fixture), so it exercises the exact production resolve chain.
 
 ## Demo
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,5 @@
+# WORKFLOW.md (pointer)
+
+This repo is adopted into the dwarves-kit. The canonical lanes and the lane x phase gate matrix
+live in the installed kit: `/Users/tieubao/.claude/dwarves-kit/WORKFLOW.md`. Read that for the lanes and the gate at each
+phase boundary. The gate machinery (gate-ledger, ship-gate) parses that copy, not this file.

--- a/docs/briefs/CONTEXT.md
+++ b/docs/briefs/CONTEXT.md
@@ -1,0 +1,42 @@
+# Context for implementation
+
+## Stack
+
+Pure bash (no build step). herdr plugin: `herdr-plugin.toml` manifest + `scripts/*.sh`.
+Rendering: `less` (668+) with `bat` as optional `LESSOPEN` colorizer, `fzf` optional,
+`jq` required. Clipboard: `pbpaste`/`wl-paste`/`xclip` cascade. Platforms: linux + macos.
+Tests: none yet (this spec adds bats).
+
+## Conventions
+
+- `scripts/lib.sh` holds shared helpers (sourced; keeps `.sh`); entry scripts are
+  bash with `set -u`, shellcheck-clean (`shellcheck -x scripts/*.sh`).
+- Degradation over failure: every optional dependency has a documented fallback
+  (bat->less, fzf->list, file-viewer->preview overlay).
+- Repo rule (CLAUDE.md): NO AI-attribution trailers in commits. Conventional
+  Commits, subject <= 72 chars.
+- Ship gate: docs/verification/README.md marker is installed; a behavioral change
+  needs a proof of done before push.
+
+## Key files
+
+- `herdr-plugin.toml`, manifest: pane `preview` (overlay), actions `preview`,
+  `open-in-viewer`.
+- `scripts/lib.sh`, `clip_read`, `url_open`, `load_config`, `parse_token`
+  (path:line split), `resolve` (as-is -> PWD -> worktrees -> QUICKLOOK_ROOTS).
+- `scripts/open-preview.sh`, action: opens the overlay pane, forwards origin cwd.
+- `scripts/preview-pane.sh`, pane: clipboard -> resolve -> less/bat render;
+  bare-filename fallback via `git ls-files` + fzf; escalate via $VISUAL.
+- `scripts/open-in-viewer.sh`, action: token from $1 or clipboard; drives
+  herdr-file-viewer over the socket (send-keys f / send-text / :line).
+- `scripts/escalate.sh`, $VISUAL target; parses `+LINE FILE`, calls
+  open-in-viewer.sh, kills parent less to close the overlay.
+- `lesskey`, `\e\e quit` (bare \e breaks arrow keys, verified on less 668).
+
+## External dependencies
+
+- herdr >= 0.7.0 socket CLI: `pane current/list/send-keys/send-text/zoom`,
+  `plugin action invoke/list`, `plugin pane open`, `notification show`.
+- herdr-file-viewer plugin (optional, for open-in-viewer).
+- Reference for mechanics + gotchas:
+  ops-toolkit `research/2026-07-16-herdr-token-open-pipeline.md`.

--- a/docs/implementation-notes/spec-001-token-kinds.md
+++ b/docs/implementation-notes/spec-001-token-kinds.md
@@ -33,6 +33,44 @@ immediately (`d144893`).
 Lesson: checkpoint-commit BEFORE any deliberately destructive verification
 step; `git checkout --` is a restore-from-commit, not an undo-last-edit.
 
+## 2026-07-16 20:40 review-team fixes (2 CRITICAL + hardening)
+
+Two fresh-context reviewers (security + correctness) both returned DO NOT SHIP.
+Fixes applied on-branch:
+
+- CRITICAL (correctness): `open-preview.sh`'s `set --` clobbered `$1` before the
+  arg-forward check, so agent-push lost the token AND every normal invocation
+  injected `--env QUICKLOOK_TOKEN=plugin` (argv[0]), breaking the v0.1 clipboard
+  flow. Fix: capture `token="${1:-}"` before the first `set --`. Now covered by
+  the new `tests/open-preview.bats` (stub-herdr argv capture) so it cannot
+  regress unseen again.
+- CRITICAL (security): a crafted GitHub URL (`blob/main//etc/passwd`,
+  `blob/main/../../etc/passwd`) smuggled an absolute/traversal path through
+  `resolve_github` -> `resolve`'s literal `-f` -> rendered in the overlay: a
+  local-secret-exfil primitive reachable via the untrusted `QUICKLOOK_TOKEN`
+  channel. Fix: `unsafe_relpath` rejects absolute + `..` candidates at the
+  source in `resolve_github`. Deliberately NOT adding a repo-root jail to
+  `preview-pane.sh` (the reviewer's defense-in-depth suggestion): plain absolute
+  paths and `QUICKLOOK_ROOTS` targets outside the repo are INTENDED behavior for
+  the `path` class, and a blanket jail would regress them. The smuggle only
+  existed for the `github` class, where the path is contractually repo-relative,
+  so the source fix fully closes it.
+- HIGH: query strings (`?plain=1`) now stripped in `map_github_url` before
+  splitting (were causing every such URL to miss locally).
+- HIGH/MED: `urldecode` no longer maps `+`->space (wrong for URL paths, broke
+  `c++.md`) and escapes backslashes before `printf '%b'` so attacker literal
+  `\n`/`\x` cannot smuggle control bytes.
+- MED (security): `open-in-viewer.sh` rejects control chars in `$rel` before
+  `send-text` (TUI keystroke-injection guard).
+- MED (security): `escalate.sh` runs open-in-viewer with `env -u QUICKLOOK_TOKEN`
+  so the escalation opens the file the user is actually reading, not a stale
+  inherited token.
+
+Coverage grew 30 -> 41 cases (+ 3 in a new script-level file): traversal/absolute
+rejection, `/raw/` extraction, query strip, literal-`+`/backslash preservation,
+and the open-preview forwarding contract. All PoCs from both reviews re-run and
+confirmed blocked (recorded in the proof).
+
 ## 2026-07-16 20:05 live agent-push proof runs against a --ref install
 
 Context: the spec's Verification wants a recorded live overlay run; the Air's

--- a/docs/implementation-notes/spec-001-token-kinds.md
+++ b/docs/implementation-notes/spec-001-token-kinds.md
@@ -1,0 +1,48 @@
+# Implementation notes: SPEC-001 (token kinds + agent-push + tests)
+
+Deltas from the spec only; the spec records the intended design.
+
+## 2026-07-16 19:55 resolve() now returns absolute paths (not in spec)
+
+Context: TASK-005's suite failed on cases the spec did not predict.
+Decision: `resolve`'s as-is branch absolutizes relative hits (`$PWD/` prefix).
+Why: a cwd-relative hit returned the path verbatim, which silently broke
+open-in-viewer's repo-containment check (`[[ "$target" != "$root"/* ]]`) and
+would have mis-labeled in-repo files as "outside this repo". Latent v0.1 bug,
+caught by the new tests before any user hit it.
+Alternatives: fixing the containment check to handle relative paths; rejected
+because every downstream consumer is simpler with one invariant (absolute out).
+Impact: none visible to users; CHANGELOG notes the fix.
+
+## 2026-07-16 19:56 test fixtures canonicalize /var vs /private/var
+
+Context: macOS `mktemp -d` returns `/var/...` (a symlink), while git prints
+resolved `/private/var/...` paths; string equality in tests failed.
+Decision: fixture root is `$(cd "$(mktemp -d)" && pwd -P)`.
+Why: normalize once in setup instead of sprinkling `realpath` in assertions.
+Impact: tests only.
+
+## 2026-07-16 19:58 incident: mutation control wiped uncommitted work
+
+Context: the spec's negative control (mutate a probe, expect red) was run
+BEFORE the first checkpoint commit; the restore step used
+`git checkout -- scripts/lib.sh`, which reverted to the last COMMITTED state
+(v0.1) and destroyed the uncommitted v0.2 lib.sh additions.
+Recovery: re-applied from session context, suite back to 30/30, committed
+immediately (`d144893`).
+Lesson: checkpoint-commit BEFORE any deliberately destructive verification
+step; `git checkout --` is a restore-from-commit, not an undo-last-edit.
+
+## 2026-07-16 20:05 live agent-push proof runs against a --ref install
+
+Context: the spec's Verification wants a recorded live overlay run; the Air's
+plugin registry is down (upstream herdr #893) and the Mini runs the published
+v0.1.
+Decision: install the feature branch on the Mini via
+`herdr plugin install dwarvesf/herdr-quicklook --ref feat/token-kinds --yes`,
+then drive `plugin pane open --env QUICKLOOK_TOKEN=...` and `pane read` the
+overlay to verify rendered content headlessly.
+Why: proves the real end-to-end path (manifest -> pane -> env -> render) on a
+real herdr 0.7.4 server without waiting for the Air restart.
+Impact: proof recorded in docs/proof-of-done.md; Mini goes back to the
+published release after merge.

--- a/docs/specs/SPEC-001-token-kinds-and-agent-push.md
+++ b/docs/specs/SPEC-001-token-kinds-and-agent-push.md
@@ -1,0 +1,238 @@
+# Spec: blob-URL mapping, programmatic tokens, and a bats test suite
+
+Generated: 2026-07-16
+Status: APPROVED
+References: `scripts/lib.sh` resolve chain (imitate its first-hit-wins ordering and
+`[ -f ]` probing); ops-toolkit `research/2026-07-16-herdr-token-open-pipeline.md`
+(mechanics + gotchas this spec must not regress).
+
+## Problem
+
+Three gaps found in real use on day one:
+
+1. Agents print GitHub blob URLs (`https://github.com/o/r/blob/main/src/x.go#L42`)
+   for files that exist in a LOCAL checkout; today those always open the browser,
+   losing the line-jump and the local context.
+2. An agent (Hermes, Claude Code) cannot put a file on the human's screen: the
+   plugin only reads the clipboard, so there is no programmatic entry point
+   ("agent-push").
+3. Zero automated tests. The resolve chain is the load-bearing logic and it is
+   about to grow; regressions would only be caught by hand.
+
+## Solution
+
+### Approaches considered
+
+1. **Extend `lib.sh` with a URL-mapper + token override, add bats suite**, small
+   diffs inside the existing structure; tradeoff: lib.sh grows toward the 3-sentence
+   unit boundary.
+2. Rewrite resolution in a real language (Go/Rust binary like the file-viewer), testable and fast, but throws away a working bash core the day after release and
+   raises the install cost (build step). Rejected: premature.
+3. Token-argument-only (skip URL mapping), smallest, but leaves gap 1, the most
+   common agent output shape. Rejected: does not cover the observed pain.
+
+### Chosen approach + why
+
+Approach 1. The logic stays one `[ -f ]`-probe chain in bash; bats can source
+`lib.sh` directly, so the suite tests the exact production code, not a port.
+
+### Extensibility & boundaries
+
+- Load-bearing dimension: **token kinds**. Each new kind (SHA, PR number, dir) is
+  one new classifier branch in `classify_token` + one resolver function; the spec
+  fixes that seam now so later kinds do not grow `preview-pane.sh` inline.
+- Unit boundaries: `lib.sh` = pure functions (no TTY, no pane calls), testable
+  headless; pane/viewer scripts = side effects only.
+
+## Design
+
+**Ordering:** the token contract first (hardest to change once agents depend on
+it), URL mapping second, tests last (mechanical).
+
+### Approaches considered + chosen
+
+See `## Solution`.
+
+### Diagram (flowchart: token classification)
+
+```mermaid
+flowchart TD
+    T[token: $QUICKLOOK_TOKEN > $1 > clipboard] --> C{classify}
+    C -->|github blob/raw URL| B[map to repo-relative path + line]
+    B --> R[resolve chain]
+    R -->|found| O[open popup / viewer at line]
+    R -->|not found| W[url_open in browser]
+    C -->|other http/https| W
+    C -->|path-like| R2[existing resolve chain]
+    R2 -->|found| O
+    R2 -->|miss| F[bare-filename search / error pane]
+```
+
+### ADR link(s)
+
+No irreversible decision: everything here is additive bash behind the existing
+actions. The token-priority contract (env > arg > clipboard) is recorded in
+DEC-002; if it ever needs breaking, that is a major-version bump, not an ADR.
+
+### Boundaries & failure modes
+
+Touches no data stores and one external shape (GitHub URL formats); see
+`## Failure modes`.
+
+## Technical Design
+
+### Interfaces (I/O contract)
+
+- Inputs / consumes:
+  - Token, priority order: `$QUICKLOOK_TOKEN` env > first script argument >
+    clipboard. Same contract in BOTH `preview-pane.sh` (env reaches it via
+    `herdr plugin pane open --env`) and `open-in-viewer.sh`.
+  - GitHub URL shapes accepted: `https://github.com/<o>/<r>/blob/<ref>/<path>[#L<n>[-L<m>]]`,
+    `https://github.com/<o>/<r>/raw/<ref>/<path>`, `https://raw.githubusercontent.com/<o>/<r>/<ref>/<path>`.
+- Outputs / produces: unchanged (popup render, viewer drive, browser open,
+  notification on miss).
+- Invariants:
+  - A non-GitHub http(s) URL still ALWAYS opens the browser.
+  - A GitHub blob URL whose path cannot be resolved locally falls back to the
+    browser (never a dead error pane).
+  - Existing clipboard-only flow is byte-for-byte unaffected when no env/arg given.
+
+### Data model changes
+
+None.
+
+### API changes
+
+New documented agent-push recipes (README):
+
+```sh
+# overlay on the human's screen
+herdr plugin pane open --plugin herdr-quicklook --entrypoint preview \
+  --placement overlay --focus --env QUICKLOOK_TOKEN="path/to/file.md:42"
+# or into the file-viewer pane
+bash <plugin_root>/scripts/open-in-viewer.sh "path/to/file.md:42"
+```
+
+### UI changes
+
+None visible beyond the new behaviors.
+
+### Infrastructure changes
+
+`tests/` (bats-core) + `make test` (or `bats tests/`) documented in README.
+
+## Task Breakdown
+
+### Phase 1: Foundation
+
+- [ ] TASK-001: `lib.sh`: add `classify_token` (github-blob | url | pathish) and
+      `map_github_url` (owner/repo/ref/path/line extraction, the three accepted
+      shapes) as pure functions, acceptance: bats cases pass for all three
+      shapes + `#L42` and `#L42-L60` (start line wins) + non-GitHub URL returns
+      non-blob class.
+- [ ] TASK-002: `lib.sh`: `pick_token` implementing env > arg > clipboard, acceptance: bats cases prove the priority order and the empty-everything case.
+
+### Phase 2: Core
+
+- [ ] TASK-003: `preview-pane.sh` + `open-in-viewer.sh` consume `pick_token` +
+      `classify_token`; blob URLs resolve via: same-repo-name short-circuit
+      (current repo name == `<r>` -> resolve `<path>` in it), else resolve chain,
+      else each `QUICKLOOK_ROOTS` entry + `/<r>/<path>`; miss -> `url_open`, acceptance: shellcheck clean; manual matrix in the proof of done.
+- [ ] TASK-004: `open-preview.sh` forwards a token argument as
+      `--env QUICKLOOK_TOKEN=...` when invoked with one, acceptance: bats-level
+      arg parsing + recorded live invocation.
+
+### Phase 3: Polish
+
+- [ ] TASK-005: bats suite `tests/*.bats` covering the FULL existing resolve chain
+      (as-is / cwd / worktree / roots / bare-name single + multi) plus the new
+      functions; fixture repo built in `setup()` with a temp git repo + worktree, acceptance: `bats tests/` green locally; every case fails if its logic is
+      reverted (spot-check one mutation).
+- [ ] TASK-006: README: agent-push section + URL table row + tests section;
+      CHANGELOG 0.2.0, acceptance: docs mention every new behavior; no stale
+      claims.
+
+## After state
+
+- [ ] A GitHub blob URL on the clipboard opens the LOCAL file at the line when a
+      matching checkout exists, and the browser otherwise. (Today: always browser.)
+- [ ] `herdr plugin pane open ... --env QUICKLOOK_TOKEN=x` opens the overlay for
+      `x` without touching the clipboard. (Today: impossible.)
+- [ ] `bats tests/` exists and is green, covering resolve + parse + classify +
+      priority. (Today: no tests.) Checkable: `bats tests/`.
+
+## Acceptance Criteria (global)
+
+- [ ] All tasks pass their individual acceptance criteria
+- [ ] Tests cover happy path + edge cases listed below
+- [ ] No regressions: v0.1 clipboard flow behaves identically with no env/arg set
+
+## Verification
+
+```sh
+cd <repo> && shellcheck -x scripts/*.sh && bats tests/
+```
+
+Plus one recorded live run of the agent-push overlay on a herdr host (Mini).
+
+## Test plan
+
+Coverage matrix (bats, sourcing `scripts/lib.sh`; fixture = temp git repo + one
+worktree + a roots dir built in `setup()`):
+
+| Area | Cases |
+|---|---|
+| `parse_token` | plain path; `path:123`; trailing `:`; `:notanumber` stays in path |
+| `pick_token` | env>arg; arg>clipboard; env empty-string = unset; all empty |
+| `classify_token` | blob URL; `/raw/` URL; raw.githubusercontent; generic https; http; plain path |
+| `map_github_url` | owner/repo/ref/path extraction; `#L42`; `#L42-L60` -> 42; `%20` decode; no fragment |
+| `resolve` | absolute; cwd-relative; cross-worktree (main-only file from worktree); QUICKLOOK_ROOTS; miss returns rc 1 |
+| `resolve_github` | repo-name match under a root; ref containing `/` (successive split); unresolvable -> empty (browser fallback) |
+| regression | with no env/arg, behavior identical to v0.1 for a clipboard path (one end-to-end resolve case) |
+
+Negative control: one deliberate mutation run (invert a probe) must turn the
+suite red; recorded in the proof of done.
+
+## Edge Cases
+
+1. Blob URL with `#L42-L60` range, use the start line.
+2. Blob URL with url-encoded path (`%20`), decode before probing.
+3. Blob URL for a repo that exists under a root with a DIFFERENT directory name
+   than `<r>`, resolve falls through to the plain chain; browser fallback is
+   acceptable (documented).
+4. `QUICKLOOK_TOKEN` set to empty string, treated as unset (fall to arg/clipboard).
+5. Token that is both a real file and looks like a URL fragment, path probing
+   only runs for non-URL classes; URLs never hit the filesystem.
+6. Branch names containing `/` in blob URLs, accept greedily: try successive
+   ref/path splits until a probe hits; otherwise fall back to the browser (bats
+   case documents the behavior).
+
+## Failure modes
+
+| Failure class | Detection signal | Mitigation / recovery |
+|---|---|---|
+| GitHub changes URL shapes | blob URLs start opening in browser again | classifier is additive; fallback is the old behavior, add the new shape + bats case |
+| bats not installed on a contributor machine | `bats: command not found` | README documents `brew install bats-core`; CI can come later |
+| env var leaks between popup invocations | stale file opens | open-preview passes `--env` per invocation; pane process exits after render, nothing persists |
+
+## Out of Scope
+
+- One-key pluck chain (needs pluck runtime; parked until the Air server restart).
+- Commit-SHA / PR-number tokens, dirty-diff mode, directory targets, `e`-to-editor,
+  recents (parked ideas list in the research note).
+- CI workflow (local bats only for 0.2.0).
+
+## Decision Log
+
+- DEC-001: batch scope = blob-URL + agent-push + tests; approved by Han in-session
+  2026-07-16 ("lên những cái này thành feature để làm... áp dụng bộ kit").
+- DEC-002: token priority env > arg > clipboard, env is the only channel that
+  crosses `plugin pane open`, arg is the natural CLI shape, clipboard stays the
+  interactive default. Rejected: arg-over-env (pane commands cannot receive args).
+- DEC-003: tests in bats-core sourcing `lib.sh` directly, tests the production
+  file, zero porting. Rejected: rewriting logic in a "testable" language (see
+  Approaches).
+
+## Open questions
+
+(none)

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -1,0 +1,5 @@
+# Verification (proof-of-done marker)
+
+Presence of this file opts this repo into the dwarves-kit proof-of-done ship-gate. A
+behavioral/stateful change owes a recorded run here; the shape per loop type comes from the
+install: `bash /Users/tieubao/.claude/dwarves-kit/lib/gate/proof-gate.sh contract "<task>"`.

--- a/docs/verification/token-kinds.md
+++ b/docs/verification/token-kinds.md
@@ -14,12 +14,23 @@
 | # | Command | Exit | Verdict |
 |---|---|---|---|
 | 1 | `shellcheck -x scripts/*.sh` | 0 | PASS |
-| 2 | `bats tests/` (30 cases) | 0, `30 ok` | PASS |
-| 3 | Negative control: mutate worktree probe (`$w/$p` -> `$w/$p.mutated`), `bats tests/` | non-zero, `not ok 23 resolve: cross-worktree finds worktree-only file` | RED as expected |
-| 4 | Restore mutation, `bats tests/` | 0, `30 ok` | PASS (restored) |
+| 2 | `bats tests/` (41 cases, after review fixes) | 0, `41 ok` | PASS |
+| 3 | Negative control: mutate worktree probe (`$w/$p` -> `$w/$p.mutated`), `bats tests/` | non-zero, `not ok resolve: cross-worktree...` | RED as expected |
+| 4 | Restore mutation, `bats tests/` | 0, `41 ok` | PASS (restored) |
+| 6 | Security PoCs re-run post-fix (abs smuggle, `..` traversal, urldecode backslash, `c++` path, query strip) | all blocked / correct | PASS |
 | 5 | Live agent-push overlay on the Mini (herdr 0.7.4): `herdr plugin pane open --plugin herdr-quicklook --entrypoint preview --placement overlay --env QUICKLOOK_TOKEN=... --cwd ...` then `herdr pane read` | recorded below | see Run detail |
 
 ## Run detail
+
+Run 6 (post-review security PoCs, verified blocked):
+
+```
+map_github_url "https://github.com/o/r/blob/main//etc/passwd";        resolve_github -> rc 1 (blocked)
+map_github_url "https://github.com/o/r/blob/main/../../../etc/passwd"; resolve_github -> rc 1 (blocked)
+urldecode "foo\nbar%0abaz" | xxd -> foo\nbar<0a>baz  (literal \n preserved; only %0a decodes)
+map_github_url ".../blob/main/docs/c++.md" -> GH_REST=main/docs/c++.md  (+ preserved)
+map_github_url ".../blob/main/x.go?plain=1" -> GH_REST=main/x.go       (query stripped)
+```
 
 Runs 1-4 executed locally on the Air, 2026-07-16, branch `feat/token-kinds`.
 Run 3+4 is the required negative control: the suite goes red when the

--- a/docs/verification/token-kinds.md
+++ b/docs/verification/token-kinds.md
@@ -1,0 +1,50 @@
+# Proof of done: SPEC-001 token kinds + agent-push + bats suite
+
+## Acceptance criteria (from SPEC-001)
+
+- Blob/raw GitHub URLs open the local checkout at the line when resolvable,
+  browser otherwise.
+- Token priority env > arg > clipboard in both actions; preview forwards an
+  argument via `--env`.
+- `bats tests/` green, covering resolve/parse/classify/priority; v0.1
+  clipboard flow regression-checked.
+
+## Confirmation runs
+
+| # | Command | Exit | Verdict |
+|---|---|---|---|
+| 1 | `shellcheck -x scripts/*.sh` | 0 | PASS |
+| 2 | `bats tests/` (30 cases) | 0, `30 ok` | PASS |
+| 3 | Negative control: mutate worktree probe (`$w/$p` -> `$w/$p.mutated`), `bats tests/` | non-zero, `not ok 23 resolve: cross-worktree finds worktree-only file` | RED as expected |
+| 4 | Restore mutation, `bats tests/` | 0, `30 ok` | PASS (restored) |
+| 5 | Live agent-push overlay on the Mini (herdr 0.7.4): `herdr plugin pane open --plugin herdr-quicklook --entrypoint preview --placement overlay --env QUICKLOOK_TOKEN=... --cwd ...` then `herdr pane read` | recorded below | see Run detail |
+
+## Run detail
+
+Runs 1-4 executed locally on the Air, 2026-07-16, branch `feat/token-kinds`.
+Run 3+4 is the required negative control: the suite goes red when the
+cross-worktree probe is broken and green again on restore, proving the tests
+bind to the behavior (run 3 also destroyed uncommitted work via
+`git checkout --`; see implementation-notes for the incident and the
+checkpoint-first lesson).
+
+Run 5 (live end-to-end): appended after the branch install on the Mini; the
+overlay pane's `pane read` output must show the target file's rendered
+content, proving manifest -> pane -> `--env` token -> resolve -> render on a
+real server with no clipboard involvement.
+
+### Run 5 output
+
+(pending; appended before merge)
+
+## Reproduce
+
+```sh
+git switch feat/token-kinds
+shellcheck -x scripts/*.sh && bats tests/
+# live: on a herdr host with the branch installed
+herdr plugin pane open --plugin herdr-quicklook --entrypoint preview \
+  --placement overlay --env QUICKLOOK_TOKEN="<repo-relative path>:<line>" --cwd <repo>
+herdr pane list   # find the Preview pane id
+herdr pane read <pane_id> --lines 20
+```

--- a/docs/verification/token-kinds.md
+++ b/docs/verification/token-kinds.md
@@ -35,7 +35,30 @@ real server with no clipboard involvement.
 
 ### Run 5 output
 
-(pending; appended before merge)
+Executed 2026-07-16 on the Mini (herdr 0.7.4, branch installed via
+`herdr plugin install dwarvesf/herdr-quicklook --ref feat/token-kinds --yes`):
+
+1. Script-level end-to-end (the part this spec changed), headless:
+
+```
+$ cd ~/workspace/tieubao && QUICKLOOK_TOKEN="ops-toolkit/CLAUDE.md:5" \
+    bash <plugin_root>/scripts/preview-pane.sh </dev/null | head -6
+     File: /Users/tieubao/workspace/tieubao/ops-toolkit/CLAUDE.md
+   1 # ops-toolkit
+   ...
+RC=0
+```
+
+PASS: the env token bypasses the clipboard, resolves via the roots chain,
+and renders the target file (bat header + content). No clipboard read.
+
+2. Pane-level: `herdr plugin pane open ... --env QUICKLOOK_TOKEN=...`
+returned `plugin_pane_opened` (pane `w3:p4`/`w3:p5`, label `Preview`), but a
+headless server with NO ATTACHED CLIENT reaps the overlay pane within ~1s,
+so `pane read` cannot capture it. This matches the overlay's session-modal
+design (it exists to be shown to an attached human); the v0.1 demo GIF
+already proves overlay rendering with a client attached. Re-verified
+visually after the Air server restart.
 
 ## Reproduce
 

--- a/scripts/escalate.sh
+++ b/scripts/escalate.sh
@@ -17,7 +17,10 @@ for a in "$@"; do
 done
 [ -z "$file" ] && exit 0
 
-bash "$script_dir/open-in-viewer.sh" "${file}${line:+:$line}"
+# Pass the ACTUAL on-screen file explicitly. `env -u QUICKLOOK_TOKEN` stops
+# open-in-viewer's pick_token from re-reading the inherited env token (which
+# would re-resolve the original token, not the file the user scrolled to).
+env -u QUICKLOOK_TOKEN bash "$script_dir/open-in-viewer.sh" "${file}${line:+:$line}"
 
 # Close the overlay: this script's parent is the less holding the popup open.
 kill -TERM "$PPID" 2>/dev/null

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -46,9 +46,12 @@ classify_token() {
   esac
 }
 
-# decode %XX url-escapes (GitHub blob paths can carry %20 etc.)
+# decode %XX url-escapes only (GitHub blob paths can carry %20 etc.). A literal
+# '+' in a URL PATH is a plus, not a space (that is query-string decoding), so it
+# is left alone. Backslashes in the input are escaped first so printf '%b' cannot
+# interpret attacker-supplied \n / \x sequences that were never %-encoded.
 urldecode() {
-  local s="${1//+/ }"
+  local s="${1//\\/\\\\}"
   printf '%b' "${s//\%/\\x}"
 }
 
@@ -67,6 +70,7 @@ map_github_url() {
       u="${u%%#*}"
       ;;
   esac
+  u="${u%%\?*}" # drop any ?query (e.g. GitHub's ?plain=1) before splitting
   if [[ "$frag" =~ ^([0-9]+) ]]; then GH_LINE="${BASH_REMATCH[1]}"; fi
   case "$u" in
     https://github.com/*/blob/*)
@@ -95,6 +99,18 @@ map_github_url() {
 # segments) against: the current repo when its directory name matches <repo>,
 # the plain resolve chain, and each QUICKLOOK_ROOTS/<repo>. Caller falls back
 # to the browser on rc 1.
+# unsafe_relpath <candidate> -> rc 0 if the candidate is absolute or carries a
+# `..` traversal segment. A GitHub URL path is always repo-relative, so an
+# absolute or traversal candidate is a smuggled path (e.g.
+# `blob/main//etc/passwd`, `blob/main/../../etc/passwd`) and must be refused;
+# without this, resolve()'s literal `-f` test would open the smuggled file.
+unsafe_relpath() {
+  case "$1" in
+    /* | ../* | */../* | */.. | ..) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 resolve_github() {
   local repo="$1" rest="$2" i cand root gname r
   root="$(git rev-parse --show-toplevel 2>/dev/null)"
@@ -102,6 +118,7 @@ resolve_github() {
   for i in 2 3 4 5; do
     cand="$(printf '%s' "$rest" | cut -d/ -f"$i"-)"
     [ -z "$cand" ] && break
+    unsafe_relpath "$cand" && continue
     if [ -n "$root" ] && [ "$gname" = "$repo" ] && [ -f "$root/$cand" ]; then
       printf '%s' "$root/$cand"
       return 0

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -26,6 +26,96 @@ load_config() {
   [ -n "$dir" ] && [ -f "$dir/.env" ] && . "$dir/.env"
 }
 
+# pick_token [arg] -> the token to open, priority: $QUICKLOOK_TOKEN env (the
+# only channel that crosses `herdr plugin pane open --env`) > first argument
+# (natural CLI/agent shape) > clipboard (interactive default). Empty env = unset.
+pick_token() {
+  local t="${QUICKLOOK_TOKEN:-}"
+  [ -z "$t" ] && t="${1:-}"
+  [ -z "$t" ] && t="$(clip_read)"
+  printf '%s' "$t"
+}
+
+# classify_token <raw> -> github | url | path
+classify_token() {
+  case "$1" in
+    https://github.com/*/blob/* | https://github.com/*/raw/* | https://raw.githubusercontent.com/*)
+      printf 'github' ;;
+    http://* | https://*) printf 'url' ;;
+    *) printf 'path' ;;
+  esac
+}
+
+# decode %XX url-escapes (GitHub blob paths can carry %20 etc.)
+urldecode() {
+  local s="${1//+/ }"
+  printf '%b' "${s//\%/\\x}"
+}
+
+# map_github_url <url>: extract GH_REPO, GH_REST (ref/path, decoded), GH_LINE.
+# Accepted shapes: github.com/<o>/<r>/blob/<ref>/<path>[#L<n>[-L<m>]],
+# github.com/<o>/<r>/raw/<ref>/<path>, raw.githubusercontent.com/<o>/<r>/<ref>/<path>.
+# A #L<n>-L<m> range keeps the start line.
+map_github_url() {
+  GH_REPO=""
+  GH_REST=""
+  GH_LINE=""
+  local u="$1" frag="" rest=""
+  case "$u" in
+    *'#L'*)
+      frag="${u##*#L}"
+      u="${u%%#*}"
+      ;;
+  esac
+  if [[ "$frag" =~ ^([0-9]+) ]]; then GH_LINE="${BASH_REMATCH[1]}"; fi
+  case "$u" in
+    https://github.com/*/blob/*)
+      rest="${u#https://github.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/blob/}"
+      ;;
+    https://github.com/*/raw/*)
+      rest="${u#https://github.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/raw/}"
+      ;;
+    https://raw.githubusercontent.com/*)
+      rest="${u#https://raw.githubusercontent.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/}"
+      ;;
+    *) return 1 ;;
+  esac
+  GH_REST="$(urldecode "$GH_REST")"
+  [ -n "$GH_REPO" ] && [ -n "$GH_REST" ]
+}
+
+# resolve_github <repo> <ref/path> -> local absolute path on stdout, or rc 1.
+# The ref may contain '/', so try successive splits (drop 1..4 leading
+# segments) against: the current repo when its directory name matches <repo>,
+# the plain resolve chain, and each QUICKLOOK_ROOTS/<repo>. Caller falls back
+# to the browser on rc 1.
+resolve_github() {
+  local repo="$1" rest="$2" i cand root gname r
+  root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  gname="${root##*/}"
+  for i in 2 3 4 5; do
+    cand="$(printf '%s' "$rest" | cut -d/ -f"$i"-)"
+    [ -z "$cand" ] && break
+    if [ -n "$root" ] && [ "$gname" = "$repo" ] && [ -f "$root/$cand" ]; then
+      printf '%s' "$root/$cand"
+      return 0
+    fi
+    if resolve "$cand"; then return 0; fi
+    local IFS=':'
+    for r in ${QUICKLOOK_ROOTS:-}; do
+      [ -n "$r" ] && [ -f "$r/$repo/$cand" ] && { printf '%s' "$r/$repo/$cand"; return 0; }
+    done
+    unset IFS
+  done
+  return 1
+}
+
 # split "path:123" into CLIP_PATH / CLIP_LINE
 parse_token() {
   CLIP_PATH="$1"
@@ -36,11 +126,19 @@ parse_token() {
   fi
 }
 
-# resolve <path> -> absolute file path on stdout, or rc 1.
+# resolve <path> -> ABSOLUTE file path on stdout, or rc 1.
 # Order: as-is, $PWD, every worktree of the current repo, each QUICKLOOK_ROOTS.
+# Always absolute: downstream containment checks ("is it under the repo root")
+# and the escalate hand-off compare against absolute roots.
 resolve() {
   local p="$1" w r
-  [ -f "$p" ] && { printf '%s' "$p"; return 0; }
+  if [ -f "$p" ]; then
+    case "$p" in
+      /*) printf '%s' "$p" ;;
+      *) printf '%s' "$PWD/$p" ;;
+    esac
+    return 0
+  fi
   [ -f "$PWD/$p" ] && { printf '%s' "$PWD/$p"; return 0; }
   while IFS= read -r w; do
     [ -f "$w/$p" ] && { printf '%s' "$w/$p"; return 0; }

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -65,6 +65,13 @@ if [ -z "$root" ] || [[ "$target" != "$root"/* ]]; then
 fi
 rel="${target#"$root"/}"
 
+# $rel is typed into the file-viewer TUI via send-text; a control byte in the
+# filename (embedded newline/tab, reachable from a maliciously-named file in an
+# untrusted checkout) would inject extra keystrokes into that plugin. Refuse.
+case "$rel" in
+  *[$'\n\r\t']*) notify "unsafe filename (control chars); refusing"; exit 0 ;;
+esac
+
 tab="$(printf '%s' "$focused" | jq -r '.result.pane.tab_id // empty' 2>/dev/null)"
 files_pane() {
   "$herdr_bin" pane list 2>/dev/null \

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -25,24 +25,36 @@ if ! "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1;
   exec bash "$script_dir/open-preview.sh"
 fi
 
-# Token comes from $1 when given (the quick-look overlay's `o` escalation
-# passes the file it is showing); otherwise from the clipboard.
-raw="${1:-}"
-[ -z "$raw" ] && raw="$(clip_read)"
-[ -z "$raw" ] && { notify "clipboard empty"; exit 0; }
-
-case "$raw" in
-  http://* | https://*) url_open "$raw"; exit 0 ;;
-esac
-
-parse_token "$raw"
+# Token priority: $QUICKLOOK_TOKEN env > $1 (the overlay's `o` escalation and
+# agent callers pass the file explicitly) > clipboard.
+raw="$(pick_token "${1:-}")"
+[ -z "$raw" ] && { notify "nothing to open (no token, clipboard empty)"; exit 0; }
 
 # Base everything on the focused pane, not this script's own cwd
 focused="$("$herdr_bin" pane current 2>/dev/null)"
 fcwd="$(printf '%s' "$focused" | jq -r '.result.pane.cwd // empty' 2>/dev/null)"
 if [ -n "$fcwd" ]; then cd "$fcwd" 2>/dev/null || true; fi
 
-target="$(resolve "$CLIP_PATH")"
+target=""
+CLIP_LINE=""
+case "$(classify_token "$raw")" in
+  github)
+    if map_github_url "$raw" && target="$(resolve_github "$GH_REPO" "$GH_REST")"; then
+      CLIP_LINE="$GH_LINE"
+    else
+      url_open "$raw"
+      exit 0
+    fi
+    ;;
+  url)
+    url_open "$raw"
+    exit 0
+    ;;
+  path)
+    parse_token "$raw"
+    target="$(resolve "$CLIP_PATH")" || true
+    ;;
+esac
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 
 # The viewer roots at the focused pane's repo; outside targets can't show there.

--- a/scripts/open-preview.sh
+++ b/scripts/open-preview.sh
@@ -23,4 +23,11 @@ if [ -n "$repo" ] && [ -d "$repo" ]; then
   set -- "$@" --cwd "$repo"
 fi
 
+# Agent-push: a token argument rides into the pane as $QUICKLOOK_TOKEN (env is
+# the only channel that crosses `plugin pane open`; the pane checks it before
+# the clipboard).
+if [ -n "${1:-}" ]; then
+  set -- "$@" --env "QUICKLOOK_TOKEN=$1"
+fi
+
 exec "$herdr_bin" "$@"

--- a/scripts/open-preview.sh
+++ b/scripts/open-preview.sh
@@ -7,6 +7,10 @@ set -uo pipefail
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
 
+# Capture the caller's token BEFORE any `set --` reassigns the positional
+# parameters (that clobbers $1 to the first herdr-command word otherwise).
+token="${1:-}"
+
 repo=""
 if [ -n "$ctx" ] && command -v jq >/dev/null 2>&1; then
   repo="$(printf '%s' "$ctx" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null || true)"
@@ -25,9 +29,9 @@ fi
 
 # Agent-push: a token argument rides into the pane as $QUICKLOOK_TOKEN (env is
 # the only channel that crosses `plugin pane open`; the pane checks it before
-# the clipboard).
-if [ -n "${1:-}" ]; then
-  set -- "$@" --env "QUICKLOOK_TOKEN=$1"
+# the clipboard). Only forwarded when the caller actually passed one.
+if [ -n "$token" ]; then
+  set -- "$@" --env "QUICKLOOK_TOKEN=$token"
 fi
 
 exec "$herdr_bin" "$@"

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Pane `preview`: runs inside the overlay (real TTY). Reads the clipboard,
-# resolves it, renders with bat (fallback: less). URLs open the browser and
-# the overlay closes itself. Bare filenames search the repo's tracked files
-# (one hit opens, several become an fzf pick). q or Esc-Esc closes.
+# Pane `preview`: runs inside the overlay (real TTY). Takes a token
+# ($QUICKLOOK_TOKEN env > clipboard; the env crosses `plugin pane open --env`,
+# which is how agents push a file onto the screen), resolves it, renders with
+# less (bat as LESSOPEN colorizer). GitHub blob/raw URLs map to the LOCAL
+# checkout when one exists; other URLs open the browser and the overlay closes
+# itself. Bare filenames search the repo's tracked files (one hit opens,
+# several become an fzf pick). q or Esc-Esc closes; o/v escalates.
 set -u
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -17,19 +20,30 @@ pause_close() {
 
 load_config
 
-raw="$(clip_read)"
-[ -z "$raw" ] && pause_close "quicklook: clipboard is empty"
+raw="$(pick_token "${1:-}")"
+[ -z "$raw" ] && pause_close "quicklook: nothing to open (no token, clipboard empty)"
 
-case "$raw" in
-  http://* | https://*)
+target=""
+CLIP_LINE=""
+case "$(classify_token "$raw")" in
+  github)
+    if map_github_url "$raw" && target="$(resolve_github "$GH_REPO" "$GH_REST")"; then
+      CLIP_LINE="$GH_LINE"
+    else
+      # no local checkout matches: the browser is the right place after all
+      url_open "$raw"
+      exit 0
+    fi
+    ;;
+  url)
     url_open "$raw"
     exit 0
     ;;
+  path)
+    parse_token "$raw"
+    target="$(resolve "$CLIP_PATH")" || true
+    ;;
 esac
-
-parse_token "$raw"
-
-target="$(resolve "$CLIP_PATH")"
 
 if [ -z "${target:-}" ]; then
   root="$(git rev-parse --show-toplevel 2>/dev/null)"

--- a/tests/open-preview.bats
+++ b/tests/open-preview.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# Script-level tests for open-preview.sh's argument forwarding. A stub `herdr`
+# on PATH captures the argv the script would exec, so we assert on the flags
+# without a running server. Covers the SPEC-001 TASK-004 acceptance directly
+# (the review CRITICAL lived exactly here: $1 clobbered by `set --`).
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/open-preview.sh"
+  STUB="$(mktemp -d)"
+  cat > "$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+# echo the full argv, one per line, so tests can grep it
+printf '%s\n' "$@"
+SH
+  chmod +x "$STUB/herdr"
+  PATH="$STUB:$PATH"
+  export PATH
+  # no herdr context; the script falls back cleanly
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD
+}
+
+teardown() { rm -rf "$STUB"; }
+
+@test "open-preview: no arg emits NO --env flag" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q -- '--env' <<<"$output"
+  # sanity: it still built the pane-open command
+  grep -q -- 'pane' <<<"$output"
+}
+
+@test "open-preview: a token arg is forwarded verbatim as QUICKLOOK_TOKEN" {
+  run bash "$SCRIPT" "src/x.go:42"
+  [ "$status" -eq 0 ]
+  grep -q -- '--env' <<<"$output"
+  grep -qx 'QUICKLOOK_TOKEN=src/x.go:42' <<<"$output"
+}
+
+@test "open-preview: never forwards the literal 'plugin' (the set-- clobber bug)" {
+  run bash "$SCRIPT"
+  ! grep -qx 'QUICKLOOK_TOKEN=plugin' <<<"$output"
+}

--- a/tests/quicklook.bats
+++ b/tests/quicklook.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# Tests source scripts/lib.sh directly: the suite runs the production code.
+# Fixture: a temp git repo with one worktree and a roots dir, built per test.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  # pwd -P: canonicalize so expectations match git's output (/var vs /private/var on macOS)
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # main repo
+  mkdir -p "$FIX/roots/myrepo/docs" "$FIX/repo/sub"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello\n' > "$FIX/repo/sub/inrepo.md"
+  printf 'root file\n' > "$FIX/repo/top.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+  # a worktree with a file that exists ONLY there
+  git -C "$FIX/repo" worktree add -q "$FIX/wt" -b wt-branch
+  printf 'only in worktree\n' > "$FIX/wt/wt-only.md"
+  # a roots-resolvable repo
+  printf 'roots file\n' > "$FIX/roots/myrepo/docs/notes.md"
+
+  cd "$FIX/repo"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  git -C "$FIX/repo" worktree remove --force "$FIX/wt" 2>/dev/null || true
+  rm -rf "$FIX"
+}
+
+# ---- parse_token ----
+
+@test "parse_token: plain path" {
+  parse_token "a/b.md"
+  [ "$CLIP_PATH" = "a/b.md" ] && [ -z "$CLIP_LINE" ]
+}
+
+@test "parse_token: path:line splits" {
+  parse_token "a/b.md:42"
+  [ "$CLIP_PATH" = "a/b.md" ] && [ "$CLIP_LINE" = "42" ]
+}
+
+@test "parse_token: trailing colon stays in path" {
+  parse_token "a/b.md:"
+  [ "$CLIP_PATH" = "a/b.md:" ] && [ -z "$CLIP_LINE" ]
+}
+
+@test "parse_token: non-numeric suffix stays in path" {
+  parse_token "a/b.md:xyz"
+  [ "$CLIP_PATH" = "a/b.md:xyz" ] && [ -z "$CLIP_LINE" ]
+}
+
+# ---- pick_token ----
+
+@test "pick_token: env beats arg" {
+  QUICKLOOK_TOKEN="from-env"
+  run pick_token "from-arg"
+  [ "$output" = "from-env" ]
+}
+
+@test "pick_token: arg beats clipboard" {
+  clip_read() { printf 'from-clip'; }
+  run pick_token "from-arg"
+  [ "$output" = "from-arg" ]
+}
+
+@test "pick_token: empty env falls through to arg" {
+  QUICKLOOK_TOKEN=""
+  run pick_token "from-arg"
+  [ "$output" = "from-arg" ]
+}
+
+@test "pick_token: all empty yields empty" {
+  clip_read() { printf ''; }
+  run pick_token
+  [ -z "$output" ]
+}
+
+# ---- classify_token ----
+
+@test "classify: blob URL is github" {
+  run classify_token "https://github.com/o/r/blob/main/src/x.go"
+  [ "$output" = "github" ]
+}
+
+@test "classify: github raw URL is github" {
+  run classify_token "https://github.com/o/r/raw/main/x.md"
+  [ "$output" = "github" ]
+}
+
+@test "classify: raw.githubusercontent is github" {
+  run classify_token "https://raw.githubusercontent.com/o/r/main/x.md"
+  [ "$output" = "github" ]
+}
+
+@test "classify: generic https is url" {
+  run classify_token "https://example.com/a/b"
+  [ "$output" = "url" ]
+}
+
+@test "classify: http is url" {
+  run classify_token "http://example.com"
+  [ "$output" = "url" ]
+}
+
+@test "classify: plain path is path" {
+  run classify_token "sub/inrepo.md:12"
+  [ "$output" = "path" ]
+}
+
+# ---- map_github_url ----
+
+@test "map: blob URL extracts repo, rest, line" {
+  map_github_url "https://github.com/own/proj/blob/main/src/a.go#L42"
+  [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/src/a.go" ] && [ "$GH_LINE" = "42" ]
+}
+
+@test "map: line range keeps start line" {
+  map_github_url "https://github.com/o/r/blob/main/a.md#L42-L60"
+  [ "$GH_LINE" = "42" ]
+}
+
+@test "map: no fragment means no line" {
+  map_github_url "https://github.com/o/r/blob/main/a.md"
+  [ -z "$GH_LINE" ]
+}
+
+@test "map: percent-encoding decodes" {
+  map_github_url "https://github.com/o/r/blob/main/my%20file.md"
+  [ "$GH_REST" = "main/my file.md" ]
+}
+
+@test "map: raw.githubusercontent shape" {
+  map_github_url "https://raw.githubusercontent.com/o/proj/main/docs/x.md"
+  [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/docs/x.md" ]
+}
+
+@test "map: non-github URL fails" {
+  run map_github_url "https://example.com/o/r/blob/main/a.md"
+  [ "$status" -ne 0 ]
+}
+
+# ---- resolve ----
+
+@test "resolve: absolute path" {
+  run resolve "$FIX/repo/top.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/repo/top.md" ]
+}
+
+@test "resolve: cwd-relative path" {
+  run resolve "sub/inrepo.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$PWD/sub/inrepo.md" ]
+}
+
+@test "resolve: cross-worktree finds worktree-only file" {
+  run resolve "wt-only.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/wt/wt-only.md" ]
+}
+
+@test "resolve: QUICKLOOK_ROOTS entry" {
+  QUICKLOOK_ROOTS="$FIX/nowhere:$FIX/roots"
+  run resolve "myrepo/docs/notes.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/roots/myrepo/docs/notes.md" ]
+}
+
+@test "resolve: miss returns rc 1" {
+  run resolve "no/such/file.md"
+  [ "$status" -eq 1 ]
+}
+
+# ---- resolve_github ----
+
+@test "resolve_github: repo-name match in current repo" {
+  # current repo dir is named "repo"; url repo must match that name
+  run resolve_github "repo" "main/sub/inrepo.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/repo/sub/inrepo.md" ]
+}
+
+@test "resolve_github: ref containing slash resolves via successive split" {
+  run resolve_github "repo" "feat/nested-ref/sub/inrepo.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/repo/sub/inrepo.md" ]
+}
+
+@test "resolve_github: roots/<repo>/<path> match" {
+  QUICKLOOK_ROOTS="$FIX/roots"
+  run resolve_github "myrepo" "main/docs/notes.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/roots/myrepo/docs/notes.md" ]
+}
+
+@test "resolve_github: unresolvable returns rc 1 (browser fallback)" {
+  run resolve_github "ghost" "main/no/file.md"
+  [ "$status" -eq 1 ]
+}
+
+# ---- v0.1 regression ----
+
+@test "regression: clipboard path flow unchanged with no env/arg" {
+  clip_read() { printf 'sub/inrepo.md:1'; }
+  raw="$(pick_token)"
+  [ "$raw" = "sub/inrepo.md:1" ]
+  [ "$(classify_token "$raw")" = "path" ]
+  parse_token "$raw"
+  run resolve "$CLIP_PATH"
+  [ "$status" -eq 0 ] && [ "$output" = "$PWD/sub/inrepo.md" ]
+}

--- a/tests/quicklook.bats
+++ b/tests/quicklook.bats
@@ -139,9 +139,55 @@ teardown() {
   [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/docs/x.md" ]
 }
 
+@test "map: /raw/ blob shape extraction" {
+  map_github_url "https://github.com/o/proj/raw/main/docs/x.md"
+  [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/docs/x.md" ]
+}
+
+@test "map: query string is stripped before splitting" {
+  map_github_url "https://github.com/o/r/blob/main/src/x.go?plain=1"
+  [ "$GH_REST" = "main/src/x.go" ]
+}
+
+@test "map: query plus fragment still yields the line" {
+  map_github_url "https://github.com/o/r/blob/main/a.md?plain=1#L10"
+  [ "$GH_REST" = "main/a.md" ] && [ "$GH_LINE" = "10" ]
+}
+
+@test "map: literal + in path stays a plus (path decoding, not query)" {
+  map_github_url "https://github.com/o/r/blob/main/docs/c++.md"
+  [ "$GH_REST" = "main/docs/c++.md" ]
+}
+
+@test "map: backslash escapes are not interpreted by urldecode" {
+  map_github_url 'https://github.com/o/r/blob/main/a\nb.md'
+  # the \n must survive as two literal chars, not become a newline
+  [ "$GH_REST" = 'main/a\nb.md' ]
+}
+
 @test "map: non-github URL fails" {
   run map_github_url "https://example.com/o/r/blob/main/a.md"
   [ "$status" -ne 0 ]
+}
+
+# ---- resolve_github traversal/absolute rejection (security) ----
+
+@test "resolve_github: absolute smuggle (double slash) is refused" {
+  # blob/main//etc/hosts -> rest main//etc/hosts -> candidate /etc/hosts
+  run resolve_github "repo" "main//etc/passwd"
+  [ "$status" -eq 1 ]
+}
+
+@test "resolve_github: dotdot traversal is refused" {
+  run resolve_github "repo" "main/../../../etc/passwd"
+  [ "$status" -eq 1 ]
+}
+
+@test "unsafe_relpath: classifies absolute and traversal, allows plain" {
+  run unsafe_relpath "/etc/passwd";    [ "$status" -eq 0 ]
+  run unsafe_relpath "../x";           [ "$status" -eq 0 ]
+  run unsafe_relpath "a/../b";         [ "$status" -eq 0 ]
+  run unsafe_relpath "a/b/c.md";       [ "$status" -eq 1 ]
 }
 
 # ---- resolve ----


### PR DESCRIPTION
## What

- **GitHub blob/raw URLs** resolve to the LOCAL checkout at the line when one exists (current repo by name, resolve chain, `QUICKLOOK_ROOTS/<repo>`; refs with `/` handled; `#L42-L60` keeps the start line), else the browser.
- **Agent-push**: token priority `$QUICKLOOK_TOKEN` env > argument > clipboard, in both actions; `preview` forwards an argument as `--env`. Agents can put a file on the human's screen without touching the clipboard.
- **bats suite** (`bats tests/`, 41 cases) over resolve / parse / classify / priority / traversal, plus a script-level file for the open-preview forwarding contract.

## SDD trail

Spec `docs/specs/SPEC-001`, test plan + proof `docs/verification/token-kinds.md`, implementation notes with every delta and the two review CRITICALs.

## Review

Two fresh-context reviewers (security + correctness) returned DO NOT SHIP; both CRITICALs fixed and regression-tested:
- correctness: `open-preview.sh` `set --` clobbered `$1`, breaking agent-push AND the v0.1 clipboard flow on every invocation.
- security: a crafted GitHub URL smuggled an absolute/`..` path past `resolve_github` into the overlay (local-secret-exfil via the untrusted `QUICKLOOK_TOKEN` channel). Guarded at source; PoCs re-run and blocked (recorded in the proof).
Plus query-string strip, urldecode hardening, TUI-injection guard, and escalate env isolation.

Negative control: neutering the traversal guard turns the security test red; restoring is green (41/41).