### PR TITLE
feat: map GitHub blob/raw URLs to the local checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- GitHub blob/raw URLs (`github.com/o/r/blob/<ref>/<path>#L<n>`, `/raw/`, `raw.githubusercontent.com`) open the LOCAL checkout at the line when one resolves (current repo by name, plain resolve chain, `QUICKLOOK_ROOTS/<repo>`); refs containing `/` are handled by successive splits; unresolvable URLs fall back to the browser. `#L42-L60` ranges keep the start line. A crafted URL cannot smuggle an absolute or `..`-traversal path (guarded).
 - Agent-push: token priority is `$QUICKLOOK_TOKEN` env > script argument > clipboard, in both actions; `preview` forwards an argument into the pane via `--env`. Agents can now put a file on the human's screen without touching the clipboard.
 - `resolve` always returns an absolute path (fixes a latent case where a cwd-relative hit failed open-in-viewer's repo-containment check).
 - `open-in-viewer` refuses filenames containing control characters before typing them into the file-viewer TUI.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 Born from a daily annoyance: coding agents print file paths all day (`src/api/handler.go:142`), and reviewing one meant leaving the terminal or retyping the path. Pair this with a hint-copy plugin like [herdr-pluck](https://github.com/rmarganti/herdr-pluck) and the whole loop is two keystrokes: pluck the path, pop the file.
 
+A few things that make it more than a pager:
+
+- **A GitHub link opens your local file.** Paste `github.com/org/repo/blob/main/src/x.go#L42` and it opens *your checkout* at line 42, not a browser tab, resolving across worktrees and your other repos.
+- **An agent can put a file on your screen.** Set `QUICKLOOK_TOKEN` and any script or coding agent pops a file into your overlay, no clipboard needed.
+- **Quick look, then commit to it.** Reading in the overlay and want the full tree? One key (`o`) escalates the same file, at the same line, into [herdr-file-viewer](https://github.com/smarzban/herdr-file-viewer).
+
 ## What it opens
 
 | Clipboard content | What happens |
@@ -117,6 +123,7 @@ Everything else is optional, and the plugin degrades instead of failing:
 
 - One token at a time: it reads the clipboard, it does not scan the screen (that is the hint-copy plugin's job).
 - `open-in-viewer` only reaches files inside the focused pane's repo (the viewer roots there); anything outside gets a notification pointing at the preview overlay instead.
+- GitHub-URL resolution matches the URL's `<repo>` against the **current checkout's directory name**. If two unrelated local repos share a directory name it can open the same-named file in the wrong one; a URL for a repo you have no local checkout of falls back to the browser.
 - Windows is untested (clipboard/opener cascades cover macOS + Linux).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Born from a daily annoyance: coding agents print file paths all day (`src/api/ha
 
 | Clipboard content | What happens |
 |---|---|
-| `https://…` / `http://…` | Opens in your default browser |
+| a GitHub **blob/raw URL** (`github.com/o/r/blob/main/src/x.go#L42`) | Opens the file in your **local checkout** at that line when one exists (current repo, worktrees, `QUICKLOOK_ROOTS/<repo>`); otherwise the browser |
+| any other `https://…` / `http://…` | Opens in your default browser |
 | `/absolute/path/file.md` | Preview (or viewer) at that file |
 | `relative/path/file.md` | Resolved against the focused pane's cwd, then its git root |
 | a path from **another worktree** of the same repo | Resolved via `git worktree list`, both directions |

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -36,6 +36,103 @@ pick_token() {
   printf '%s' "$t"
 }
 
+# classify_token <raw> -> github | url | path
+classify_token() {
+  case "$1" in
+    https://github.com/*/blob/* | https://github.com/*/raw/* | https://raw.githubusercontent.com/*)
+      printf 'github' ;;
+    http://* | https://*) printf 'url' ;;
+    *) printf 'path' ;;
+  esac
+}
+
+# decode %XX url-escapes only (GitHub blob paths can carry %20 etc.). A literal
+# '+' in a URL PATH is a plus, not a space (that is query-string decoding), so it
+# is left alone. Backslashes in the input are escaped first so printf '%b' cannot
+# interpret attacker-supplied \n / \x sequences that were never %-encoded.
+urldecode() {
+  local s="${1//\\/\\\\}"
+  printf '%b' "${s//\%/\\x}"
+}
+
+# map_github_url <url>: extract GH_REPO, GH_REST (ref/path, decoded), GH_LINE.
+# Accepted shapes: github.com/<o>/<r>/blob/<ref>/<path>[#L<n>[-L<m>]],
+# github.com/<o>/<r>/raw/<ref>/<path>, raw.githubusercontent.com/<o>/<r>/<ref>/<path>.
+# A #L<n>-L<m> range keeps the start line.
+map_github_url() {
+  GH_REPO=""
+  GH_REST=""
+  GH_LINE=""
+  local u="$1" frag="" rest=""
+  case "$u" in
+    *'#L'*)
+      frag="${u##*#L}"
+      u="${u%%#*}"
+      ;;
+  esac
+  u="${u%%\?*}" # drop any ?query (e.g. GitHub's ?plain=1) before splitting
+  if [[ "$frag" =~ ^([0-9]+) ]]; then GH_LINE="${BASH_REMATCH[1]}"; fi
+  case "$u" in
+    https://github.com/*/blob/*)
+      rest="${u#https://github.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/blob/}"
+      ;;
+    https://github.com/*/raw/*)
+      rest="${u#https://github.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/raw/}"
+      ;;
+    https://raw.githubusercontent.com/*)
+      rest="${u#https://raw.githubusercontent.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/}"
+      ;;
+    *) return 1 ;;
+  esac
+  GH_REST="$(urldecode "$GH_REST")"
+  [ -n "$GH_REPO" ] && [ -n "$GH_REST" ]
+}
+
+# unsafe_relpath <candidate> -> rc 0 if the candidate is absolute or carries a
+# `..` traversal segment. A GitHub URL path is always repo-relative, so an
+# absolute or traversal candidate is a smuggled path (e.g.
+# `blob/main//etc/passwd`, `blob/main/../../etc/passwd`) and must be refused;
+# without this, resolve()'s literal `-f` test would open the smuggled file.
+unsafe_relpath() {
+  case "$1" in
+    /* | ../* | */../* | */.. | ..) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# resolve_github <repo> <ref/path> -> local absolute path on stdout, or rc 1.
+# The ref may contain '/', so try successive splits (drop 1..4 leading
+# segments) against: the current repo when its directory name matches <repo>,
+# the plain resolve chain, and each QUICKLOOK_ROOTS/<repo>. Caller falls back
+# to the browser on rc 1.
+resolve_github() {
+  local repo="$1" rest="$2" i cand root gname r
+  root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  gname="${root##*/}"
+  for i in 2 3 4 5; do
+    cand="$(printf '%s' "$rest" | cut -d/ -f"$i"-)"
+    [ -z "$cand" ] && break
+    unsafe_relpath "$cand" && continue
+    if [ -n "$root" ] && [ "$gname" = "$repo" ] && [ -f "$root/$cand" ]; then
+      printf '%s' "$root/$cand"
+      return 0
+    fi
+    if resolve "$cand"; then return 0; fi
+    local IFS=':'
+    for r in ${QUICKLOOK_ROOTS:-}; do
+      [ -n "$r" ] && [ -f "$r/$repo/$cand" ] && { printf '%s' "$r/$repo/$cand"; return 0; }
+    done
+    unset IFS
+  done
+  return 1
+}
+
 # split "path:123" into CLIP_PATH / CLIP_LINE
 parse_token() {
   CLIP_PATH="$1"

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -30,18 +30,29 @@ fi
 raw="$(pick_token "${1:-}")"
 [ -z "$raw" ] && { notify "nothing to open (no token, clipboard empty)"; exit 0; }
 
-case "$raw" in
-  http://* | https://*) url_open "$raw"; exit 0 ;;
-esac
-
-parse_token "$raw"
-
 # Base everything on the focused pane, not this script's own cwd
 focused="$("$herdr_bin" pane current 2>/dev/null)"
 fcwd="$(printf '%s' "$focused" | jq -r '.result.pane.cwd // empty' 2>/dev/null)"
 if [ -n "$fcwd" ]; then cd "$fcwd" 2>/dev/null || true; fi
 
-target="$(resolve "$CLIP_PATH")"
+target=""
+CLIP_LINE=""
+case "$(classify_token "$raw")" in
+  github)
+    if map_github_url "$raw" && target="$(resolve_github "$GH_REPO" "$GH_REST")"; then
+      CLIP_LINE="$GH_LINE"
+    else
+      url_open "$raw"
+      exit 0
+    fi
+    ;;
+  url)
+    url_open "$raw"; exit 0 ;;
+  path)
+    parse_token "$raw"
+    target="$(resolve "$CLIP_PATH")" || true
+    ;;
+esac
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 
 # The viewer roots at the focused pane's repo; outside targets can't show there.

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -22,16 +22,27 @@ load_config
 raw="$(pick_token "${1:-}")"
 [ -z "$raw" ] && pause_close "quicklook: nothing to open (no token, clipboard empty)"
 
-case "$raw" in
-  http://* | https://*)
+target=""
+CLIP_LINE=""
+case "$(classify_token "$raw")" in
+  github)
+    if map_github_url "$raw" && target="$(resolve_github "$GH_REPO" "$GH_REST")"; then
+      CLIP_LINE="$GH_LINE"
+    else
+      # no local checkout matches: the browser is the right place after all
+      url_open "$raw"
+      exit 0
+    fi
+    ;;
+  url)
     url_open "$raw"
     exit 0
     ;;
+  path)
+    parse_token "$raw"
+    target="$(resolve "$CLIP_PATH")" || true
+    ;;
 esac
-
-parse_token "$raw"
-
-target="$(resolve "$CLIP_PATH")"
 
 if [ -z "${target:-}" ]; then
   root="$(git rev-parse --show-toplevel 2>/dev/null)"

--- a/tests/dispatch.bats
+++ b/tests/dispatch.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# Script-level tests for the token dispatch in preview-pane.sh: run the actual
+# script with a github / path / url token and assert where it ends up. `less`
+# is stubbed to print the file it was asked to open (preview-pane execs it with
+# the resolved target as the last argument), so we can assert the resolved path
+# without a real pager or herdr server. This is the coverage the unit tests
+# (which call lib.sh functions directly) do not give: it proves the case block
+# in the consumer script is wired correctly.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/preview-pane.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # a repo whose DIRECTORY NAME is "myrepo" so a github URL for repo "myrepo" matches
+  mkdir -p "$FIX/myrepo"
+  git -C "$FIX/myrepo" init -q -b main
+  printf 'line1\nline2\nline3\n' > "$FIX/myrepo/f.md"
+  git -C "$FIX/myrepo" add -A
+  git -C "$FIX/myrepo" -c user.email=t@t -c user.name=t commit -qm fix
+
+  # stubs: `less` prints its args (so the target path is visible); `herdr`
+  # answers config-dir with empty; `bat` absent so preview-pane takes the less path.
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\n' > "$STUB/less"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/herdr"
+  chmod +x "$STUB/less" "$STUB/herdr"
+
+  cd "$FIX/myrepo"
+  # keep git/coreutils reachable but force our less + no bat
+  export PATH="$STUB:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+  # make sure bat is not found even if installed system-wide
+  bat() { return 127; }
+  export -f bat 2>/dev/null || true
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+@test "dispatch: github blob URL opens the local file at the line" {
+  export QUICKLOOK_TOKEN="https://github.com/owner/myrepo/blob/main/f.md#L3"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # resolved to the LOCAL file, with the +3 line jump
+  [[ "$output" == *"$FIX/myrepo/f.md"* ]]
+  [[ "$output" == *"+3"* ]]
+}
+
+@test "dispatch: a plain relative path token opens locally" {
+  export QUICKLOOK_TOKEN="f.md:2"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$FIX/myrepo/f.md"* ]]
+  [[ "$output" == *"+2"* ]]
+}
+
+@test "dispatch: a github URL with no matching local checkout does not open a file" {
+  export QUICKLOOK_TOKEN="https://github.com/owner/ghostrepo/blob/main/nope.md"
+  run bash "$SCRIPT"
+  # no local file resolved -> browser fallback path, less never called with a target
+  ! [[ "$output" == *"LESS_ARGS"*"nope.md"* ]]
+}

--- a/tests/quicklook.bats
+++ b/tests/quicklook.bats
@@ -104,3 +104,117 @@ teardown() {
   run resolve "no/such/file.md"
   [ "$status" -eq 1 ]
 }
+
+# ---- classify_token ----
+
+@test "classify: blob URL is github" {
+  run classify_token "https://github.com/o/r/blob/main/src/x.go"
+  [ "$output" = "github" ]
+}
+
+@test "classify: /raw/ URL is github" {
+  run classify_token "https://github.com/o/r/raw/main/x.md"
+  [ "$output" = "github" ]
+}
+
+@test "classify: raw.githubusercontent is github" {
+  run classify_token "https://raw.githubusercontent.com/o/r/main/x.md"
+  [ "$output" = "github" ]
+}
+
+@test "classify: generic https is url" {
+  run classify_token "https://example.com/a/b"
+  [ "$output" = "url" ]
+}
+
+@test "classify: plain path is path" {
+  run classify_token "sub/inrepo.md:12"
+  [ "$output" = "path" ]
+}
+
+# ---- map_github_url ----
+
+@test "map: blob URL extracts repo, rest, line" {
+  map_github_url "https://github.com/own/proj/blob/main/src/a.go#L42"
+  [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/src/a.go" ] && [ "$GH_LINE" = "42" ]
+}
+
+@test "map: line range keeps start line" {
+  map_github_url "https://github.com/o/r/blob/main/a.md#L42-L60"
+  [ "$GH_LINE" = "42" ]
+}
+
+@test "map: /raw/ shape extraction" {
+  map_github_url "https://github.com/o/proj/raw/main/docs/x.md"
+  [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/docs/x.md" ]
+}
+
+@test "map: raw.githubusercontent shape" {
+  map_github_url "https://raw.githubusercontent.com/o/proj/main/docs/x.md"
+  [ "$GH_REPO" = "proj" ] && [ "$GH_REST" = "main/docs/x.md" ]
+}
+
+@test "map: query string is stripped before splitting" {
+  map_github_url "https://github.com/o/r/blob/main/src/x.go?plain=1"
+  [ "$GH_REST" = "main/src/x.go" ]
+}
+
+@test "map: query plus fragment still yields the line" {
+  map_github_url "https://github.com/o/r/blob/main/a.md?plain=1#L10"
+  [ "$GH_REST" = "main/a.md" ] && [ "$GH_LINE" = "10" ]
+}
+
+@test "map: literal + in path stays a plus" {
+  map_github_url "https://github.com/o/r/blob/main/docs/c++.md"
+  [ "$GH_REST" = "main/docs/c++.md" ]
+}
+
+@test "map: backslash escapes are not interpreted" {
+  map_github_url 'https://github.com/o/r/blob/main/a\nb.md'
+  [ "$GH_REST" = 'main/a\nb.md' ]
+}
+
+@test "map: non-github URL fails" {
+  run map_github_url "https://example.com/o/r/blob/main/a.md"
+  [ "$status" -ne 0 ]
+}
+
+# ---- resolve_github + traversal rejection (security) ----
+
+@test "resolve_github: repo-name match in current repo" {
+  run resolve_github "repo" "main/sub/inrepo.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/repo/sub/inrepo.md" ]
+}
+
+@test "resolve_github: ref containing slash resolves via successive split" {
+  run resolve_github "repo" "feat/nested-ref/sub/inrepo.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/repo/sub/inrepo.md" ]
+}
+
+@test "resolve_github: roots/<repo>/<path> match" {
+  QUICKLOOK_ROOTS="$FIX/roots"
+  run resolve_github "myrepo" "main/docs/notes.md"
+  [ "$status" -eq 0 ] && [ "$output" = "$FIX/roots/myrepo/docs/notes.md" ]
+}
+
+@test "resolve_github: unresolvable returns rc 1 (browser fallback)" {
+  run resolve_github "ghost" "main/no/file.md"
+  [ "$status" -eq 1 ]
+}
+
+@test "resolve_github: absolute smuggle (double slash) is refused" {
+  run resolve_github "repo" "main//etc/passwd"
+  [ "$status" -eq 1 ]
+}
+
+@test "resolve_github: dotdot traversal is refused" {
+  run resolve_github "repo" "main/../../../etc/passwd"
+  [ "$status" -eq 1 ]
+}
+
+@test "unsafe_relpath: classifies absolute and traversal, allows plain" {
+  run unsafe_relpath "/etc/passwd";  [ "$status" -eq 0 ]
+  run unsafe_relpath "../x";         [ "$status" -eq 0 ]
+  run unsafe_relpath "a/../b";       [ "$status" -eq 0 ]
+  run unsafe_relpath "a/b/c.md";     [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Rebased onto main after #3 (agent-push) merged; the old stacked PR #4 auto-closed when its base branch was deleted. Same reviewed code.

A GitHub blob/raw URL on the clipboard opens the LOCAL file at the line when a matching checkout exists (current repo by name, resolve chain, `QUICKLOOK_ROOTS/<repo>`; refs with `/` handled; `#L42-L60` keeps the start line; `?plain=1` stripped), else the browser. A crafted URL cannot smuggle an absolute or `..`-traversal path (guarded at source; PoCs asserted blocked). Adds 40 total bats (unit + script-level dispatch). Reviewed SHIP by correctness + advisor.