### PR TITLE
feat: agent-push tokens (env > arg > clipboard) + bats suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Agent-push: token priority is `$QUICKLOOK_TOKEN` env > script argument > clipboard, in both actions; `preview` forwards an argument into the pane via `--env`. Agents can now put a file on the human's screen without touching the clipboard.
+- `resolve` always returns an absolute path (fixes a latent case where a cwd-relative hit failed open-in-viewer's repo-containment check).
+- `open-in-viewer` refuses filenames containing control characters before typing them into the file-viewer TUI.
+- bats test suite (`bats tests/`) over the resolve chain, token parsing, and priority; shellcheck + bats documented as the dev loop.
+
 ## 0.1.0 (2026-07-16)
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ Optional. Create `.env` in the directory `herdr plugin config-dir herdr-quickloo
 QUICKLOOK_ROOTS="$HOME/workspace:$HOME/src"
 ```
 
+## Agent-push (programmatic tokens)
+
+The plugin reads, in priority order: `$QUICKLOOK_TOKEN` env > script argument > clipboard. That gives an agent (or any script) a way to put a file on the human's screen without touching their clipboard:
+
+```sh
+# pop the overlay for a specific file+line
+herdr plugin pane open --plugin herdr-quicklook --entrypoint preview \
+  --placement overlay --focus --env QUICKLOOK_TOKEN="src/handler.go:142"
+```
+
+An empty `QUICKLOOK_TOKEN` is treated as unset; the interactive clipboard flow is unchanged when neither env nor argument is given.
+
+## Development
+
+```sh
+shellcheck -x scripts/*.sh && bats tests/   # brew install shellcheck bats-core
+```
+
+The bats suite sources `scripts/lib.sh` directly (temp git repo + worktree + roots fixture), so it exercises the exact production resolve chain.
+
 ## Demo
 
 ![quick look: copy a path, pop the file at the right line](demo/preview.gif)

--- a/scripts/escalate.sh
+++ b/scripts/escalate.sh
@@ -17,7 +17,10 @@ for a in "$@"; do
 done
 [ -z "$file" ] && exit 0
 
-bash "$script_dir/open-in-viewer.sh" "${file}${line:+:$line}"
+# Pass the ACTUAL on-screen file explicitly. `env -u QUICKLOOK_TOKEN` stops
+# open-in-viewer's pick_token from re-reading the inherited env token (which
+# would re-resolve the original token, not the file the user scrolled to).
+env -u QUICKLOOK_TOKEN bash "$script_dir/open-in-viewer.sh" "${file}${line:+:$line}"
 
 # Close the overlay: this script's parent is the less holding the popup open.
 kill -TERM "$PPID" 2>/dev/null

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -26,6 +26,16 @@ load_config() {
   [ -n "$dir" ] && [ -f "$dir/.env" ] && . "$dir/.env"
 }
 
+# pick_token [arg] -> the token to open, priority: $QUICKLOOK_TOKEN env (the
+# only channel that crosses `herdr plugin pane open --env`) > first argument
+# (natural CLI/agent shape) > clipboard (interactive default). Empty env = unset.
+pick_token() {
+  local t="${QUICKLOOK_TOKEN:-}"
+  [ -z "$t" ] && t="${1:-}"
+  [ -z "$t" ] && t="$(clip_read)"
+  printf '%s' "$t"
+}
+
 # split "path:123" into CLIP_PATH / CLIP_LINE
 parse_token() {
   CLIP_PATH="$1"
@@ -36,11 +46,19 @@ parse_token() {
   fi
 }
 
-# resolve <path> -> absolute file path on stdout, or rc 1.
+# resolve <path> -> ABSOLUTE file path on stdout, or rc 1.
 # Order: as-is, $PWD, every worktree of the current repo, each QUICKLOOK_ROOTS.
+# Always absolute: a downstream containment check ("is it under the repo root")
+# must compare against absolute roots, so a bare relative hit is joined to $PWD.
 resolve() {
   local p="$1" w r
-  [ -f "$p" ] && { printf '%s' "$p"; return 0; }
+  if [ -f "$p" ]; then
+    case "$p" in
+      /*) printf '%s' "$p" ;;
+      *) printf '%s' "$PWD/$p" ;;
+    esac
+    return 0
+  fi
   [ -f "$PWD/$p" ] && { printf '%s' "$PWD/$p"; return 0; }
   while IFS= read -r w; do
     [ -f "$w/$p" ] && { printf '%s' "$w/$p"; return 0; }

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -25,11 +25,10 @@ if ! "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1;
   exec bash "$script_dir/open-preview.sh"
 fi
 
-# Token comes from $1 when given (the quick-look overlay's `o` escalation
-# passes the file it is showing); otherwise from the clipboard.
-raw="${1:-}"
-[ -z "$raw" ] && raw="$(clip_read)"
-[ -z "$raw" ] && { notify "clipboard empty"; exit 0; }
+# Token priority: $QUICKLOOK_TOKEN env > $1 (the overlay's `o` escalation and
+# agent callers pass the file explicitly) > clipboard.
+raw="$(pick_token "${1:-}")"
+[ -z "$raw" ] && { notify "nothing to open (no token, clipboard empty)"; exit 0; }
 
 case "$raw" in
   http://* | https://*) url_open "$raw"; exit 0 ;;
@@ -52,6 +51,13 @@ if [ -z "$root" ] || [[ "$target" != "$root"/* ]]; then
   exit 0
 fi
 rel="${target#"$root"/}"
+
+# $rel is typed into the file-viewer TUI via send-text; a control byte in the
+# filename (e.g. an embedded newline in a maliciously-named file) would inject
+# extra keystrokes into that plugin. Refuse.
+case "$rel" in
+  *[$'\n\r\t']*) notify "unsafe filename (control chars); refusing"; exit 0 ;;
+esac
 
 tab="$(printf '%s' "$focused" | jq -r '.result.pane.tab_id // empty' 2>/dev/null)"
 files_pane() {

--- a/scripts/open-preview.sh
+++ b/scripts/open-preview.sh
@@ -7,6 +7,10 @@ set -uo pipefail
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
 
+# Capture the caller's token BEFORE any `set --` reassigns the positional
+# parameters (that clobbers $1 to the first herdr-command word otherwise).
+token="${1:-}"
+
 repo=""
 if [ -n "$ctx" ] && command -v jq >/dev/null 2>&1; then
   repo="$(printf '%s' "$ctx" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null || true)"
@@ -21,6 +25,13 @@ set -- plugin pane open \
 
 if [ -n "$repo" ] && [ -d "$repo" ]; then
   set -- "$@" --cwd "$repo"
+fi
+
+# Agent-push: a token argument rides into the pane as $QUICKLOOK_TOKEN (env is
+# the only channel that crosses `plugin pane open`; the pane checks it before
+# the clipboard). Only forwarded when the caller actually passed one.
+if [ -n "$token" ]; then
+  set -- "$@" --env "QUICKLOOK_TOKEN=$token"
 fi
 
 exec "$herdr_bin" "$@"

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -17,8 +17,10 @@ pause_close() {
 
 load_config
 
-raw="$(clip_read)"
-[ -z "$raw" ] && pause_close "quicklook: clipboard is empty"
+# Token priority: $QUICKLOOK_TOKEN env (agents set this via `plugin pane open
+# --env`) > $1 > clipboard. Lets an agent push a file onto the screen.
+raw="$(pick_token "${1:-}")"
+[ -z "$raw" ] && pause_close "quicklook: nothing to open (no token, clipboard empty)"
 
 case "$raw" in
   http://* | https://*)

--- a/tests/open-preview.bats
+++ b/tests/open-preview.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# Script-level tests for open-preview.sh's argument forwarding. A stub `herdr`
+# on PATH captures the argv the script would exec, so we assert on the flags
+# without a running server. Covers the SPEC-001 TASK-004 acceptance directly
+# (the review CRITICAL lived exactly here: $1 clobbered by `set --`).
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/open-preview.sh"
+  STUB="$(mktemp -d)"
+  cat > "$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+# echo the full argv, one per line, so tests can grep it
+printf '%s\n' "$@"
+SH
+  chmod +x "$STUB/herdr"
+  PATH="$STUB:$PATH"
+  export PATH
+  # no herdr context; the script falls back cleanly
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD
+}
+
+teardown() { rm -rf "$STUB"; }
+
+@test "open-preview: no arg emits NO --env flag" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q -- '--env' <<<"$output"
+  # sanity: it still built the pane-open command
+  grep -q -- 'pane' <<<"$output"
+}
+
+@test "open-preview: a token arg is forwarded verbatim as QUICKLOOK_TOKEN" {
+  run bash "$SCRIPT" "src/x.go:42"
+  [ "$status" -eq 0 ]
+  grep -q -- '--env' <<<"$output"
+  grep -qx 'QUICKLOOK_TOKEN=src/x.go:42' <<<"$output"
+}
+
+@test "open-preview: never forwards the literal 'plugin' (the set-- clobber bug)" {
+  run bash "$SCRIPT"
+  ! grep -qx 'QUICKLOOK_TOKEN=plugin' <<<"$output"
+}

--- a/tests/quicklook.bats
+++ b/tests/quicklook.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Tests source scripts/lib.sh directly: the suite runs the production code.
+# Fixture: a temp git repo with one worktree and a roots dir, built per test.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  # pwd -P canonicalizes /var vs /private/var so expectations match git output
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/roots/myrepo/docs" "$FIX/repo/sub"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello\n' > "$FIX/repo/sub/inrepo.md"
+  printf 'root file\n' > "$FIX/repo/top.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+  git -C "$FIX/repo" worktree add -q "$FIX/wt" -b wt-branch
+  printf 'only in worktree\n' > "$FIX/wt/wt-only.md"
+  printf 'roots file\n' > "$FIX/roots/myrepo/docs/notes.md"
+
+  cd "$FIX/repo"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  git -C "$FIX/repo" worktree remove --force "$FIX/wt" 2>/dev/null || true
+  rm -rf "$FIX"
+}
+
+# ---- parse_token ----
+
+@test "parse_token: plain path" {
+  parse_token "a/b.md"
+  [ "$CLIP_PATH" = "a/b.md" ] && [ -z "$CLIP_LINE" ]
+}
+
+@test "parse_token: path:line splits" {
+  parse_token "a/b.md:42"
+  [ "$CLIP_PATH" = "a/b.md" ] && [ "$CLIP_LINE" = "42" ]
+}
+
+@test "parse_token: trailing colon stays in path" {
+  parse_token "a/b.md:"
+  [ "$CLIP_PATH" = "a/b.md:" ] && [ -z "$CLIP_LINE" ]
+}
+
+@test "parse_token: non-numeric suffix stays in path" {
+  parse_token "a/b.md:xyz"
+  [ "$CLIP_PATH" = "a/b.md:xyz" ] && [ -z "$CLIP_LINE" ]
+}
+
+# ---- pick_token (env > arg > clipboard) ----
+
+@test "pick_token: env beats arg" {
+  QUICKLOOK_TOKEN="from-env"
+  run pick_token "from-arg"
+  [ "$output" = "from-env" ]
+}
+
+@test "pick_token: arg beats clipboard" {
+  clip_read() { printf 'from-clip'; }
+  run pick_token "from-arg"
+  [ "$output" = "from-arg" ]
+}
+
+@test "pick_token: empty env falls through to arg" {
+  QUICKLOOK_TOKEN=""
+  run pick_token "from-arg"
+  [ "$output" = "from-arg" ]
+}
+
+@test "pick_token: all empty yields empty" {
+  clip_read() { printf ''; }
+  run pick_token
+  [ -z "$output" ]
+}
+
+# ---- resolve ----
+
+@test "resolve: absolute path" {
+  run resolve "$FIX/repo/top.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/repo/top.md" ]
+}
+
+@test "resolve: cwd-relative path returns absolute" {
+  run resolve "sub/inrepo.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$PWD/sub/inrepo.md" ]
+}
+
+@test "resolve: cross-worktree finds worktree-only file" {
+  run resolve "wt-only.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/wt/wt-only.md" ]
+}
+
+@test "resolve: QUICKLOOK_ROOTS entry" {
+  QUICKLOOK_ROOTS="$FIX/nowhere:$FIX/roots"
+  run resolve "myrepo/docs/notes.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/roots/myrepo/docs/notes.md" ]
+}
+
+@test "resolve: miss returns rc 1" {
+  run resolve "no/such/file.md"
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Token source becomes `$QUICKLOOK_TOKEN` env > script argument > clipboard, in both actions. `preview` forwards an argument into the pane via `--env`, so an agent can put a file on the human's screen without touching their clipboard. The interactive clipboard flow is unchanged when neither env nor argument is given.

Also folds in fixes surfaced by an earlier review pass:
- `open-preview.sh` captured `$1` before the `set --` that builds the herdr command (a prior version clobbered it, which would have broken both agent-push and the plain clipboard flow).
- `open-in-viewer.sh` refuses filenames with control characters before typing them into the file-viewer TUI.
- `resolve` always returns an absolute path (a cwd-relative hit previously failed the repo-containment check).

## Tests

`shellcheck -x scripts/*.sh && bats tests/` — 16 cases (token parse/priority + resolve chain) plus a script-level file that asserts open-preview's forwarding contract against a stub `herdr`.