### PR TITLE
feat: map GitLab and Bitbucket blob URLs to the local checkout

### DIFF
--- a/scripts/handlers/github.sh
+++ b/scripts/handlers/github.sh
@@ -1,17 +1,84 @@
 # shellcheck shell=bash
-# github.sh: github.com/.../blob/... , .../raw/... and raw.githubusercontent.com
-# URLs. Wired to classify_token / map_github_url / resolve_github in lib.sh.
-# SG-03 (more-hosts) EXTENDS this exact file for GitLab/Bitbucket blob URLs;
-# keep this filename, see HANDOFF.md.
+# github.sh: github.com/.../blob/... , .../raw/... , raw.githubusercontent.com,
+# gitlab.com/.../-/blob/... and bitbucket.org/.../src/... blob URLs. Registry
+# entry stays "github" (see HANDOFF.md , SG-01 pinned this filename for the
+# SG-03 host extension); the three hosts are sibling shapes dispatched inside
+# match_github/handle_github, sharing lib.sh's resolve_github resolver and
+# unsafe_relpath traversal guard unchanged.
 # shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (resolve_any_token's caller)
 
 match_github() {
-  [ "$(classify_token "$1")" = "github" ]
+  local raw="$1"
+  [ "$(classify_token "$raw")" = "github" ] && return 0
+  case "$raw" in
+    https://gitlab.com/*/-/blob/*) return 0 ;;
+    https://bitbucket.org/*/src/*) return 0 ;;
+  esac
+  return 1
+}
+
+# map_gitlab_url <url>: extract GH_REPO, GH_REST (ref/path, decoded), GH_LINE.
+# Accepted shape: gitlab.com/<o>/<r>/-/blob/<ref>/<path>[#L<n>].
+map_gitlab_url() {
+  GH_REPO=""
+  GH_REST=""
+  GH_LINE=""
+  local u="$1" frag="" rest=""
+  case "$u" in
+    *'#L'*)
+      frag="${u##*#L}"
+      u="${u%%#*}"
+      ;;
+  esac
+  u="${u%%\?*}" # drop any ?query before splitting
+  if [[ "$frag" =~ ^([0-9]+) ]]; then GH_LINE="${BASH_REMATCH[1]}"; fi
+  case "$u" in
+    https://gitlab.com/*/-/blob/*)
+      rest="${u#https://gitlab.com/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/-/blob/}"
+      ;;
+    *) return 1 ;;
+  esac
+  GH_REST="$(urldecode "$GH_REST")"
+  [ -n "$GH_REPO" ] && [ -n "$GH_REST" ]
+}
+
+# map_bitbucket_url <url>: extract GH_REPO, GH_REST (ref/path, decoded), GH_LINE.
+# Accepted shape: bitbucket.org/<o>/<r>/src/<ref>/<path>[#lines-<n>].
+map_bitbucket_url() {
+  GH_REPO=""
+  GH_REST=""
+  GH_LINE=""
+  local u="$1" frag="" rest=""
+  case "$u" in
+    *'#lines-'*)
+      frag="${u##*#lines-}"
+      u="${u%%#*}"
+      ;;
+  esac
+  u="${u%%\?*}" # drop any ?query before splitting
+  if [[ "$frag" =~ ^([0-9]+) ]]; then GH_LINE="${BASH_REMATCH[1]}"; fi
+  case "$u" in
+    https://bitbucket.org/*/src/*)
+      rest="${u#https://bitbucket.org/}"
+      GH_REPO="$(printf '%s' "$rest" | cut -d/ -f2)"
+      GH_REST="${rest#*/*/src/}"
+      ;;
+    *) return 1 ;;
+  esac
+  GH_REST="$(urldecode "$GH_REST")"
+  [ -n "$GH_REPO" ] && [ -n "$GH_REST" ]
 }
 
 handle_github() {
-  local raw="$1" t
-  if map_github_url "$raw" && t="$(resolve_github "$GH_REPO" "$GH_REST")"; then
+  local raw="$1" t mapper
+  case "$raw" in
+    https://gitlab.com/*) mapper=map_gitlab_url ;;
+    https://bitbucket.org/*) mapper=map_bitbucket_url ;;
+    *) mapper=map_github_url ;;
+  esac
+  if "$mapper" "$raw" && t="$(resolve_github "$GH_REPO" "$GH_REST")"; then
     RESOLVED_TARGET="$t"
     RESOLVED_LINE="$GH_LINE"
     RESOLVED_MODE="file"

--- a/tests/handlers-hosts.bats
+++ b/tests/handlers-hosts.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# Tests for the GitLab + Bitbucket blob-URL host shapes added to
+# scripts/handlers/github.sh (SG-03, more-hosts). Same fixture shape as
+# registry.bats: a temp git repo, exercised through resolve_any_token so the
+# whole registry path (match_github -> handle_github -> shared resolve_github
+# + unsafe_relpath) is proven end to end, not just the per-host mapper.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/repo/sub"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello\n' > "$FIX/repo/sub/inrepo.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+
+  cd "$FIX/repo"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# ---- match_github: new host shapes accepted, unrelated hosts fall through ----
+
+@test "match_github: gitlab blob URL is accepted" {
+  match_github "https://gitlab.com/o/repo/-/blob/main/sub/inrepo.md#L1"
+}
+
+@test "match_github: bitbucket blob URL is accepted" {
+  match_github "https://bitbucket.org/o/repo/src/main/sub/inrepo.md#lines-1"
+}
+
+@test "match_github: a non-matching host falls through" {
+  ! match_github "https://example.com/o/r/blob/main/a.md"
+}
+
+@test "match_github: a gitlab non-blob URL (e.g. repo root) falls through" {
+  ! match_github "https://gitlab.com/o/repo"
+}
+
+@test "match_github: a bitbucket non-src URL (e.g. repo root) falls through" {
+  ! match_github "https://bitbucket.org/o/repo"
+}
+
+# ---- map_gitlab_url ----
+
+@test "map_gitlab_url: extracts repo, rest, line" {
+  map_gitlab_url "https://gitlab.com/own/proj/-/blob/main/src/a.go#L42"
+  [ "$GH_REPO" = "proj" ]
+  [ "$GH_REST" = "main/src/a.go" ]
+  [ "$GH_LINE" = "42" ]
+}
+
+@test "map_gitlab_url: no line anchor leaves GH_LINE empty" {
+  map_gitlab_url "https://gitlab.com/o/proj/-/blob/main/docs/x.md"
+  [ "$GH_REPO" = "proj" ]
+  [ "$GH_REST" = "main/docs/x.md" ]
+  [ "$GH_LINE" = "" ]
+}
+
+@test "map_gitlab_url: non-gitlab URL fails" {
+  run map_gitlab_url "https://example.com/o/r/-/blob/main/a.md"
+  [ "$status" -ne 0 ]
+}
+
+# ---- map_bitbucket_url ----
+
+@test "map_bitbucket_url: extracts repo, rest, line" {
+  map_bitbucket_url "https://bitbucket.org/own/proj/src/main/src/a.go#lines-42"
+  [ "$GH_REPO" = "proj" ]
+  [ "$GH_REST" = "main/src/a.go" ]
+  [ "$GH_LINE" = "42" ]
+}
+
+@test "map_bitbucket_url: no line anchor leaves GH_LINE empty" {
+  map_bitbucket_url "https://bitbucket.org/o/proj/src/main/docs/x.md"
+  [ "$GH_REPO" = "proj" ]
+  [ "$GH_REST" = "main/docs/x.md" ]
+  [ "$GH_LINE" = "" ]
+}
+
+@test "map_bitbucket_url: non-bitbucket URL fails" {
+  run map_bitbucket_url "https://example.com/o/r/src/main/a.md"
+  [ "$status" -ne 0 ]
+}
+
+# ---- end-to-end resolution via resolve_any_token ----
+
+@test "registry: gitlab blob URL resolves locally as mode=file" {
+  resolve_any_token "https://gitlab.com/o/repo/-/blob/main/sub/inrepo.md#L1"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/sub/inrepo.md" ]
+  [ "$RESOLVED_LINE" = "1" ]
+}
+
+@test "registry: bitbucket blob URL resolves locally as mode=file" {
+  resolve_any_token "https://bitbucket.org/o/repo/src/main/sub/inrepo.md#lines-1"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/sub/inrepo.md" ]
+  [ "$RESOLVED_LINE" = "1" ]
+}
+
+@test "registry: unresolvable gitlab URL falls back to mode=browser" {
+  resolve_any_token "https://gitlab.com/o/ghostrepo/-/blob/main/nope.md"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://gitlab.com/o/ghostrepo/-/blob/main/nope.md" ]
+}
+
+@test "registry: unresolvable bitbucket URL falls back to mode=browser" {
+  resolve_any_token "https://bitbucket.org/o/ghostrepo/src/main/nope.md"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://bitbucket.org/o/ghostrepo/src/main/nope.md" ]
+}
+
+@test "registry: gitlab URL with a nested (multi-segment) ref resolves via successive split" {
+  resolve_any_token "https://gitlab.com/o/repo/-/blob/feat/nested-ref/sub/inrepo.md#L1"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/sub/inrepo.md" ]
+}
+
+# ---- traversal / absolute-smuggle negative controls, re-asserted per host ----
+# Same smuggle shapes github.sh's own tests already close for github.com
+# (registry.bats / quicklook.bats), re-run through the full GitLab and
+# Bitbucket URL parse -> resolve_github -> unsafe_relpath path end to end.
+
+@test "gitlab: absolute-slash smuggle (//etc/passwd) is refused, falls back to browser" {
+  resolve_any_token "https://gitlab.com/o/repo/-/blob/main//etc/passwd"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+}
+
+@test "gitlab: dotdot traversal smuggle (../../etc/passwd) is refused, falls back to browser" {
+  resolve_any_token "https://gitlab.com/o/repo/-/blob/main/../../../etc/passwd"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+}
+
+@test "bitbucket: absolute-slash smuggle (//etc/passwd) is refused, falls back to browser" {
+  resolve_any_token "https://bitbucket.org/o/repo/src/main//etc/passwd"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+}
+
+@test "bitbucket: dotdot traversal smuggle (../../etc/passwd) is refused, falls back to browser" {
+  resolve_any_token "https://bitbucket.org/o/repo/src/main/../../../etc/passwd"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+}


### PR DESCRIPTION
Extends the URL-to-local-file mapping to GitLab and Bitbucket blob URLs, reusing the shared
resolver + traversal guard (smuggle negative controls re-asserted for both hosts).

## Run-table

| Check | Command | Result |
|---|---|---|
| New tests | `bats tests/handlers-hosts.bats` | 20/20 pass |
| Full suite (no regression) | `bats tests/*.bats` | 80/80 pass |
| Lint | `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean |

## Negative controls (re-asserted per host)

Traversal/absolute-smuggle guard from the GitHub mapper (`unsafe_relpath` in `scripts/lib.sh`,
unchanged) re-run end to end through `resolve_any_token` for both new host shapes:

- `gitlab: absolute-slash smuggle (//etc/passwd) is refused, falls back to browser`, pass
- `gitlab: dotdot traversal smuggle (../../etc/passwd) is refused, falls back to browser`, pass
- `bitbucket: absolute-slash smuggle (//etc/passwd) is refused, falls back to browser`, pass
- `bitbucket: dotdot traversal smuggle (../../etc/passwd) is refused, falls back to browser`, pass

## COVERAGE-DELTA

| Metric | Before (SG-01 merge) | After |
|---|---|---|
| bats test files | 6 | 7 (+`tests/handlers-hosts.bats`) |
| bats test cases | 60 | 80 (+20) |
| Host URL shapes mapped locally | 1 (github.com blob/raw + raw.githubusercontent.com) | 3 (+ gitlab.com `-/blob/`, bitbucket.org `src/`) |
| Traversal/absolute-smuggle negative controls | 2 (github.com only, in `registry.bats`/`quicklook.bats`) | 4 (+2, gitlab + bitbucket, re-asserted end-to-end via `resolve_any_token`) |
| `scripts/handlers/*.sh` line-anchor syntaxes handled | 1 (`#L<n>`) | 2 (+ `#lines-<n>` for Bitbucket) |

## Design

`scripts/handlers/github.sh` stays the one file (registry entry stays `github`, per
`HANDOFF.md`). `match_github` now also accepts `gitlab.com/*/-/blob/*` and
`bitbucket.org/*/src/*` shapes alongside the existing `classify_token` check.
`handle_github` picks the matching per-host mapper (`map_github_url` / `map_gitlab_url` /
`map_bitbucket_url`, one parser per host) by URL prefix, then hands `GH_REPO`/`GH_REST` to
the SAME `resolve_github` in `scripts/lib.sh` every host already used, that function's
successive-split resolve chain (current repo by name -> `resolve()` -> `QUICKLOOK_ROOTS/<repo>`)
and its `unsafe_relpath` traversal guard are untouched, so every host runs through one shared
resolver and one shared guard, per the goal's quality bar. `scripts/lib.sh` and the two pane
scripts are untouched.
