### PR TITLE
feat: e -> $EDITOR escalation in the preview overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `e` in the preview overlay opens the current file, at the current line, in `$EDITOR` (config `QUICKLOOK_EDITOR` beats `$EDITOR` beats `zed --wait`); the overlay resumes once the editor exits. Bound via less's `pshell` shell-escape (a `^P`-suppressed `#` command), since the single `visual` slot is already `o`'s.
 - GitHub blob/raw URLs (`github.com/o/r/blob/<ref>/<path>#L<n>`, `/raw/`, `raw.githubusercontent.com`) open the LOCAL checkout at the line when one resolves (current repo by name, plain resolve chain, `QUICKLOOK_ROOTS/<repo>`); refs containing `/` are handled by successive splits; unresolvable URLs fall back to the browser. `#L42-L60` ranges keep the start line. A crafted URL cannot smuggle an absolute or `..`-traversal path (guarded).
 - Agent-push: token priority is `$QUICKLOOK_TOKEN` env > script argument > clipboard, in both actions; `preview` forwards an argument into the pane via `--env`. Agents can now put a file on the human's screen without touching the clipboard.
 - `resolve` always returns an absolute path (fixes a latent case where a cwd-relative hit failed open-in-viewer's repo-containment check).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A few things that make it more than a pager:
 - **A GitHub link opens your local file.** Paste `github.com/org/repo/blob/main/src/x.go#L42` and it opens *your checkout* at line 42, not a browser tab, resolving across worktrees and your other repos.
 - **An agent can put a file on your screen.** Set `QUICKLOOK_TOKEN` and any script or coding agent pops a file into your overlay, no clipboard needed.
 - **Quick look, then commit to it.** Reading in the overlay and want the full tree? One key (`o`) escalates the same file, at the same line, into [herdr-file-viewer](https://github.com/smarzban/herdr-file-viewer).
+- **Or straight into your editor.** `e` opens the same file, at the same line, in `$EDITOR` (config-overridable); the overlay resumes once you close it.
 
 ## What it opens
 
@@ -58,6 +59,7 @@ Reload with `herdr server reload-config`.
 |---|---|
 | `q` or `Esc Esc` | Close the overlay (a bare Esc cannot coexist with arrow-key scrolling in less, so quit is double-Esc) |
 | `o` (or `v`) | **Escalate**: close the overlay and open this file, at the same line, in the herdr-file-viewer pane (when that plugin is installed) |
+| `e` | **Edit**: open this file, at the same line, in `$EDITOR` (config-overridable, default `zed --wait`); the overlay resumes when the editor exits |
 | `/`, `n`, `N` | Search inside the file |
 | arrows / PgUp / PgDn | Scroll |
 
@@ -72,6 +74,12 @@ Optional. Create `.env` in the directory `herdr plugin config-dir herdr-quickloo
 # print repo-prefixed paths like "myrepo/docs/notes.md" and all your repos
 # live under one parent directory.
 QUICKLOOK_ROOTS="$HOME/workspace:$HOME/src"
+
+# Command launched by `e` in the overlay. Precedence: this key > $EDITOR >
+# "zed --wait". Set it here rather than relying on $EDITOR alone: the herdr
+# server process that launches this pane does not reliably inherit an
+# interactive shell's exported vars.
+QUICKLOOK_EDITOR="zed --wait"
 ```
 
 ## Agent-push (programmatic tokens)
@@ -115,7 +123,7 @@ Everything else is optional, and the plugin degrades instead of failing:
 
 ## How it works
 
-- **preview** opens a plugin overlay pane (a real TTY) that reads the clipboard, resolves the token, and renders it with `less` (bat as the `LESSOPEN` colorizer). Esc-to-quit ships via a `lesskey` file.
+- **preview** opens a plugin overlay pane (a real TTY) that reads the clipboard, resolves the token, and renders it with `less` (bat as the `LESSOPEN` colorizer). Esc-to-quit ships via a `lesskey` file. `o` escalates via less's single `visual` slot (`$VISUAL` -> `escalate.sh`); `e` cannot reuse that slot, so it is bound directly to less's `pshell` shell-escape action instead (`escalate-editor.sh`, with a `^P` extra-string prefix that suppresses the shell-escape's normal "done" prompt so the overlay resumes cleanly).
 - **open-in-viewer** has no goto-file API to call, so it drives the viewer's own keys over the herdr socket: it ensures a `Files` pane exists in the focused tab (opening one via the viewer's action if needed), then sends `f`, types the repo-relative path, and presses Enter; `path:123` follows up with the viewer's `:` goto-line. This is UI-scripting by nature: if the viewer's keymap changes upstream, this action needs a revisit.
 - No event hooks, no daemons, nothing runs until you press your key.
 

--- a/config.example
+++ b/config.example
@@ -10,3 +10,11 @@
 # standing in a different repo. If all your repos live under ~/workspace,
 # adding it here lets that path resolve to ~/workspace/myrepo/docs/notes.md.
 #QUICKLOOK_ROOTS="$HOME/workspace:$HOME/src"
+
+# QUICKLOOK_EDITOR: command launched by `e` in the preview overlay, at the
+# current file+line. Precedence: this key > $EDITOR > "zed --wait". Set this
+# instead of (or in addition to) exporting $EDITOR in your shell: the herdr
+# server process that launches this pane does not reliably inherit your
+# interactive shell's exported vars, so a config value here is the reliable
+# path (the same reason QUICKLOOK_ROOTS lives here instead of relying on env).
+#QUICKLOOK_EDITOR="zed --wait"

--- a/lesskey
+++ b/lesskey
@@ -1,6 +1,16 @@
 # q or Esc-Esc closes the preview. A bare \e binding cannot coexist with
 # arrow keys (they send ESC-prefixed sequences and less fires the single-char
 # binding immediately, verified on less 668), so quit is double-Esc instead.
+#
+# `e` -> $EDITOR: less binds only ONE `visual` slot, already claimed by `o`
+# (escalate to herdr-file-viewer). `e` is bound directly to `pshell` (the
+# `#` shell-escape, prompt-expanded) with an extra string instead: `\020`
+# (^P) suppresses the "done (press RETURN)" prompt shell-escapes normally
+# print, so the overlay resumes exactly like `visual` does. `?lm+%lm. %g`
+# mirrors LESSEDIT's own default expansion (current-line + shell-escaped
+# filename); QUICKLOOK_EDITOR_SCRIPT is exported by preview-pane.sh.
+# Verified against a real less 668 session (PR proof).
 #command
 \e\e quit
 o visual
+e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n

--- a/scripts/escalate-editor.sh
+++ b/scripts/escalate-editor.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# escalate-editor.sh: invoked by less as a lesskey `pshell` command when the
+# user presses `e` in the quick-look overlay. less calls it as
+# `escalate-editor.sh [+LINE] FILE` (the same +LINE/FILE shape LESSEDIT
+# passes to `visual`, reusing escalate.sh's arg-parsing convention).
+#
+# Unlike escalate.sh (bound to the single `visual` slot, already claimed by
+# `o` -> herdr-file-viewer), `e` cannot reuse `visual`. It is instead bound
+# directly to less's `pshell` action (the `#` shell-escape, prompt-expanded)
+# via an extra string in lesskey, so this script runs as an ordinary
+# shell-escape command. less already suspends/resumes itself around a
+# shell-escape: it does NOT need this script to kill its parent (contrast
+# escalate.sh, which does, because `visual` hands off the whole session).
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/lib.sh
+. "$script_dir/lib.sh"
+
+load_config
+
+line=""
+file=""
+for a in "$@"; do
+  case "$a" in
+    +[0-9]*) line="${a#+}" ;;
+    *) file="$a" ;;
+  esac
+done
+[ -z "$file" ] && exit 0
+
+# Precedence: config QUICKLOOK_EDITOR (from .env, see load_config) > $EDITOR
+# > "zed --wait". A config value beats $EDITOR because the herdr server
+# process that launches this pane does not reliably inherit an interactive
+# shell's exported EDITOR (the same server-env gotcha QUICKLOOK_ROOTS exists
+# for); the .env file is read directly regardless of the server's env.
+editor_cmd=()
+read -ra editor_cmd <<<"${QUICKLOOK_EDITOR:-${EDITOR:-zed --wait}}"
+[ "${#editor_cmd[@]}" -eq 0 ] && exit 0
+
+if [ -n "$line" ]; then
+  exec "${editor_cmd[@]}" "+$line" "$file"
+else
+  exec "${editor_cmd[@]}" "$file"
+fi

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -78,6 +78,8 @@ lesskey_args=()
 [ -f "$script_dir/../lesskey" ] && lesskey_args=(--lesskey-src="$script_dir/../lesskey")
 
 export VISUAL="$script_dir/escalate.sh"
+# Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
+export QUICKLOOK_EDITOR_SCRIPT="$script_dir/escalate-editor.sh"
 if command -v bat >/dev/null 2>&1; then
   export LESSOPEN='|bat --color=always --style=numbers,header %s'
   exec less -R "${lesskey_args[@]}" ${CLIP_LINE:++$CLIP_LINE} "$target"

--- a/tests/editor-escalate.bats
+++ b/tests/editor-escalate.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# Script-level tests for escalate-editor.sh (the `e` -> $EDITOR hand-off).
+# A stub editor script logs its argv, so we assert the exact command line
+# built without invoking a real editor. Config precedence is exercised via a
+# stub `herdr` binary answering `plugin config-dir` with a fixture dir that
+# holds a `.env` (mirrors dispatch.bats' herdr-stub pattern).
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/escalate-editor.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  STUB="$(mktemp -d)"
+  CFGDIR="$(mktemp -d)"
+
+  printf 'line1\nline2\n' > "$FIX/f.md"
+  printf 'target\n' > "$FIX/file with space.md"
+
+  # editor stubs: each logs its OWN identity + argv, so a test can tell which
+  # one actually ran (precedence) as well as the exact argv built.
+  cat > "$STUB/env-editor" <<'SH'
+#!/usr/bin/env bash
+{ printf 'ENV ARGC:%d ARGS:' "$#"; for a in "$@"; do printf '[%s]' "$a"; done; printf '\n'; } >> "$STUB_LOG"
+SH
+  cat > "$STUB/cfg-editor" <<'SH'
+#!/usr/bin/env bash
+{ printf 'CFG ARGC:%d ARGS:' "$#"; for a in "$@"; do printf '[%s]' "$a"; done; printf '\n'; } >> "$STUB_LOG"
+SH
+  chmod +x "$STUB/env-editor" "$STUB/cfg-editor"
+
+  # herdr stub: `plugin config-dir herdr-quicklook` prints CFGDIR (empty by
+  # default, no .env -> load_config finds nothing, matching production when
+  # no config file has been created)
+  cat > "$STUB/herdr" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = plugin ] && [ "\$2" = config-dir ]; then printf '%s\n' "$CFGDIR"; exit 0; fi
+exit 0
+SH
+  chmod +x "$STUB/herdr"
+
+  STUB_LOG="$FIX/editor.log"
+  export STUB_LOG STUB
+  export HERDR_BIN_PATH="$STUB/herdr"
+  export PATH="$STUB:$PATH"
+  unset QUICKLOOK_EDITOR EDITOR
+}
+
+teardown() {
+  rm -rf "$FIX" "$STUB" "$CFGDIR"
+}
+
+@test "no line: builds \$EDITOR + file argv" {
+  export EDITOR="$STUB/env-editor"
+  run bash "$SCRIPT" "$FIX/f.md"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$STUB_LOG")" = "ENV ARGC:1 ARGS:[$FIX/f.md]" ]
+}
+
+@test "+line: builds \$EDITOR +LINE file argv" {
+  export EDITOR="$STUB/env-editor"
+  run bash "$SCRIPT" "+5" "$FIX/f.md"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$STUB_LOG")" = "ENV ARGC:2 ARGS:[+5][$FIX/f.md]" ]
+}
+
+@test "space-in-filename stays one arg" {
+  export EDITOR="$STUB/env-editor"
+  run bash "$SCRIPT" "+2" "$FIX/file with space.md"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$STUB_LOG")" = "ENV ARGC:2 ARGS:[+2][$FIX/file with space.md]" ]
+}
+
+@test "config QUICKLOOK_EDITOR beats \$EDITOR" {
+  printf 'QUICKLOOK_EDITOR="%s"\n' "$STUB/cfg-editor" > "$CFGDIR/.env"
+  export EDITOR="$STUB/env-editor"
+  run bash "$SCRIPT" "$FIX/f.md"
+  [ "$status" -eq 0 ]
+  # the CFG stub ran (config wins); the ENV stub never fired
+  [ "$(cat "$STUB_LOG")" = "CFG ARGC:1 ARGS:[$FIX/f.md]" ]
+}
+
+@test "no file argument: exits quietly, no editor invoked" {
+  export EDITOR="$STUB/env-editor"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$STUB_LOG" ]
+}


### PR DESCRIPTION
Adds `e` in the preview overlay to open the current file+line in `$EDITOR` (config-overridable),
mirroring `o`->file-viewer. Includes a real less-session capture proving the key mechanism (less
has one `visual` slot; the PR documents how the second hand-off is wired). Run-table below.

## Key mechanism (design question, resolved)

less exposes exactly one `visual` slot (`$VISUAL`, driven by the `v` action), already claimed by
`o` -> `escalate.sh` -> herdr-file-viewer. `e` cannot reuse it. Chosen: **(b) bind `e` directly to
a shell command**, specifically less's `pshell` action (the `#` shell-escape, whose command string
is prompt-expanded the same way `visual`'s `LESSEDIT` is). The lesskey line:

```
e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n
```

- `\020` (^P) suppresses the shell-escape's normal `"...done (press RETURN)"` prompt, so the
  overlay resumes exactly like `visual` does when the editor exits.
- `?lm+%lm. %g` is LESSEDIT's own default expansion (`%E ?lm+%lm. %g`), reused verbatim: current
  line + shell-escaped filename (one argv-safe token even with a space in the name). This gives
  `e` the same line-number semantics `o` already has, for free.
- `QUICKLOOK_EDITOR_SCRIPT` is exported by `preview-pane.sh` (mirrors how it exports `VISUAL` for
  `escalate.sh`) and points at the new `scripts/escalate-editor.sh`, which reuses `escalate.sh`'s
  `+LINE FILE` argv-parsing loop, then execs `$EDITOR`/`QUICKLOOK_EDITOR` (config beats env beats
  `zed --wait`) with `[+LINE] FILE`.

Options (a) dispatcher-flag-file and (c) route-through-`escalate.sh` were not needed; `pshell` is
already a clean, independent second slot. Fallback (d) was not needed either, since (b) worked on
the first real-session test. Full reasoning + the SG-05 (`d` key) handoff constraint recorded in
the mega-goal `DECISIONS.md`.

## Real less-session proof (the risk this PR had to retire)

Drove the ACTUAL production `lesskey` + `scripts/escalate-editor.sh` (not a throwaway stand-in)
inside a real pty (`less -N --lesskey-src=lesskey <file>` under `expect`), `$EDITOR` pointed at a
logging stub script:

```
$ expect drive-real.exp   # presses `e` on a 5-line file, then `q`
...
$ cat editor.log
EDITOR-INVOKED ARGC:2 ARGS:[+5][sample.txt]
```

`e` reached the real `escalate-editor.sh`, which built the exact `+LINE FILE` argv and exec'd the
stub editor. After the stub exited, the subsequent `q` closed the overlay cleanly (session exited
0) -- no leftover "(press RETURN)" prompt, confirming the `^P` suppression works end to end, not
just in isolation.

Regression checks against the same updated `lesskey` file:

```
$ expect drive-o-regression.exp   # VISUAL=stub, presses `o`
EDITOR-INVOKED ARGC:2 ARGS:[+5][sample.txt]     # o -> visual still fires, unaffected by the new e binding

$ expect drive-quit.exp           # presses `q`
QUIT_OK

$ expect drive-escesc.exp         # presses Esc Esc
ESCESC_OK
```

## Run-table

| Command | Exit | Result |
|---|---|---|
| `shellcheck -x scripts/*.sh` | 0 | clean |
| `bats tests/` | 0 | 45 ok (5 new in `tests/editor-escalate.bats`: no-line argv, `+line` argv, space-in-filename stays one arg, config `QUICKLOOK_EDITOR` beats `$EDITOR`, no-file-arg exits quietly) |
| real less session: `e` on production `lesskey`+`escalate-editor.sh`, `$EDITOR`=logging stub | 0 | `ARGC:2 ARGS:[+5][sample.txt]`, overlay resumed cleanly (no stray "press RETURN") |
| real less session: `o` (VISUAL=stub) on the same updated `lesskey` | 0 | stub invoked identically -- `o`/`visual` unaffected by the new `e` binding |
| real less session: `q` | 0 | quits |
| real less session: `Esc Esc` | 0 | quits |

## Touches

`scripts/escalate-editor.sh` (new), `lesskey`, `scripts/preview-pane.sh` (exports
`QUICKLOOK_EDITOR_SCRIPT`), `tests/editor-escalate.bats` (new), `config.example` + `README.md`
(document `QUICKLOOK_EDITOR`), `CHANGELOG.md`.
