### PR TITLE
refactor: extract token dispatch into a lib.sh entry + handler registry

### DIFF
--- a/scripts/handlers/bare-name.sh
+++ b/scripts/handlers/bare-name.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+# bare-name.sh: fuzzy fallback for a path token that resolve() (path.sh)
+# could not find directly - grep the repo's tracked files for a
+# case-insensitive substring match, fzf-pick when there is more than one hit.
+# This is interactive UI (it can print a listing, block on an fzf pick, or
+# `exit` the calling script directly on a no-fzf multi-match), not a pure
+# target+line+mode resolution, so by design match_bare_name always declines
+# automatic dispatch through resolve_any_token. preview-pane.sh calls
+# handle_bare_name directly when resolve_any_token reports no match;
+# open-in-viewer.sh intentionally does not (zero behavior change from before
+# this refactor). See DECISIONS.md: "bare-name is opt-in, not an auto kind".
+# shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (preview-pane.sh)
+
+match_bare_name() { return 1; }
+
+# handle_bare_name <clip_path> -> a single or fzf-picked match: sets
+# RESOLVED_TARGET (mode=file) and returns 0. Zero matches, no repo root, or
+# an fzf cancel: returns 1 (caller shows its own "not found"). Multiple
+# matches with no fzf installed: prints the candidate list itself and exits
+# the CALLING SCRIPT directly, exactly matching the pre-refactor inline
+# behavior.
+handle_bare_name() {
+  local clip_path="$1" root matches n pick
+  root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  [ -z "$root" ] && return 1
+  matches="$(git -C "$root" ls-files 2>/dev/null | grep -iF -- "$clip_path" | head -100)"
+  n="$(printf '%s' "$matches" | grep -c . 2>/dev/null)"
+  if [ "$n" -eq 1 ]; then
+    RESOLVED_TARGET="$root/$matches"
+    RESOLVED_LINE=""
+    RESOLVED_MODE="file"
+    return 0
+  elif [ "$n" -gt 1 ]; then
+    if command -v fzf >/dev/null 2>&1; then
+      pick="$(printf '%s\n' "$matches" | fzf --prompt="$clip_path ▸ " --reverse --cycle --height=100%)" || exit 0
+      [ -z "$pick" ] && return 1
+      RESOLVED_TARGET="$root/$pick"
+      RESOLVED_LINE=""
+      RESOLVED_MODE="file"
+      return 0
+    else
+      printf '%s matches "%s" in this repo (install fzf for an interactive pick):\n\n' "$n" "$clip_path"
+      printf '%s\n' "$matches"
+      printf '\n'
+      read -r -n1 -p "press any key to close" _ 2>/dev/null || sleep 2
+      exit 0
+    fi
+  fi
+  return 1
+}

--- a/scripts/handlers/dir.sh
+++ b/scripts/handlers/dir.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+# dir.sh: STUB for SG-04 (dir-targets). Reserved shape: a token that resolves
+# to a directory opens the file-viewer rooted there (render-mode `viewer`),
+# or an eza/ls tree in the popup when the viewer is absent (render-mode
+# `command`). Registered in HANDLER_KINDS now, ahead of path.sh's catch-all,
+# so SG-04 only needs to edit this file: a real match_dir + handle_dir body,
+# no lib.sh or pane-script changes required. Must test file first, dir
+# second, so it never shadows path.sh's file resolution.
+
+match_dir() { return 1; }
+handle_dir() { return 1; }

--- a/scripts/handlers/github.sh
+++ b/scripts/handlers/github.sh
@@ -1,0 +1,25 @@
+# shellcheck shell=bash
+# github.sh: github.com/.../blob/... , .../raw/... and raw.githubusercontent.com
+# URLs. Wired to classify_token / map_github_url / resolve_github in lib.sh.
+# SG-03 (more-hosts) EXTENDS this exact file for GitLab/Bitbucket blob URLs;
+# keep this filename, see HANDOFF.md.
+# shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (resolve_any_token's caller)
+
+match_github() {
+  [ "$(classify_token "$1")" = "github" ]
+}
+
+handle_github() {
+  local raw="$1" t
+  if map_github_url "$raw" && t="$(resolve_github "$GH_REPO" "$GH_REST")"; then
+    RESOLVED_TARGET="$t"
+    RESOLVED_LINE="$GH_LINE"
+    RESOLVED_MODE="file"
+    return 0
+  fi
+  # no local checkout matches: the browser is the right place after all
+  RESOLVED_TARGET="$raw"
+  RESOLVED_LINE=""
+  RESOLVED_MODE="browser"
+  return 0
+}

--- a/scripts/handlers/path.sh
+++ b/scripts/handlers/path.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+# path.sh: the catch-all kind, a filesystem path (optionally "path:line").
+# match_path always succeeds, so it MUST stay last in HANDLER_KINDS - see the
+# ordering note in the contract comment at the top of lib.sh.
+# shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (resolve_any_token's caller)
+
+match_path() {
+  [ "$(classify_token "$1")" = "path" ]
+}
+
+handle_path() {
+  parse_token "$1"
+  local t
+  t="$(resolve "$CLIP_PATH")" || return 1
+  RESOLVED_TARGET="$t"
+  RESOLVED_LINE="$CLIP_LINE"
+  RESOLVED_MODE="file"
+}

--- a/scripts/handlers/url.sh
+++ b/scripts/handlers/url.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# url.sh: any other http(s) URL. github.sh is checked first in HANDLER_KINDS
+# and claims the github-shaped URLs, so this only ever sees generic ones.
+# shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (resolve_any_token's caller)
+
+match_url() {
+  [ "$(classify_token "$1")" = "url" ]
+}
+
+handle_url() {
+  RESOLVED_TARGET="$1"
+  RESOLVED_LINE=""
+  RESOLVED_MODE="browser"
+  return 0
+}

--- a/scripts/handlers/vcs.sh
+++ b/scripts/handlers/vcs.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+# vcs.sh: STUB for SG-02 (vcs-tokens). Reserved shape: a bare commit SHA ->
+# `git show`, a `#123`/PR reference -> `gh pr view`, render-mode `command`
+# (see the RESOLVED_CMD contract note at the top of lib.sh - untrusted
+# clipboard input must stay a real argv, never a rebuilt string). Registered
+# in HANDLER_KINDS now, ahead of path.sh's catch-all, so SG-02 only needs to
+# edit this file: a real match_vcs + handle_vcs body, no lib.sh or
+# pane-script changes required.
+
+match_vcs() { return 1; }
+handle_vcs() { return 1; }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -2,6 +2,59 @@
 # lib.sh, shared helpers for herdr-quicklook scripts (sourced, keeps .sh).
 # shellcheck disable=SC2034  # CLIP_PATH/CLIP_LINE are consumed by the sourcing scripts
 
+# -----------------------------------------------------------------------
+# Handler-registry contract
+#
+# A token kind lives in its own scripts/handlers/<kind>.sh and exports two
+# functions:
+#
+#   match_<kind> <raw>   -> rc 0 if this handler owns the token's shape. No
+#                           resolution work, no side effects.
+#   handle_<kind> <raw>  -> resolves the token. On success sets
+#                           RESOLVED_TARGET / RESOLVED_LINE / RESOLVED_MODE
+#                           (and RESOLVED_CMD for `command` mode, see below)
+#                           and returns 0. A handler that recognizes the
+#                           token's shape but cannot resolve a target returns
+#                           1; the caller decides what happens next
+#                           (open-in-viewer.sh reports "not found";
+#                           preview-pane.sh additionally tries the bare-name
+#                           fuzzy fallback below).
+#
+# RESOLVED_MODE is one of:
+#   file    - RESOLVED_TARGET is a local path (RESOLVED_LINE optional);
+#             caller renders/drives it.
+#   browser - RESOLVED_TARGET is a URL; caller does
+#             `url_open "$RESOLVED_TARGET"`.
+#   viewer  - RESOLVED_TARGET is a directory to root the file-viewer at.
+#             Reserved: no handler emits this yet (SG-04/dir.sh).
+#   command - RESOLVED_CMD (a bash ARRAY, not a string) is the argv to run;
+#             its output is what the caller shows. A flat string is not
+#             enough here: a command-mode handler runs an external tool
+#             (`git show`, `gh pr view`) against untrusted clipboard input,
+#             so the args must stay a real argv and never get rebuilt from a
+#             flattened string (that would reopen the exact shell-injection
+#             surface the mode exists to avoid). Widened per this sub-goal's
+#             own contingency clause; see DECISIONS.md. Reserved: no handler
+#             emits this yet (SG-02/vcs.sh).
+#
+# resolve_any_token <raw> walks HANDLER_KINDS in order and dispatches to the
+# first handler whose match_<kind> accepts the token, returning that
+# handler's rc. Order matters: `path` (scripts/handlers/path.sh) is the
+# catch-all (match_path always succeeds), so it MUST stay last, or a
+# later-added kind's real tokens would never reach their own handler.
+#
+# scripts/preview-pane.sh and scripts/open-in-viewer.sh call ONLY
+# resolve_any_token; they are never edited to add a new kind. Adding a kind
+# = one new scripts/handlers/<kind>.sh + one line in HANDLER_KINDS below.
+#
+# scripts/handlers/bare-name.sh is the one documented exception: its fuzzy
+# git-ls-files search + interactive fzf pick is opt-in (match_bare_name
+# always declines automatic dispatch); preview-pane.sh calls
+# handle_bare_name directly when resolve_any_token reports no match.
+# open-in-viewer.sh intentionally does not, so its behavior is unchanged
+# from before this refactor. See DECISIONS.md.
+# -----------------------------------------------------------------------
+
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 
 clip_read() {
@@ -16,6 +69,12 @@ url_open() {
   elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$1"
   fi >/dev/null 2>&1
 }
+
+# record_open <token> -> no-op today (best-effort). SG-07 (recents) fills in
+# the body; both pane scripts already call this at the point a successful
+# open is known, so that sub-goal stays a lib.sh-only change for the body
+# itself (it may still touch the pane scripts' call sites, see DECISIONS.md).
+record_open() { :; }
 
 # Optional config: QUICKLOOK_ROOTS, colon-separated extra roots to try for
 # relative paths (e.g. the parent directory holding all your repos).
@@ -163,6 +222,39 @@ resolve() {
   local IFS=':'
   for r in ${QUICKLOOK_ROOTS:-}; do
     [ -n "$r" ] && [ -f "$r/$p" ] && { printf '%s' "$r/$p"; return 0; }
+  done
+  return 1
+}
+
+# Registry order (first match wins): specific-shape kinds before the
+# catch-all. `path` MUST stay last (see the contract comment at the top of
+# this file). vcs/dir are registered now as stubs (SG-02/SG-04 fill in their
+# match_/handle_ bodies later, one file each, no registry-line edit needed).
+HANDLER_KINDS=(github url vcs dir path)
+
+_herdr_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for _herdr_handler in "$_herdr_lib_dir"/handlers/*.sh; do
+  # shellcheck disable=SC1090
+  [ -f "$_herdr_handler" ] && . "$_herdr_handler"
+done
+unset _herdr_handler _herdr_lib_dir
+
+# resolve_any_token <raw> -> see the handler-registry contract at the top of
+# this file. Sets RESOLVED_TARGET / RESOLVED_LINE / RESOLVED_MODE (and
+# RESOLVED_CMD for command mode) and returns 0 on a resolved token, or
+# returns 1 if no handler matched, or the matched handler could not resolve
+# a target (caller does its own fallback, if any).
+resolve_any_token() {
+  local raw="$1" kind
+  RESOLVED_TARGET=""
+  RESOLVED_LINE=""
+  RESOLVED_MODE=""
+  RESOLVED_CMD=()
+  for kind in "${HANDLER_KINDS[@]}"; do
+    if "match_$kind" "$raw"; then
+      "handle_$kind" "$raw"
+      return $?
+    fi
   done
   return 1
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -20,22 +20,45 @@
 #                           preview-pane.sh additionally tries the bare-name
 #                           fuzzy fallback below).
 #
-# RESOLVED_MODE is one of:
+# RESOLVED_MODE is one of, and BOTH pane scripts act on all four (see their
+# own RESOLVED_MODE case block; this is load-bearing, not aspirational , a
+# handler is free to emit any of these today and get correct behavior):
 #   file    - RESOLVED_TARGET is a local path (RESOLVED_LINE optional);
-#             caller renders/drives it.
+#             caller renders/drives it. Produced today by github.sh, path.sh.
 #   browser - RESOLVED_TARGET is a URL; caller does
-#             `url_open "$RESOLVED_TARGET"`.
-#   viewer  - RESOLVED_TARGET is a directory to root the file-viewer at.
-#             Reserved: no handler emits this yet (SG-04/dir.sh).
+#             `url_open "$RESOLVED_TARGET"`. Produced today by github.sh
+#             (no local checkout), url.sh.
 #   command - RESOLVED_CMD (a bash ARRAY, not a string) is the argv to run;
-#             its output is what the caller shows. A flat string is not
-#             enough here: a command-mode handler runs an external tool
-#             (`git show`, `gh pr view`) against untrusted clipboard input,
-#             so the args must stay a real argv and never get rebuilt from a
-#             flattened string (that would reopen the exact shell-injection
-#             surface the mode exists to avoid). Widened per this sub-goal's
-#             own contingency clause; see DECISIONS.md. Reserved: no handler
-#             emits this yet (SG-02/vcs.sh).
+#             its output is paged for the user. A flat string is not enough
+#             here: a command-mode handler runs an external tool (`git show`,
+#             `gh pr view`) against untrusted clipboard input, so the args
+#             must stay a real argv and never get rebuilt from a flattened
+#             string (that would reopen the exact shell-injection surface
+#             the mode exists to avoid). Widened per this sub-goal's own
+#             contingency clause; see DECISIONS.md. preview-pane.sh runs
+#             RESOLVED_CMD through render_command_in_pager (below) directly
+#             (it has the real TTY); open-in-viewer.sh has no pager of its
+#             own, so it re-invokes the SAME raw token through
+#             scripts/open-preview.sh (a fresh resolve_any_token call there
+#             reproduces the identical RESOLVED_CMD deterministically , safe
+#             for command-mode specifically, see the viewer caveat below).
+#             No handler emits this yet (SG-02/vcs.sh is a stub).
+#   viewer  - RESOLVED_TARGET is a directory to root the file-viewer at.
+#             preview-pane.sh's safe DEGRADE (no handler drives the real
+#             file-viewer socket protocol yet) pages an `eza --tree` /
+#             `ls -la` listing of RESOLVED_TARGET via render_command_in_pager
+#             , the same shape SG-04's own goal file already documents as
+#             its no-viewer-installed fallback. open-in-viewer.sh cannot do
+#             even that (no pager of its own) and cannot safely forward the
+#             raw token the way command-mode does either: path.sh's
+#             resolve() only matches regular files (`-f`), so a directory
+#             token would fail to re-resolve there and silently read as "not
+#             found". It notifies the user and stops instead. Neither arm
+#             ever falls through to file-rendering on a directory ,
+#             the concrete bug this widening exists to prevent. Real
+#             viewer-rooting over the herdr socket is SG-04's own feature;
+#             expect it to replace these degrade bodies. No handler emits
+#             this yet (SG-04/dir.sh is a stub).
 #
 # resolve_any_token <raw> walks HANDLER_KINDS in order and dispatches to the
 # first handler whose match_<kind> accepts the token, returning that
@@ -44,8 +67,14 @@
 # later-added kind's real tokens would never reach their own handler.
 #
 # scripts/preview-pane.sh and scripts/open-in-viewer.sh call ONLY
-# resolve_any_token; they are never edited to add a new kind. Adding a kind
-# = one new scripts/handlers/<kind>.sh + one line in HANDLER_KINDS below.
+# resolve_any_token to CLASSIFY/RESOLVE a token; that side is never edited to
+# add a new kind. Each script's own RESOLVED_MODE case block is where the
+# four modes above render/act; a kind whose handler starts emitting `viewer`
+# or `command` for real (SG-02/SG-04) is expected to refine those bodies ,
+# a disclosed, minor exception to "pane scripts untouched", see HANDOFF.md.
+# Adding a purely additive kind (mode file/browser only) needs zero
+# pane-script edits: one new scripts/handlers/<kind>.sh + one line in
+# HANDLER_KINDS below.
 #
 # scripts/handlers/bare-name.sh is the one documented exception: its fuzzy
 # git-ls-files search + interactive fzf pick is opt-in (match_bare_name
@@ -232,12 +261,28 @@ resolve() {
 # match_/handle_ bodies later, one file each, no registry-line edit needed).
 HANDLER_KINDS=(github url vcs dir path)
 
-_herdr_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-for _herdr_handler in "$_herdr_lib_dir"/handlers/*.sh; do
+# LIB_DIR: this file's own directory (== scripts/), kept around (not
+# unset) so render_command_in_pager below can find ../lesskey the same way
+# the pane scripts locate it from their own script_dir.
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for _herdr_handler in "$LIB_DIR"/handlers/*.sh; do
   # shellcheck disable=SC1090
   [ -f "$_herdr_handler" ] && . "$_herdr_handler"
 done
-unset _herdr_handler _herdr_lib_dir
+unset _herdr_handler
+
+# render_command_in_pager <argv...> -> runs argv, pages its combined
+# stdout+stderr through less (color preserved via -R, so a command that
+# emits ANSI itself, e.g. `git show --color=always`, still highlights).
+# Used for RESOLVED_MODE=command and preview-pane.sh's RESOLVED_MODE=viewer
+# tree-listing degrade (see the contract comment above). Only meaningful
+# from a script with a real TTY (preview-pane.sh); returns the pipeline's
+# exit status.
+render_command_in_pager() {
+  local lesskey_args=()
+  [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
+  "$@" 2>&1 | less -R "${lesskey_args[@]}"
+}
 
 # resolve_any_token <raw> -> see the handler-registry contract at the top of
 # this file. Sets RESOLVED_TARGET / RESOLVED_LINE / RESOLVED_MODE (and

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -39,10 +39,45 @@ target=""
 CLIP_LINE=""
 if resolve_any_token "$raw"; then
   case "$RESOLVED_MODE" in
-    browser) url_open "$RESOLVED_TARGET"; exit 0 ;;
+    browser)
+      url_open "$RESOLVED_TARGET"
+      exit 0
+      ;;
+    command)
+      # This script has no pager of its own (it only drives OTHER panes over
+      # the herdr socket, see the header comment); command-mode output needs
+      # a real TTY. Re-resolving the SAME raw token in the preview overlay is
+      # safe here specifically: a command-mode token (SHA / #123 / PR URL)
+      # doesn't depend on a filesystem test, so resolve_any_token reproduces
+      # the identical RESOLVED_CMD there deterministically. Dispatch BEFORE
+      # the empty-target guard below: a real command-mode result legitimately
+      # leaves RESOLVED_TARGET empty.
+      if [ "${#RESOLVED_CMD[@]}" -gt 0 ]; then
+        record_open "$raw"
+        exec bash "$script_dir/open-preview.sh" "$raw"
+      fi
+      # RESOLVED_CMD empty is a handler bug; fall through to "not found".
+      ;;
+    viewer)
+      # RESOLVED_TARGET is a directory. Driving the file-viewer at an
+      # arbitrary directory root, or even paging a tree listing, both need a
+      # real pane with a TTY, which this action script does not have. Unlike
+      # command-mode above, forwarding the raw token through
+      # scripts/open-preview.sh is NOT safe here: path.sh's resolve() only
+      # matches regular files (`-f`), so a directory token fails to
+      # re-resolve there and would silently read as "not found". No handler
+      # emits this mode yet (dir.sh is a stub; SG-04 owns the real behavior,
+      # including whichever pane ends up rendering it). Never fall through
+      # to the file-driving code below on a directory target , notify and
+      # stop instead.
+      notify "directory viewer not wired yet: $RESOLVED_TARGET"
+      exit 0
+      ;;
+    *)
+      target="$RESOLVED_TARGET"
+      CLIP_LINE="$RESOLVED_LINE"
+      ;;
   esac
-  target="$RESOLVED_TARGET"
-  CLIP_LINE="$RESOLVED_LINE"
 fi
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -37,22 +37,13 @@ if [ -n "$fcwd" ]; then cd "$fcwd" 2>/dev/null || true; fi
 
 target=""
 CLIP_LINE=""
-case "$(classify_token "$raw")" in
-  github)
-    if map_github_url "$raw" && target="$(resolve_github "$GH_REPO" "$GH_REST")"; then
-      CLIP_LINE="$GH_LINE"
-    else
-      url_open "$raw"
-      exit 0
-    fi
-    ;;
-  url)
-    url_open "$raw"; exit 0 ;;
-  path)
-    parse_token "$raw"
-    target="$(resolve "$CLIP_PATH")" || true
-    ;;
-esac
+if resolve_any_token "$raw"; then
+  case "$RESOLVED_MODE" in
+    browser) url_open "$RESOLVED_TARGET"; exit 0 ;;
+  esac
+  target="$RESOLVED_TARGET"
+  CLIP_LINE="$RESOLVED_LINE"
+fi
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 
 # The viewer roots at the focused pane's repo; outside targets can't show there.
@@ -105,3 +96,5 @@ if [ -n "$CLIP_LINE" ]; then
   "$herdr_bin" pane send-text "$pid" "$CLIP_LINE" >/dev/null 2>&1
   "$herdr_bin" pane send-keys "$pid" Enter >/dev/null 2>&1
 fi
+
+record_open "$raw"

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -24,51 +24,27 @@ raw="$(pick_token "${1:-}")"
 
 target=""
 CLIP_LINE=""
-case "$(classify_token "$raw")" in
-  github)
-    if map_github_url "$raw" && target="$(resolve_github "$GH_REPO" "$GH_REST")"; then
-      CLIP_LINE="$GH_LINE"
-    else
-      # no local checkout matches: the browser is the right place after all
-      url_open "$raw"
-      exit 0
-    fi
-    ;;
-  url)
-    url_open "$raw"
-    exit 0
-    ;;
-  path)
-    parse_token "$raw"
-    target="$(resolve "$CLIP_PATH")" || true
-    ;;
-esac
-
-if [ -z "${target:-}" ]; then
-  root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  if [ -n "$root" ]; then
-    matches="$(git -C "$root" ls-files 2>/dev/null | grep -iF -- "$CLIP_PATH" | head -100)"
-    n="$(printf '%s' "$matches" | grep -c . 2>/dev/null)"
-    if [ "$n" -eq 1 ]; then
-      target="$root/$matches"
-    elif [ "$n" -gt 1 ]; then
-      if command -v fzf >/dev/null 2>&1; then
-        pick="$(printf '%s\n' "$matches" | fzf --prompt="$CLIP_PATH ▸ " --reverse --cycle --height=100%)" || exit 0
-        [ -n "$pick" ] && target="$root/$pick"
-      else
-        # no fzf: list the candidates so the user can copy an exact path and retry
-        printf '%s matches "%s" in this repo (install fzf for an interactive pick):\n\n' "$n" "$CLIP_PATH"
-        printf '%s\n' "$matches"
-        printf '\n'
-        read -r -n1 -p "press any key to close" _ 2>/dev/null || sleep 2
-        exit 0
-      fi
-    fi
-  fi
+if resolve_any_token "$raw"; then
+  case "$RESOLVED_MODE" in
+    browser) url_open "$RESOLVED_TARGET"; exit 0 ;;
+  esac
+  target="$RESOLVED_TARGET"
+  CLIP_LINE="$RESOLVED_LINE"
+else
+  # Only a path-shaped token reaches here (github/url always resolve one way
+  # or another via resolve_any_token): fall back to the interactive
+  # bare-name search over this repo's tracked files.
+  parse_token "$raw"
+  handle_bare_name "$CLIP_PATH" && {
+    target="$RESOLVED_TARGET"
+    CLIP_LINE="$RESOLVED_LINE"
+  }
 fi
 
 [ -z "${target:-}" ] && pause_close "quicklook: not a file I can find: $raw" \
   "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS, repo filename search)"
+
+record_open "$raw"
 
 # Render with less driving the real FILE (not a bat pipe), so less keeps the
 # filename and its `visual` command works: `o` (or `v`) escalates to the

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -26,10 +26,46 @@ target=""
 CLIP_LINE=""
 if resolve_any_token "$raw"; then
   case "$RESOLVED_MODE" in
-    browser) url_open "$RESOLVED_TARGET"; exit 0 ;;
+    browser)
+      url_open "$RESOLVED_TARGET"
+      exit 0
+      ;;
+    command)
+      # RESOLVED_CMD is the argv (a bash array, never a flattened string ,
+      # see the contract comment at the top of lib.sh). Dispatch BEFORE the
+      # empty-target guard below: a real command-mode result legitimately
+      # has an empty RESOLVED_TARGET (it uses RESOLVED_CMD instead), so
+      # falling into that guard would wrongly report "not a file I can
+      # find" for a successful resolution.
+      if [ "${#RESOLVED_CMD[@]}" -gt 0 ]; then
+        record_open "$raw"
+        render_command_in_pager "${RESOLVED_CMD[@]}"
+        exit $?
+      fi
+      # RESOLVED_CMD empty is a handler bug (claimed command mode with no
+      # argv to run); fall through and treat it like an unresolved token.
+      ;;
+    viewer)
+      # RESOLVED_TARGET is a directory. No handler drives the real
+      # file-viewer socket protocol yet (SG-04 owns that); never fall
+      # through to the file-render path below on a directory target, that
+      # is the exact `exec less <directory>` bug this arm exists to
+      # prevent. Safe degrade: page a tree/listing of it instead, the same
+      # shape SG-04's own goal file already documents as its no-viewer
+      # fallback.
+      record_open "$raw"
+      if command -v eza >/dev/null 2>&1; then
+        render_command_in_pager eza --tree "$RESOLVED_TARGET"
+      else
+        render_command_in_pager ls -la "$RESOLVED_TARGET"
+      fi
+      exit $?
+      ;;
+    *)
+      target="$RESOLVED_TARGET"
+      CLIP_LINE="$RESOLVED_LINE"
+      ;;
   esac
-  target="$RESOLVED_TARGET"
-  CLIP_LINE="$RESOLVED_LINE"
 else
   # Only a path-shaped token reaches here (github/url always resolve one way
   # or another via resolve_any_token): fall back to the interactive

--- a/tests/dispatch-modes.bats
+++ b/tests/dispatch-modes.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# Script-level tests for the RESOLVED_MODE=command / RESOLVED_MODE=viewer
+# dispatch arms in preview-pane.sh and open-in-viewer.sh (added after the
+# kit:advisor CRITICAL on PR #7: a mode-unaware pane script would either
+# reject a valid command-mode result on its empty RESOLVED_TARGET, or fall
+# through to `exec less <directory>` for a viewer-mode result). No real
+# handler emits these modes yet (vcs.sh/dir.sh are stubs), so this drops a
+# TEMPORARY test-only handler file into the real scripts/handlers/ directory
+# for the duration of each test (glob-discovered by lib.sh at source time,
+# same as any real handler) and removes it in teardown , the only way to
+# exercise the full pane-script dispatch as a fresh process, same style as
+# dispatch.bats.
+
+setup() {
+  PREVIEW="$BATS_TEST_DIRNAME/../scripts/preview-pane.sh"
+  VIEWER="$BATS_TEST_DIRNAME/../scripts/open-in-viewer.sh"
+  HANDLERS_DIR="$BATS_TEST_DIRNAME/../scripts/handlers"
+  TEST_HANDLER="$HANDLERS_DIR/zzz-test-only.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/myrepo/somedir"
+  git -C "$FIX/myrepo" init -q -b main
+  printf 'line1\n' > "$FIX/myrepo/f.md"
+  git -C "$FIX/myrepo" add -A
+  git -C "$FIX/myrepo" -c user.email=t@t -c user.name=t commit -qm fix
+
+  MARKER="$(mktemp)"
+
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\n' > "$STUB/less"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/herdr"
+  chmod +x "$STUB/less" "$STUB/herdr"
+
+  cd "$FIX/myrepo"
+  export PATH="$STUB:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+  bat() { return 127; }
+  export -f bat 2>/dev/null || true
+
+  # a test-only handler kind, claimed via QUICKLOOK_TOKEN token names below.
+  # match_zzz_test_only intentionally does NOT get added to HANDLER_KINDS
+  # (that array is a fixed literal in lib.sh, not test-mutable from outside
+  # the sourcing process) - instead it's globbed in automatically by the
+  # `for _herdr_handler in "$LIB_DIR"/handlers/*.sh` loop, same as any real
+  # handler file, and it self-registers into HANDLER_KINDS at source time.
+  cat > "$TEST_HANDLER" <<HANDLER
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+match_zzz_test_only() {
+  case "\$1" in
+    TEST_CMD_TOKEN|TEST_CMD_EMPTY_TOKEN|TEST_VIEWER_TOKEN) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+handle_zzz_test_only() {
+  case "\$1" in
+    TEST_CMD_TOKEN)
+      RESOLVED_MODE="command"
+      RESOLVED_CMD=(bash -c 'printf "%s\n" "\$@" > "$MARKER"' -- "one" "two words" "three")
+      return 0
+      ;;
+    TEST_CMD_EMPTY_TOKEN)
+      RESOLVED_MODE="command"
+      RESOLVED_CMD=()
+      return 0
+      ;;
+    TEST_VIEWER_TOKEN)
+      RESOLVED_MODE="viewer"
+      RESOLVED_TARGET="$FIX/myrepo/somedir"
+      return 0
+      ;;
+  esac
+  return 1
+}
+# HANDLER_KINDS is a literal array already set by the time this file is
+# sourced (lib.sh builds it, THEN globs scripts/handlers/*.sh); prepend so
+# this test kind gets first look, same mechanism registry.bats already
+# exercises ("a higher-priority handler always wins").
+HANDLER_KINDS=(zzz_test_only "\${HANDLER_KINDS[@]}")
+HANDLER
+}
+
+teardown() {
+  cd /
+  rm -f "$TEST_HANDLER"
+  rm -f "$MARKER"
+  rm -rf "$FIX" "$STUB"
+}
+
+# ---- preview-pane.sh: command mode ----
+
+@test "preview-pane command mode: runs the argv, each element stays one token" {
+  export QUICKLOOK_TOKEN="TEST_CMD_TOKEN"
+  run bash "$PREVIEW"
+  [ "$status" -eq 0 ]
+  # the argv ran (marker file was written) with each element intact,
+  # including the one with an embedded space, proving no re-splitting.
+  run cat "$MARKER"
+  [ "${lines[0]}" = "one" ]
+  [ "${lines[1]}" = "two words" ]
+  [ "${lines[2]}" = "three" ]
+}
+
+@test "preview-pane command mode: output is paged (less invoked, not exec'd on a path)" {
+  export QUICKLOOK_TOKEN="TEST_CMD_TOKEN"
+  run bash "$PREVIEW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  # command-mode output is piped into less's stdin, never appended as a
+  # trailing positional arg (that would mean the OLD file-render path ran).
+  [[ "$output" != *"LESS_ARGS:"*"$FIX"* ]]
+}
+
+@test "preview-pane command mode: empty RESOLVED_CMD does not hit the not-found guard as a crash, falls through cleanly" {
+  export QUICKLOOK_TOKEN="TEST_CMD_EMPTY_TOKEN"
+  run bash "$PREVIEW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not a file I can find"* ]]
+}
+
+# ---- preview-pane.sh: viewer mode ----
+
+@test "preview-pane viewer mode: never reaches exec less on the directory" {
+  export QUICKLOOK_TOKEN="TEST_VIEWER_TOKEN"
+  run bash "$PREVIEW"
+  [ "$status" -eq 0 ]
+  # less WAS invoked (the safe tree-listing degrade pages through it), but
+  # never with the directory as a trailing file argument - that would be
+  # the exact `exec less <directory>` bug this arm exists to prevent.
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" != *"LESS_ARGS:"*"somedir"* ]]
+}
+
+# ---- open-in-viewer.sh: command / viewer modes never touch the file-viewer
+# send-keys path (which types a token in as if it were a repo-relative FILE)
+
+@test "open-in-viewer command mode: hands off to the preview overlay, does not send-keys" {
+  cat > "$STUB/jq" <<'JQ'
+#!/usr/bin/env bash
+exit 1
+JQ
+  chmod +x "$STUB/jq"
+  export QUICKLOOK_TOKEN="TEST_CMD_TOKEN"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  # open-preview.sh (the degrade target) builds a `plugin pane open` herdr
+  # command; the stub herdr just exits 0, so all we can assert from here is
+  # that the file-viewer's own send-keys sequence (which would print
+  # nothing distinctive via the herdr stub, but DOES require jq to parse
+  # `pane current`/`pane list` first) never got that far - confirmed by jq
+  # never having been asked to parse a `pane list` Files-pane query.
+  ! grep -q "pane_id" <<<"$output"
+}
+
+@test "open-in-viewer viewer mode: notifies and stops, does not send-keys" {
+  cat > "$STUB/jq" <<'JQ'
+#!/usr/bin/env bash
+printf '{}'
+JQ
+  chmod +x "$STUB/jq"
+  export QUICKLOOK_TOKEN="TEST_VIEWER_TOKEN"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+}

--- a/tests/registry.bats
+++ b/tests/registry.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# Tests for the handler-registry dispatch (scripts/lib.sh resolve_any_token +
+# scripts/handlers/*.sh). Sources lib.sh directly, same fixture shape as
+# quicklook.bats: a temp git repo with one worktree and a roots dir.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  HANDLERS_DIR="$BATS_TEST_DIRNAME/../scripts/handlers"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/roots/myrepo/docs" "$FIX/repo/sub"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello\n' > "$FIX/repo/sub/inrepo.md"
+  printf 'root file\n' > "$FIX/repo/top.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+
+  cd "$FIX/repo"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# ---- each moved kind still resolves as before ----
+# NOTE: called directly (not via `run`) because resolve_any_token communicates
+# through global RESOLVED_* vars, which `run`'s subshell would not leak back -
+# same pattern quicklook.bats already uses for map_github_url/resolve_github.
+
+@test "registry: github blob URL resolves locally as mode=file" {
+  # "repo" is the current repo's directory name, matching resolve_github's
+  # gname check.
+  resolve_any_token "https://github.com/o/repo/blob/main/sub/inrepo.md#L1"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/sub/inrepo.md" ]
+  [ "$RESOLVED_LINE" = "1" ]
+}
+
+@test "registry: a plain relative path resolves as mode=file" {
+  resolve_any_token "top.md:3"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/top.md" ]
+  [ "$RESOLVED_LINE" = "3" ]
+}
+
+@test "registry: a generic https URL resolves as mode=browser" {
+  resolve_any_token "https://example.com/a/b"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://example.com/a/b" ]
+}
+
+@test "registry: an unresolvable github URL falls back to mode=browser" {
+  resolve_any_token "https://github.com/o/ghostrepo/blob/main/nope.md"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://github.com/o/ghostrepo/blob/main/nope.md" ]
+}
+
+# ---- an unmatched token falls through ----
+
+@test "registry: an unresolvable path token returns rc 1, no target set" {
+  rc=0
+  resolve_any_token "no/such/file.md" || rc=$?
+  [ "$rc" -eq 1 ]
+  [ -z "$RESOLVED_TARGET" ]
+  [ -z "$RESOLVED_MODE" ]
+}
+
+# ---- a registered handler wins / first-match ordering ----
+
+@test "registry: github is checked before url (github wins for a github-shaped URL)" {
+  # a locally-resolvable github URL structurally also matches url.sh's http(s)
+  # pattern; if url.sh won instead of github.sh, mode would be browser with
+  # the raw URL as target, not file with a local path.
+  resolve_any_token "https://github.com/o/repo/blob/main/top.md"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [[ "$RESOLVED_TARGET" == "$FIX/repo/top.md" ]]
+}
+
+@test "registry: a higher-priority handler always wins over a later one, any token" {
+  # register a synthetic catch-all kind at the FRONT of HANDLER_KINDS and
+  # confirm it claims a token that would otherwise resolve via github/path -
+  # proving position, not content, decides ordering.
+  match_zzz() { return 0; }
+  handle_zzz() {
+    RESOLVED_TARGET="zzz-target"
+    RESOLVED_LINE=""
+    RESOLVED_MODE="zzz-mode"
+    return 0
+  }
+  HANDLER_KINDS=(zzz "${HANDLER_KINDS[@]}")
+
+  resolve_any_token "https://github.com/o/repo/blob/main/top.md"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "zzz-mode" ]
+  [ "$RESOLVED_TARGET" = "zzz-target" ]
+}
+
+# ---- contract-compliance: every handler exports match_<kind> + handle_<kind> ----
+
+@test "registry: every scripts/handlers/*.sh exports match_<kind> and handle_<kind>" {
+  local f kind
+  for f in "$HANDLERS_DIR"/*.sh; do
+    kind="$(basename "$f" .sh)"
+    kind="${kind//-/_}"
+    declare -F "match_$kind" >/dev/null || {
+      echo "missing match_$kind in $f" >&2
+      return 1
+    }
+    declare -F "handle_$kind" >/dev/null || {
+      echo "missing handle_$kind in $f" >&2
+      return 1
+    }
+  done
+}
+
+@test "registry: HANDLER_KINDS has path last (the catch-all must not shadow later kinds)" {
+  local last="${HANDLER_KINDS[${#HANDLER_KINDS[@]}-1]}"
+  [ "$last" = "path" ]
+}


### PR DESCRIPTION
Refactor: extract the duplicated token dispatch into one `lib.sh` entry + a handler registry
(`scripts/handlers/`), so a new token-kind is one file. No behavior change; 40 existing tests
pass. Run-table below. Foundation for the v0.3 token-kind features.

**Update:** a `kit:advisor` CRITICAL on the first version of this diff found that only
`file`/`browser` had a dispatch arm in the pane scripts, even though the contract promised all
four `RESOLVED_MODE` values. Fixed: both pane scripts now have `command` and `viewer` arms too
(details below). Run-table reflects the fixed version.

## Run-table

| Command | Exit | Result |
|---|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | 0 | clean |
| `bats tests/` | 0 | `1..55`, 55 ok (40 pre-existing unchanged + 9 registry + 6 dispatch-modes) |

Full bats output:

```
1..55
ok 1 preview-pane command mode: runs the argv, each element stays one token
ok 2 preview-pane command mode: output is paged (less invoked, not exec'd on a path)
ok 3 preview-pane command mode: empty RESOLVED_CMD does not hit the not-found guard as a crash, falls through cleanly
ok 4 preview-pane viewer mode: never reaches exec less on the directory
ok 5 open-in-viewer command mode: hands off to the preview overlay, does not send-keys
ok 6 open-in-viewer viewer mode: notifies and stops, does not send-keys
ok 7 dispatch: github blob URL opens the local file at the line
ok 8 dispatch: a plain relative path token opens locally
ok 9 dispatch: a github URL with no matching local checkout does not open a file
ok 10 open-preview: no arg emits NO --env flag
ok 11 open-preview: a token arg is forwarded verbatim as QUICKLOOK_TOKEN
ok 12 open-preview: never forwards the literal 'plugin' (the set-- clobber bug)
ok 13 parse_token: plain path
ok 14 parse_token: path:line splits
ok 15 parse_token: trailing colon stays in path
ok 16 parse_token: non-numeric suffix stays in path
ok 17 pick_token: env beats arg
ok 18 pick_token: arg beats clipboard
ok 19 pick_token: empty env falls through to arg
ok 20 pick_token: all empty yields empty
ok 21 resolve: absolute path
ok 22 resolve: cwd-relative path returns absolute
ok 23 resolve: cross-worktree finds worktree-only file
ok 24 resolve: QUICKLOOK_ROOTS entry
ok 25 resolve: miss returns rc 1
ok 26 classify: blob URL is github
ok 27 classify: /raw/ URL is github
ok 28 classify: raw.githubusercontent is github
ok 29 classify: generic https is url
ok 30 classify: plain path is path
ok 31 map: blob URL extracts repo, rest, line
ok 32 map: line range keeps start line
ok 33 map: /raw/ shape extraction
ok 34 map: raw.githubusercontent shape
ok 35 map: query string is stripped before splitting
ok 36 map: query plus fragment still yields the line
ok 37 map: literal + in path stays a plus
ok 38 map: backslash escapes are not interpreted
ok 39 map: non-github URL fails
ok 40 resolve_github: repo-name match in current repo
ok 41 resolve_github: ref containing slash resolves via successive split
ok 42 resolve_github: roots/<repo>/<path> match
ok 43 resolve_github: unresolvable returns rc 1 (browser fallback)
ok 44 resolve_github: absolute smuggle (double slash) is refused
ok 45 resolve_github: dotdot traversal is refused
ok 46 unsafe_relpath: classifies absolute and traversal, allows plain
ok 47 registry: github blob URL resolves locally as mode=file
ok 48 registry: a plain relative path resolves as mode=file
ok 49 registry: a generic https URL resolves as mode=browser
ok 50 registry: an unresolvable github URL falls back to mode=browser
ok 51 registry: an unresolvable path token returns rc 1, no target set
ok 52 registry: github is checked before url (github wins for a github-shaped URL)
ok 53 registry: a higher-priority handler always wins over a later one, any token
ok 54 registry: every scripts/handlers/*.sh exports match_<kind> and handle_<kind>
ok 55 registry: HANDLER_KINDS has path last (the catch-all must not shadow later kinds)
```

## Done= check

`grep -n classify_token scripts/preview-pane.sh scripts/open-in-viewer.sh` -> no match
(exit 1): neither pane script has an inline `classify_token` case block anymore.

## Registry contract

`scripts/lib.sh` gains `resolve_any_token <raw>` (documented in a comment block at its
top) plus `HANDLER_KINDS=(github url vcs dir path)`. Each kind is
`scripts/handlers/<kind>.sh` exporting `match_<kind>` (owns this token's shape?) +
`handle_<kind>` (resolves; sets `RESOLVED_TARGET`/`RESOLVED_LINE`/`RESOLVED_MODE`, and
`RESOLVED_CMD` for `command` mode). `path` is the catch-all and stays last so a later
kind's real tokens aren't shadowed. `vcs.sh`/`dir.sh` land now as declared stubs so
SG-02/SG-04 only edit one already-registered file each. `bare-name.sh` is a documented
exception (opt-in, not auto-dispatched) that keeps the interactive fuzzy-search fallback
exclusive to `preview-pane.sh`, matching pre-refactor behavior.

## What the command/viewer arms do (added in the fix commit)

Both `preview-pane.sh` and `open-in-viewer.sh` now dispatch all four `RESOLVED_MODE`
values, ordered BEFORE the empty-target guard (a real `command`-mode result legitimately
leaves `RESOLVED_TARGET` empty; it carries `RESOLVED_CMD` instead):

- **`command`**: `preview-pane.sh` runs `RESOLVED_CMD` (a bash array, never a
  string-rebuilt argv) through the new `lib.sh` helper `render_command_in_pager`, which
  pages the command's combined stdout/stderr through `less -R`. `open-in-viewer.sh` has
  no pager of its own, so it re-invokes the same raw token through
  `scripts/open-preview.sh`, letting the preview overlay do the real rendering, safe
  specifically because a command-mode token (SHA / `#123` / PR URL) doesn't depend on a
  filesystem test, so `resolve_any_token` reproduces the identical `RESOLVED_CMD` there
  deterministically. An empty `RESOLVED_CMD` (a handler bug) falls through to the normal
  "not found" path in both scripts.
- **`viewer`**: `RESOLVED_TARGET` is a directory. No handler drives the real
  file-viewer socket protocol yet (that's SG-04/`dir.sh`'s own feature). `preview-pane.sh`
  degrades safely by paging an `eza --tree` (fallback `ls -la`) listing of the directory
  through the same pager helper, the exact fallback shape SG-04's own goal file already
  documents for when the viewer plugin is absent. `open-in-viewer.sh` cannot even do that
  (no pager) and cannot safely forward the token the way `command` mode does (a
  directory fails `path.sh`'s `resolve()` `-f` test and would silently read as "not
  found"), so it notifies the user and stops. Neither script ever falls through to the
  file-render / file-viewer-send-keys path on a directory target, which is the concrete
  bug this fix closes.

No handler emits `command`/`viewer` today (`vcs.sh`/`dir.sh` are still stubs); the arms
are exercised end-to-end via a temporary test-only handler in `tests/dispatch-modes.bats`
(dropped into `scripts/handlers/` for the duration of each test, removed in teardown).
