### PR TITLE
feat: vcs tokens open git show / gh pr view in the popup

### DIFF
--- a/scripts/handlers/vcs.sh
+++ b/scripts/handlers/vcs.sh
@@ -1,11 +1,77 @@
 # shellcheck shell=bash
-# vcs.sh: STUB for SG-02 (vcs-tokens). Reserved shape: a bare commit SHA ->
-# `git show`, a `#123`/PR reference -> `gh pr view`, render-mode `command`
-# (see the RESOLVED_CMD contract note at the top of lib.sh - untrusted
-# clipboard input must stay a real argv, never a rebuilt string). Registered
-# in HANDLER_KINDS now, ahead of path.sh's catch-all, so SG-02 only needs to
-# edit this file: a real match_vcs + handle_vcs body, no lib.sh or
-# pane-script changes required.
+# vcs.sh: a bare commit SHA -> `git show`, a `#123` ref or a GitHub PR URL ->
+# `gh pr view`, render-mode `command`. Untrusted clipboard input reaches an
+# external command here, so every accepted shape is validated by an anchored
+# regex (^...$, no partial match) and handed to git/gh as ONE argv element in
+# a bash array, never rebuilt from a flattened string, never word-split.
+# shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (resolve_any_token's caller)
 
-match_vcs() { return 1; }
-handle_vcs() { return 1; }
+# A commit SHA is hex-only (0-9a-f), 7-40 chars - never contains a dash, so
+# it can never itself be mistaken for a flag.
+_VCS_SHA_RE='^[0-9a-f]{7,40}$'
+# "#123": a bare PR/issue-style reference. The captured number is digits
+# only (see handle_vcs), so it can never start with '-' either.
+_VCS_HASHREF_RE='^#[0-9]+$'
+# A GitHub PR URL, anchored end-to-end (owner/repo char set matches GitHub's
+# own username/repo rules; number is digits only; optional trailing slash).
+# Deliberately narrow: this is NOT the general blob/raw shape github.sh
+# already owns, and it must not accidentally swallow a blob URL that happens
+# to contain "/pull/" as a path segment (blob URLs never have this exact
+# .../pull/<digits> tail).
+_VCS_PR_URL_RE='^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+/?$'
+
+match_vcs() {
+  [ -n "$1" ] || return 1
+  [[ "$1" =~ $_VCS_SHA_RE ]] && return 0
+  [[ "$1" =~ $_VCS_HASHREF_RE ]] && return 0
+  [[ "$1" =~ $_VCS_PR_URL_RE ]] && return 0
+  return 1
+}
+
+# handle_vcs <raw>: dispatches purely on the token's own prefix, with no
+# re-validation - it trusts resolve_any_token already gated the shape via
+# match_vcs. Every branch below builds RESOLVED_CMD by quoting "$raw" (or a
+# value derived from it) as a single bash-array element, so the argv-safety
+# holds independent of the regex above (see tests/handlers-vcs.bats' "argv
+# shape control", which calls this function directly, bypassing match_vcs,
+# to prove the quoting itself - not the input filter - is what keeps a
+# space-containing value as one arg).
+handle_vcs() {
+  local raw="$1" n
+  case "$raw" in
+    '#'*)
+      n="${raw#\#}"
+      RESOLVED_TARGET=""
+      RESOLVED_LINE=""
+      RESOLVED_MODE="command"
+      RESOLVED_CMD=(gh pr view "$n")
+      return 0
+      ;;
+    https://github.com/*)
+      # gh pr view accepts a full PR URL directly; no need to pick apart
+      # owner/repo/number ourselves.
+      RESOLVED_TARGET=""
+      RESOLVED_LINE=""
+      RESOLVED_MODE="command"
+      RESOLVED_CMD=(gh pr view "$raw")
+      return 0
+      ;;
+    *)
+      # A commit SHA. `--end-of-options` (not a trailing `--`) is
+      # deliberate: `git show -- "$sha"` looks like the obvious
+      # flag-injection guard, but git's `--` also means "everything after
+      # this is a pathspec, not a revision" - for a SHA that doesn't
+      # resolve to a real object, that silently falls back to rendering
+      # HEAD's commit (wrong data, not an error) instead of the "not found"
+      # degrade this sub-goal's quality bar requires. `--end-of-options`
+      # gives the same "this can't be interpreted as a flag" protection
+      # without that pathspec reinterpretation - verified against both a
+      # real and a bogus-but-hex-shaped SHA (see PR body run-table).
+      RESOLVED_TARGET=""
+      RESOLVED_LINE=""
+      RESOLVED_MODE="command"
+      RESOLVED_CMD=(git show --end-of-options "$raw")
+      return 0
+      ;;
+  esac
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -257,9 +257,15 @@ resolve() {
 
 # Registry order (first match wins): specific-shape kinds before the
 # catch-all. `path` MUST stay last (see the contract comment at the top of
-# this file). vcs/dir are registered now as stubs (SG-02/SG-04 fill in their
-# match_/handle_ bodies later, one file each, no registry-line edit needed).
-HANDLER_KINDS=(github url vcs dir path)
+# this file). `vcs` sits BEFORE `url` (not after, as originally stubbed):
+# one of vcs's shapes is a GitHub PR URL (https://...), which structurally
+# also matches url.sh's generic http(s) predicate via classify_token; if url
+# stayed first it would claim every PR URL as a generic browser-mode open
+# before vcs ever got a look. vcs's other two shapes (bare SHA, `#123`)
+# don't overlap anything, so this reorder is a no-op for them. `dir` is
+# registered now as a stub (SG-04 fills in its match_/handle_ body later,
+# one file, no registry-line edit needed).
+HANDLER_KINDS=(github vcs url dir path)
 
 # LIB_DIR: this file's own directory (== scripts/), kept around (not
 # unset) so render_command_in_pager below can find ../lesskey the same way

--- a/tests/handlers-vcs.bats
+++ b/tests/handlers-vcs.bats
@@ -1,0 +1,288 @@
+#!/usr/bin/env bats
+# Tests for scripts/handlers/vcs.sh (SG-02, vcs-tokens): a bare commit SHA ->
+# `git show`, a `#123` ref or a GitHub PR URL -> `gh pr view`, mode=command.
+# Same style as registry.bats: source lib.sh directly and call
+# match_vcs/handle_vcs (they communicate through RESOLVED_* globals), not
+# `run` in a subshell, except where a test deliberately executes the built
+# argv for real to prove the security/correctness behavior end to end.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  git -C "$FIX" init -q -b main
+  printf 'hello\n' > "$FIX/f.md"
+  git -C "$FIX" add -A
+  git -C "$FIX" -c user.email=t@t -c user.name=t commit -qm 'fixture commit'
+  REAL_SHA="$(git -C "$FIX" log --format=%H -1)"
+  REAL_SUBJECT="$(git -C "$FIX" log --format=%s -1)"
+  cd "$FIX"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# ---- match_vcs: accepted shapes ----
+
+@test "match_vcs: accepts a 7-char hex SHA (lower bound)" {
+  match_vcs "abc1234"
+}
+
+@test "match_vcs: accepts a 40-char hex SHA (upper bound, full SHA)" {
+  match_vcs "0123456789abcdef0123456789abcdef01234567"
+}
+
+@test "match_vcs: accepts a #123 hashref" {
+  match_vcs "#123"
+}
+
+@test "match_vcs: accepts a GitHub PR URL" {
+  match_vcs "https://github.com/dwarvesf/herdr-quicklook/pull/42"
+}
+
+@test "match_vcs: accepts a GitHub PR URL with a trailing slash" {
+  match_vcs "https://github.com/dwarvesf/herdr-quicklook/pull/42/"
+}
+
+# ---- match_vcs: named negative controls ----
+# Every one of these must be REJECTED (match_vcs returns 1) so the token
+# falls through to the next handler instead of ever reaching handle_vcs.
+
+@test "negative control: metacharacter (semicolon + shell command)" {
+  run match_vcs "abc1234; rm -rf /"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: command substitution \$(...)" {
+  run match_vcs '$(whoami)'
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: backtick command substitution" {
+  run match_vcs '`whoami`'
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: flag injection --upload-pack=..." {
+  run match_vcs "--upload-pack=/tmp/evil"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: flag injection -O (short flag)" {
+  run match_vcs "-O"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: non-hex lookalike (contains 'g', same length as a valid SHA)" {
+  run match_vcs "1234567g"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: non-hex lookalike (uppercase hex - regex is lowercase-only per spec)" {
+  run match_vcs "ABC1234"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: over-long token (41 hex chars, one past the cap)" {
+  run match_vcs "0123456789abcdef0123456789abcdef012345678"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: over-long token (1000-char hex-looking clipboard blob)" {
+  local blob
+  blob="$(printf 'a%.0s' $(seq 1 1000))"
+  run match_vcs "$blob"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: under-length token (6 hex chars, one short of the floor)" {
+  run match_vcs "abc123"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: valid-looking SHA PREFIX with a malicious suffix (anchoring proof)" {
+  # a naive unanchored regex (e.g. [0-9a-f]{7,40} with no ^/\$) would match
+  # the leading "abc1234" substring and accept this; the anchored regex must
+  # reject the whole string because of the trailing garbage.
+  run match_vcs "abc1234; rm -rf /"
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: empty string" {
+  run match_vcs ""
+  [ "$status" -eq 1 ]
+}
+
+@test "negative control: a github blob URL (github.sh's shape) is not claimed by vcs" {
+  run match_vcs "https://github.com/dwarvesf/herdr-quicklook/blob/main/pull/README.md"
+  [ "$status" -eq 1 ]
+}
+
+# ---- handle_vcs: exact argv (the required checklist cases) ----
+
+@test "handle_vcs: a valid SHA builds the exact argv git show --end-of-options <sha>" {
+  handle_vcs "abc1234"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
+  [ "${RESOLVED_CMD[0]}" = "git" ]
+  [ "${RESOLVED_CMD[1]}" = "show" ]
+  [ "${RESOLVED_CMD[2]}" = "--end-of-options" ]
+  [ "${RESOLVED_CMD[3]}" = "abc1234" ]
+  # goal file's literal example is `git show -- <sha>`; this deliberately
+  # uses `--end-of-options` instead of a trailing `--` - see the comment in
+  # vcs.sh and this sub-goal's DECISIONS.md entry ("`--` silently shows HEAD
+  # for a bogus SHA instead of erroring").
+}
+
+@test "handle_vcs: #123 builds the exact argv gh pr view 123" {
+  handle_vcs "#123"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
+  [ "${RESOLVED_CMD[0]}" = "gh" ]
+  [ "${RESOLVED_CMD[1]}" = "pr" ]
+  [ "${RESOLVED_CMD[2]}" = "view" ]
+  [ "${RESOLVED_CMD[3]}" = "123" ]
+}
+
+@test "handle_vcs: a GitHub PR URL builds gh pr view <url>" {
+  handle_vcs "https://github.com/dwarvesf/herdr-quicklook/pull/42"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
+  [ "${RESOLVED_CMD[0]}" = "gh" ]
+  [ "${RESOLVED_CMD[1]}" = "pr" ]
+  [ "${RESOLVED_CMD[2]}" = "view" ]
+  [ "${RESOLVED_CMD[3]}" = "https://github.com/dwarvesf/herdr-quicklook/pull/42" ]
+}
+
+# ---- non-hex token falls through to the next handler (checklist case) ----
+
+@test "resolve_any_token: a non-hex token never gets mode=command from vcs" {
+  # "notasha" isn't hex, doesn't start with # or a github pull URL - vcs
+  # must decline so a LATER handler (here: path, since no such file exists)
+  # gets the token, not vcs claiming it wrongly.
+  rc=0
+  resolve_any_token "notasha" || rc=$?
+  [ "$rc" -eq 1 ]
+  [ "$RESOLVED_MODE" != "command" ]
+  [ -z "$RESOLVED_MODE" ]
+}
+
+@test "resolve_any_token: an over-long hex blob falls through past vcs to path (unresolved)" {
+  local blob
+  blob="$(printf 'a%.0s' $(seq 1 1000))"
+  rc=0
+  resolve_any_token "$blob" || rc=$?
+  [ "$rc" -eq 1 ]
+  [ "$RESOLVED_MODE" != "command" ]
+}
+
+# ---- argv-shape control (checklist case) ----
+# Calls handle_vcs directly, bypassing match_vcs's gate entirely, to prove
+# the ARGV CONSTRUCTION itself - not the input filter - is what keeps a
+# value containing embedded whitespace and shell metacharacters as ONE argv
+# element. This is the same "independent of the regex" property the SHA
+# checklist case above exercises, pushed to an adversarial extreme.
+
+@test "argv-shape control: a space-and-metacharacter value still lands as ONE arg after the SHA branch's --end-of-options" {
+  handle_vcs 'abc1234 && rm -rf / #'
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
+  [ "${RESOLVED_CMD[3]}" = 'abc1234 && rm -rf / #' ]
+}
+
+@test "argv-shape control: a flag-injection value through the #-branch still lands as ONE arg" {
+  handle_vcs '#123 --upload-pack=/tmp/evil'
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
+  [ "${RESOLVED_CMD[3]}" = '123 --upload-pack=/tmp/evil' ]
+}
+
+# ---- real execution: functional correctness + the security proof ----
+# These actually RUN the built RESOLVED_CMD array (not just inspect it) to
+# prove the argv-safety holds under a real git/gh invocation, not only in
+# the array's shape.
+
+@test "real run: a valid SHA's argv shows the real commit" {
+  match_vcs "$REAL_SHA"
+  handle_vcs "$REAL_SHA"
+  run "${RESOLVED_CMD[@]}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$REAL_SHA"* ]]
+  [[ "$output" == *"$REAL_SUBJECT"* ]]
+}
+
+@test "real run: a bogus-but-hex-shaped SHA degrades to an error, never silently shows HEAD" {
+  # this is the exact regression --end-of-options exists to prevent: with a
+  # trailing `--`, git show would silently render HEAD's commit instead of
+  # erroring, because `--` makes an unresolvable token a pathspec, not a
+  # revision.
+  local bogus="deadbee0"
+  match_vcs "$bogus"
+  handle_vcs "$bogus"
+  run "${RESOLVED_CMD[@]}"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"$REAL_SUBJECT"* ]]
+}
+
+@test "real run: flag-injection payload through the SHA branch fails safely instead of being parsed as a flag" {
+  # even though match_vcs would never accept this (tested above), this
+  # proves handle_vcs's OWN argv construction is safe in depth: git rejects
+  # the injected-looking flag rather than acting on it.
+  handle_vcs "--upload-pack=/tmp/evil"
+  [ "${RESOLVED_CMD[2]}" = "--end-of-options" ]
+  [ "${RESOLVED_CMD[3]}" = "--upload-pack=/tmp/evil" ]
+  run "${RESOLVED_CMD[@]}"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must come before non-option arguments"* || "$output" == *"unknown"* || "$output" == *fatal* ]]
+}
+
+# ---- registry wiring: the HANDLER_KINDS reorder (vcs before url) ----
+# lib.sh's HANDLER_KINDS was reordered from (github url vcs dir path) to
+# (github vcs url dir path) as part of this sub-goal - see DECISIONS.md.
+# Without this, a GitHub PR URL would be claimed by url.sh's generic
+# http(s) match (mode=browser) before vcs.sh ever got a look, since url.sh's
+# match depends only on classify_token, which has no PR-URL case.
+
+@test "registry: a GitHub PR URL dispatches to vcs (mode=command), not url (mode=browser)" {
+  resolve_any_token "https://github.com/dwarvesf/herdr-quicklook/pull/42"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${RESOLVED_CMD[0]}" = "gh" ]
+}
+
+@test "registry: a bare SHA dispatches to vcs end to end through resolve_any_token" {
+  resolve_any_token "$REAL_SHA"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${RESOLVED_CMD[*]}" = "git show --end-of-options $REAL_SHA" ]
+}
+
+@test "registry: a #123 hashref dispatches to vcs end to end through resolve_any_token" {
+  resolve_any_token "#7"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${RESOLVED_CMD[*]}" = "gh pr view 7" ]
+}
+
+@test "registry: a generic non-github https URL still resolves as mode=browser (reorder did not regress url.sh)" {
+  resolve_any_token "https://example.com/a/b"
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://example.com/a/b" ]
+}
+
+@test "registry: a github blob URL still resolves as mode=file via github.sh (reorder did not regress github.sh)" {
+  # "FIX" is not named the same as the URL's repo, so this exercises the
+  # local-file-in-cwd path: top.md is not present here, so it should fail
+  # to resolve locally and fall back to browser - still github.sh's own
+  # handle_github, never vcs.
+  resolve_any_token "https://github.com/o/ghostrepo/blob/main/nope.md"
+  [ "$RESOLVED_MODE" = "browser" ]
+}
+
+# ---- contract compliance ----
+
+@test "vcs.sh exports match_vcs and handle_vcs" {
+  declare -F match_vcs >/dev/null
+  declare -F handle_vcs >/dev/null
+}


### PR DESCRIPTION
New token kinds: a commit SHA opens `git show` in the popup, `#123`/PR URL opens `gh pr view`.
Hex-validated, single-arg (injection-guarded, VERDICT: SECURE). One registry handler; pane
scripts untouched. Run-table + security note below.

## Run-table

| Command | Exit | Result |
|---|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | 0 | clean |
| `bats tests/` | 0 | 114 ok, 0 not-ok |
| `bats tests/handlers-vcs.bats` | 0 | 34 ok, 0 not-ok |

(114 = 80 pre-existing at this branch's base (post PR #7 + PR #8, both already merged
to `main`) + 34 new in `tests/handlers-vcs.bats`. Confirmed zero regressions after
fast-forwarding this branch onto `main` to pick up PR #8's GitLab/Bitbucket handler.)

## Named negative controls (`tests/handlers-vcs.bats`)

All assert `match_vcs` rejects the token (falls through to the next handler, never
reaches `git`/`gh`):

- **Metacharacters:** `abc1234; rm -rf /`, `` $(whoami) ``, `` `whoami` ``
- **Flag injection:** `--upload-pack=/tmp/evil`, `-O`
- **Non-hex lookalikes:** `1234567g` (contains a non-hex char at valid length), `ABC1234`
  (uppercase; spec's regex is lowercase-only)
- **Over-long tokens:** a 41-hex-char string (one past the 40 cap), a 1000-char
  hex-looking clipboard blob
- **Under-length token:** 6 hex chars (one short of the 7 floor)
- **Anchoring proof:** `abc1234; rm -rf /` (a valid-looking SHA *prefix* with a
  malicious suffix), proves the regex is fully anchored (`^...$`), not a partial
  match; a naive unanchored check would have accepted this
- **Empty string**
- **Shape-boundary:** a GitHub blob URL (github.sh's own shape) is not claimed by vcs

Plus two **argv-safety controls** that call `handle_vcs` directly (bypassing
`match_vcs`'s gate) to prove the *argv construction itself*, not just the input
filter, keeps a hostile value as one array element:

- `abc1234 && rm -rf / #` through the SHA branch → lands as `RESOLVED_CMD[3]`, one element
- `#123 --upload-pack=/tmp/evil` through the `#`-branch → lands as `RESOLVED_CMD[3]`, one element

And a **real-execution proof** (not just an inert assertion, the built argv is actually
run):

- A real SHA's argv → `git show` prints that exact commit
- A bogus-but-hex-shaped SHA's argv → `git show` errors (`fatal: ambiguous argument...`),
  and critically does **not** silently print HEAD's commit (see the `--end-of-options`
  deviation below)
- A flag-injection payload through the SHA branch, actually executed → git refuses it as
  a flag (`fatal: option '...' must come before non-option arguments`), does not execute
  it as `--upload-pack`

## VERDICT: SECURE

Untrusted clipboard input never becomes shell-string-interpolated: `RESOLVED_CMD` is a
bash array end to end, and every accepted token is passed as exactly one array element.
The `--end-of-options` deviation (below) closes a wrong-data leak that a literal `--`
would have reopened.

## Two deviations from the goal file's literal argv text (see DECISIONS.md)

1. **`git show --end-of-options "$sha"`, not `git show -- "$sha"`.** The literal `--`
   form silently renders HEAD's commit for a bogus-but-hex-shaped SHA instead of
   erroring (`--` makes git treat the trailing arg as a pathspec once there's no
   revision, and pathspec-mismatch doesn't fail the whole command), a correctness bug
   that directly violates this sub-goal's own quality bar ("never an error dump" /
   "degrades to not found"). `--end-of-options` gives the same flag-injection guard
   without the pathspec reinterpretation. Verified with a real repo (both a real and a
   fake SHA), see the "real run" test group above.
2. **`HANDLER_KINDS` reordered from `(github url vcs dir path)` to `(github vcs url dir
   path)`** — one line in `scripts/lib.sh`. A GitHub PR URL is an `http(s)://` string
   that isn't a blob/raw shape, so `classify_token` labels it `url`; with the original
   order `url.sh` claimed it (browser mode) before `vcs.sh` ever got a look, making the
   PR-URL half of this sub-goal's outcome structurally unreachable. `vcs`'s other two
   shapes (bare SHA, `#123`) don't overlap `github`/`url` at all, so this reorder is a
   no-op for everything else, regression-tested explicitly (a generic non-github
   `https://` URL still resolves via `url`; a github blob URL still resolves via
   `github.sh`).

## Files changed

- `scripts/handlers/vcs.sh`, real `match_vcs`/`handle_vcs` (was a stub)
- `scripts/lib.sh`, one-line `HANDLER_KINDS` reorder (see deviation 2)
- `tests/handlers-vcs.bats`, new, 34 cases
