### PR TITLE
feat: recents log + reopen/pick action (prefix+shift+v)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ command = "herdr plugin action invoke preview --plugin herdr-quicklook"
 key = "prefix+o"
 type = "shell"
 command = "herdr plugin action invoke open-in-viewer --plugin herdr-quicklook"
+
+[[keys.command]]              # reopen a recent quicklook
+key = "prefix+shift+v"
+type = "shell"
+command = "herdr plugin action invoke recents --plugin herdr-quicklook"
 ```
 
 Reload with `herdr server reload-config`.
@@ -64,6 +69,12 @@ Reload with `herdr server reload-config`.
 | arrows / PgUp / PgDn | Scroll |
 
 The overlay is sized by herdr; it closes itself after handing a URL to the browser.
+
+## Recents (`prefix+shift+v`)
+
+Every successful open (a file, a URL, a `command`/`viewer`-mode result) is recorded to a small, bounded log (last 20, deduped: reopening something already in the log just moves it back to the front). Press the binding and it reopens the most recent entry directly; with [`fzf`](https://github.com/junegunn/fzf) installed and more than one entry, it opens an fzf pick over the last N instead.
+
+The log lives outside any git repo, at `${XDG_STATE_HOME:-~/.local/state}/herdr-quicklook/recents`, never inside your working tree. Recording is best-effort: a write failure (unwritable state dir, or the guard above refusing a path that resolved inside a repo) never blocks the open it was trying to record.
 
 ## Configuration
 
@@ -125,6 +136,7 @@ Everything else is optional, and the plugin degrades instead of failing:
 
 - **preview** opens a plugin overlay pane (a real TTY) that reads the clipboard, resolves the token, and renders it with `less` (bat as the `LESSOPEN` colorizer). Esc-to-quit ships via a `lesskey` file. `o` escalates via less's single `visual` slot (`$VISUAL` -> `escalate.sh`); `e` cannot reuse that slot, so it is bound directly to less's `pshell` shell-escape action instead (`escalate-editor.sh`, with a `^P` extra-string prefix that suppresses the shell-escape's normal "done" prompt so the overlay resumes cleanly).
 - **open-in-viewer** has no goto-file API to call, so it drives the viewer's own keys over the herdr socket: it ensures a `Files` pane exists in the focused tab (opening one via the viewer's action if needed), then sends `f`, types the repo-relative path, and presses Enter; `path:123` follows up with the viewer's `:` goto-line. This is UI-scripting by nature: if the viewer's keymap changes upstream, this action needs a revisit.
+- **recents** has no TTY of its own either (herdr runs every action's command headless), so it opens a second overlay pane (`recents-pick`) just for the fzf pick; the chosen entry is then handed to the SAME `preview` overlay-rendering code (`preview-pane.sh`, `exec`'d in place, not a third pane) so a reopened entry resolves and records exactly like a fresh open.
 - No event hooks, no daemons, nothing runs until you press your key.
 
 ## Limitations

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -37,3 +37,19 @@ platforms = ["linux", "macos"]
 title = "Open clipboard path in file viewer"
 description = "Open the clipboard's file path inside the herdr-file-viewer pane (requires that plugin)."
 command = ["bash", "scripts/open-in-viewer.sh"]
+
+# The recents picker: an overlay with a real TTY running fzf (same shape as
+# the preview pane, needed for the same reason - see scripts/recents.sh).
+# Opened by the `recents` action below.
+[[panes]]
+id = "recents-pick"
+title = "Recents"
+placement = "overlay"
+command = ["bash", "scripts/recents-pane.sh"]
+
+[[actions]]
+id = "recents"
+platforms = ["linux", "macos"]
+title = "Reopen a recent quicklook"
+description = "Reopen the most recently opened path/URL, or fzf-pick among the last N when fzf is installed."
+command = ["bash", "scripts/recents.sh"]

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -99,11 +99,92 @@ url_open() {
   fi >/dev/null 2>&1
 }
 
-# record_open <token> -> no-op today (best-effort). SG-07 (recents) fills in
-# the body; both pane scripts already call this at the point a successful
-# open is known, so that sub-goal stays a lib.sh-only change for the body
-# itself (it may still touch the pane scripts' call sites, see DECISIONS.md).
-record_open() { :; }
+# ---- recents (SG-07): a small "last opened" log, read by the `recents`
+# action / recents-pick pane (scripts/recents.sh, scripts/recents-pane.sh).
+# State lives under a proper state dir, NEVER inside a repo working tree,
+# see recents_path_is_safe below.
+
+# RECENTS_MAX: bounded log size (last-N, deduped). Overridable for tests.
+RECENTS_MAX="${QUICKLOOK_RECENTS_MAX:-20}"
+
+# recents_state_dir -> the directory the recents log lives in (not created
+# here). ${XDG_STATE_HOME:-$HOME/.local/state}/herdr-quicklook, per this
+# sub-goal's goal file. Not the plugin config-dir: that would mean shelling
+# out to `herdr plugin config-dir` (an extra process, and a hard runtime
+# dependency on herdr itself) on every single successful open, when the XDG
+# state dir needs nothing more than $HOME.
+recents_state_dir() {
+  printf '%s/herdr-quicklook' "${XDG_STATE_HOME:-$HOME/.local/state}"
+}
+
+# recents_state_file -> the recents log itself.
+recents_state_file() {
+  printf '%s/recents' "$(recents_state_dir)"
+}
+
+# recents_path_is_safe <path> -> rc 0 if no ancestor directory of <path> is
+# a git working tree (a `.git` entry - a directory for a normal repo, a file
+# for a worktree/submodule gitlink). A pure path-walk, no `git` binary
+# required and no dependency on the directory existing yet, so it works
+# before the first `mkdir -p`. This is the hard guard the goal file
+# requires: state must NEVER land inside a repo, however
+# XDG_STATE_HOME/$HOME ends up set on a given machine.
+recents_path_is_safe() {
+  local d
+  d="$(dirname -- "$1")"
+  while [ -n "$d" ] && [ "$d" != "/" ] && [ "$d" != "." ]; do
+    [ -e "$d/.git" ] && return 1
+    d="$(dirname -- "$d")"
+  done
+  return 0
+}
+
+# record_open <token> -> append <token> to the recents log: dedup (an
+# existing occurrence of the same token moves to the front instead of
+# duplicating) and cap at RECENTS_MAX (oldest entries drop off). Best-effort
+# by design (this sub-goal's Quality bar): an empty token, an unsafe path,
+# an unwritable dir, or any write failure is silently swallowed - a
+# recording failure must never block the open it is recording. Atomic:
+# builds the new content in a temp file in the SAME directory, then renames
+# over the real file, so a concurrent reader never observes a half-written
+# log.
+record_open() {
+  local token="$1" file dir tmp
+  [ -z "$token" ] && return 0
+  file="$(recents_state_file)"
+  dir="$(dirname -- "$file")"
+  recents_path_is_safe "$file" || return 0
+  mkdir -p -- "$dir" 2>/dev/null || return 0
+  tmp="$(mktemp "$dir/.recents.XXXXXX" 2>/dev/null)" || return 0
+  if {
+    [ -f "$file" ] && grep -Fxv -- "$token" "$file" 2>/dev/null
+    printf '%s\n' "$token"
+  } | tail -n "$RECENTS_MAX" >"$tmp" 2>/dev/null; then
+    mv -f -- "$tmp" "$file" 2>/dev/null
+  else
+    rm -f -- "$tmp" 2>/dev/null
+  fi
+  return 0
+}
+
+# recents_list -> the recents log, MOST-RECENT-FIRST, one token per line.
+# Missing or empty file: no output, rc 0. A corrupt/unreadable file never
+# crashes the caller (errors are swallowed; worst case is fewer or garbled
+# candidates, never a nonzero exit the caller has to guard against).
+recents_list() {
+  local file
+  file="$(recents_state_file)"
+  [ -f "$file" ] || return 0
+  # Reverse without depending on GNU-only `tac` (not on macOS by default);
+  # this sed idiom is portable to BSD sed too.
+  sed '1!G;h;$!d' "$file" 2>/dev/null
+  return 0
+}
+
+# recents_latest -> the single most-recently-opened token, or empty.
+recents_latest() {
+  recents_list | head -1
+}
 
 # Optional config: QUICKLOOK_ROOTS, colon-separated extra roots to try for
 # relative paths (e.g. the parent directory holding all your repos).

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -40,6 +40,10 @@ CLIP_LINE=""
 if resolve_any_token "$raw"; then
   case "$RESOLVED_MODE" in
     browser)
+      # Opening the browser is a successful open like any other mode (this
+      # sub-goal's Outcome says "every successful open"); record before the
+      # exit. See the matching comment in preview-pane.sh and DECISIONS.md.
+      record_open "$raw"
       url_open "$RESOLVED_TARGET"
       exit 0
       ;;

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -27,6 +27,12 @@ CLIP_LINE=""
 if resolve_any_token "$raw"; then
   case "$RESOLVED_MODE" in
     browser)
+      # Opening the browser is a successful open like any other mode (this
+      # sub-goal's Outcome says "every successful open"); record before the
+      # exit, not after - SG-01's original placement here reached
+      # url_open+exit before either pane script's own record_open call site,
+      # so a browsed URL was never recorded. See DECISIONS.md.
+      record_open "$raw"
       url_open "$RESOLVED_TARGET"
       exit 0
       ;;

--- a/scripts/recents-pane.sh
+++ b/scripts/recents-pane.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pane `recents-pick`: runs inside an overlay (real TTY, same placement as
+# the `preview` pane). Opened by the `recents` action (scripts/recents.sh),
+# which has no TTY of its own to run fzf from - see the header comment
+# there.
+#
+# No fzf installed: reopens the most recent entry directly, no interactive
+# step (the goal's stated degrade). fzf installed: presents the recents log
+# (most-recent-first) for a pick. Either way, the chosen raw token is handed
+# to preview-pane.sh via QUICKLOOK_TOKEN and `exec`'d IN THIS SAME PANE/TTY
+# (not a new pane) - reusing preview-pane.sh's own resolve+render+
+# record_open logic verbatim means a reopened recents entry is itself
+# recorded again, which is exactly the recency-bump dedup semantic
+# record_open already implements (see lib.sh).
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck disable=SC1091
+. "$script_dir/lib.sh"
+
+load_config
+
+pause_close() {
+  printf '%s\n' "$*"
+  read -r -n1 -p "press any key to close" _ 2>/dev/null || sleep 2
+  exit 0
+}
+
+candidates=()
+while IFS= read -r line; do
+  [ -n "$line" ] && candidates+=("$line")
+done < <(recents_list)
+
+[ "${#candidates[@]}" -eq 0 ] && pause_close "quicklook: no recents yet"
+
+if command -v fzf >/dev/null 2>&1; then
+  pick="$(printf '%s\n' "${candidates[@]}" | fzf --prompt="recents ▸ " --reverse --cycle --height=100%)" || exit 0
+  [ -z "$pick" ] && exit 0
+else
+  # No fzf: reopen the most recent (candidates[0], recents_list is
+  # already most-recent-first) with no interactive step.
+  pick="${candidates[0]}"
+fi
+
+export QUICKLOOK_TOKEN="$pick"
+exec bash "$script_dir/preview-pane.sh"

--- a/scripts/recents.sh
+++ b/scripts/recents.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Action `recents`: reopen the most recently quick-looked token, or fzf-pick
+# among the last N when fzf is installed.
+#
+# herdr runs an action's own command WITHOUT a TTY (the same constraint every
+# other action in this plugin is built around, and the installed
+# jt.command-palette plugin's open.sh documents identically for its own
+# fzf-driven picker) - so the interactive pick cannot run here directly. This
+# script only opens the `recents-pick` overlay pane (scripts/recents-pane.sh
+# below), which DOES get a TTY, forwarding the origin workspace's cwd the
+# same way scripts/open-preview.sh does, so a relative token in the recents
+# log resolves against the repo the user was actually in.
+set -uo pipefail
+
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
+
+repo=""
+if [ -n "$ctx" ] && command -v jq >/dev/null 2>&1; then
+  repo="$(printf '%s' "$ctx" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || repo="${HERDR_WORKSPACE_CWD:-}"
+
+set -- plugin pane open \
+  --plugin herdr-quicklook \
+  --entrypoint recents-pick \
+  --placement overlay \
+  --focus
+
+if [ -n "$repo" ] && [ -d "$repo" ]; then
+  set -- "$@" --cwd "$repo"
+fi
+
+exec "$herdr_bin" "$@"

--- a/tests/recents.bats
+++ b/tests/recents.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+# Tests for the `recents` feature (SG-07): lib.sh's record_open/recents_*
+# state functions, plus script-level coverage for scripts/recents.sh (the
+# no-TTY action) and scripts/recents-pane.sh (the fzf-capable overlay pane
+# it opens), and the browser-mode record_open call added to both pane
+# scripts. Unit tests source lib.sh directly (same fixture shape as
+# quicklook.bats/registry.bats); XDG_STATE_HOME is pointed at a fixture dir
+# per test for isolation.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/state" "$FIX/repo"
+  git -C "$FIX/repo" init -q -b main
+  printf 'x\n' > "$FIX/repo/f.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+
+  export XDG_STATE_HOME="$FIX/state"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS
+  RECENTS_MAX=20
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# ---- recents_state_dir / recents_state_file ----
+
+@test "recents_state_dir: honors XDG_STATE_HOME, namespaced under herdr-quicklook" {
+  run recents_state_dir
+  [ "$output" = "$FIX/state/herdr-quicklook" ]
+}
+
+@test "recents_state_file: lives inside the state dir" {
+  run recents_state_file
+  [ "$output" = "$FIX/state/herdr-quicklook/recents" ]
+}
+
+# ---- record_open: basic append, dedup, cap ----
+
+@test "record_open: creates the state file and writes the token" {
+  record_open "a/b.md"
+  [ -f "$(recents_state_file)" ]
+  [ "$(cat "$(recents_state_file)")" = "a/b.md" ]
+}
+
+@test "record_open: a second distinct token becomes the latest" {
+  record_open "a.md"
+  record_open "b.md"
+  run recents_latest
+  [ "$output" = "b.md" ]
+}
+
+@test "record_open: dedups - reopening an existing token moves it to the front, no duplicate line" {
+  record_open "a.md"
+  record_open "b.md"
+  record_open "a.md"
+  run recents_latest
+  [ "$output" = "a.md" ]
+  lines_total="$(wc -l < "$(recents_state_file)" | tr -d ' ')"
+  [ "$lines_total" -eq 2 ]
+}
+
+@test "record_open: caps at RECENTS_MAX, oldest entries drop off" {
+  RECENTS_MAX=3
+  record_open "a"
+  record_open "b"
+  record_open "c"
+  record_open "d"
+  run recents_list
+  [ "${lines[0]}" = "d" ]
+  [ "${lines[1]}" = "c" ]
+  [ "${lines[2]}" = "b" ]
+  [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "record_open: empty token is a no-op (no file created)" {
+  record_open ""
+  [ ! -e "$(recents_state_file)" ]
+}
+
+@test "record_open: is best-effort when the state dir cannot be created" {
+  # Point the state dir at a path whose parent is a regular FILE (mkdir -p
+  # must fail); record_open must swallow that, not error/exit the caller.
+  printf 'not a dir\n' > "$FIX/state/blocker"
+  XDG_STATE_HOME="$FIX/state/blocker"
+  record_open "a.md"
+  [ ! -e "$FIX/state/blocker/herdr-quicklook" ]
+}
+
+# ---- recents_list / recents_latest: missing / corrupt file ----
+
+@test "recents_list: missing file returns nothing, rc 0" {
+  run recents_list
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "recents_latest: empty log returns empty" {
+  run recents_latest
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "recents_list: an unreadable state file degrades to empty, never crashes" {
+  mkdir -p "$(recents_state_dir)"
+  printf 'a\nb\n' > "$(recents_state_file)"
+  chmod 000 "$(recents_state_file)"
+  run recents_list
+  [ "$status" -eq 0 ]
+  chmod 644 "$(recents_state_file)"
+}
+
+# ---- recents_path_is_safe: the never-inside-a-repo guard ----
+
+@test "recents_path_is_safe: a path outside any repo is safe" {
+  run recents_path_is_safe "$FIX/state/herdr-quicklook/recents"
+  [ "$status" -eq 0 ]
+}
+
+@test "recents_path_is_safe: a path inside a git working tree is unsafe" {
+  run recents_path_is_safe "$FIX/repo/.state/herdr-quicklook/recents"
+  [ "$status" -eq 1 ]
+}
+
+@test "record_open: refuses to write when XDG_STATE_HOME resolves inside a repo (the guard fires end to end)" {
+  XDG_STATE_HOME="$FIX/repo/.state"
+  record_open "a.md"
+  [ ! -e "$FIX/repo/.state" ]
+}
+
+# ---- script-level: browser-mode opens are now recorded (both pane scripts) ----
+
+script_stubs() {
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\n' > "$STUB/less"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/herdr"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/open"
+  chmod +x "$STUB/less" "$STUB/herdr" "$STUB/open"
+  # Deliberately NOT /opt/homebrew/bin: this host has a real fzf/bat/eza
+  # there, and the no-fzf tests below need `command -v fzf` to actually
+  # miss. git/sed/tail/mktemp/grep/dirname/mv/rm all resolve fine from
+  # /usr/bin:/bin:/usr/local/bin alone.
+  export PATH="$STUB:/usr/bin:/bin:/usr/local/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+}
+
+@test "preview-pane.sh: a browser-mode open (generic URL) is recorded" {
+  script_stubs
+  cd "$FIX/repo"
+  export QUICKLOOK_TOKEN="https://example.com/a/b"
+  run bash "$BATS_TEST_DIRNAME/../scripts/preview-pane.sh"
+  [ "$status" -eq 0 ]
+  run recents_latest
+  [ "$output" = "https://example.com/a/b" ]
+}
+
+@test "open-in-viewer.sh: a browser-mode open (generic URL) is recorded" {
+  script_stubs
+  cat > "$STUB/jq" <<'JQ'
+#!/usr/bin/env bash
+exit 1
+JQ
+  chmod +x "$STUB/jq"
+  cd "$FIX/repo"
+  export QUICKLOOK_TOKEN="https://example.com/x/y"
+  run bash "$BATS_TEST_DIRNAME/../scripts/open-in-viewer.sh"
+  [ "$status" -eq 0 ]
+  run recents_latest
+  [ "$output" = "https://example.com/x/y" ]
+}
+
+# ---- script-level: scripts/recents.sh (the no-TTY action) ----
+
+@test "recents.sh: opens the recents-pick overlay pane" {
+  script_stubs
+  cd "$FIX/repo"
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD
+  run bash "$BATS_TEST_DIRNAME/../scripts/recents.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "recents.sh: forwards argv building a recents-pick pane-open (via herdr stub echoing argv)" {
+  STUB="$(mktemp -d)"
+  cat > "$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@"
+SH
+  chmod +x "$STUB/herdr"
+  export PATH="$STUB:$PATH"
+  export HERDR_BIN_PATH="$STUB/herdr"
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD
+  run bash "$BATS_TEST_DIRNAME/../scripts/recents.sh"
+  [ "$status" -eq 0 ]
+  grep -qx -- 'recents-pick' <<<"$output"
+  grep -qx -- 'overlay' <<<"$output"
+}
+
+# ---- script-level: scripts/recents-pane.sh (the TTY-holding picker) ----
+
+@test "recents-pane.sh: no recents yet -> pause_close message, no crash" {
+  script_stubs
+  cd "$FIX/repo"
+  run bash "$BATS_TEST_DIRNAME/../scripts/recents-pane.sh" < /dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no recents yet"* ]]
+}
+
+@test "recents-pane.sh: no fzf on PATH -> reopens the latest with no interactive step" {
+  script_stubs
+  cd "$FIX/repo"
+  record_open "f.md"
+  # PATH built by script_stubs has no fzf, matching the degrade path.
+  run bash "$BATS_TEST_DIRNAME/../scripts/recents-pane.sh" < /dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"$FIX/repo/f.md"* ]]
+}
+
+@test "recents-pane.sh: fzf present -> the picked candidate is what gets reopened" {
+  script_stubs
+  cd "$FIX/repo"
+  printf 'x\n' > "$FIX/repo/g.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm more
+  record_open "f.md"
+  record_open "g.md"
+  # a stub fzf that deterministically picks the SECOND candidate on stdin
+  # (proving the real fzf's stdin, not just "always the first"), matching
+  # bare-name.sh's existing fzf-stub-free style would be impractical here -
+  # fzf itself needs a stub since bats has no real TTY for it to attach to.
+  cat > "$STUB/fzf" <<'SH'
+#!/usr/bin/env bash
+sed -n '2p'
+SH
+  chmod +x "$STUB/fzf"
+  run bash "$BATS_TEST_DIRNAME/../scripts/recents-pane.sh" < /dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"$FIX/repo/f.md"* ]]
+  [[ "$output" != *"$FIX/repo/g.md"* ]]
+}
+
+@test "recents-pane.sh: reopening a recents entry re-records it (recency bump via preview-pane.sh's own record_open)" {
+  script_stubs
+  cd "$FIX/repo"
+  record_open "f.md"
+  run bash "$BATS_TEST_DIRNAME/../scripts/recents-pane.sh" < /dev/null
+  [ "$status" -eq 0 ]
+  run recents_latest
+  [ "$output" = "f.md" ]
+}


### PR DESCRIPTION
Records opens to a bounded state file and adds a `recents` action (bind `prefix+shift+v`) to
reopen the latest or fzf-pick the last N. State lives outside any repo; recording is best-effort.
Run-table below.

## What's in this PR

- `scripts/lib.sh`: fills in `record_open` (dedup + cap at `RECENTS_MAX=20`, atomic
  temp-file+rename write) and adds `recents_state_dir`/`recents_state_file`/
  `recents_path_is_safe`/`recents_list`/`recents_latest`. State lives at
  `${XDG_STATE_HOME:-~/.local/state}/herdr-quicklook/recents`; `recents_path_is_safe`
  refuses to write if any ancestor of that path is a git working tree.
- `scripts/recents.sh` (new): the `recents` action. No TTY (herdr constraint), so it
  only opens the `recents-pick` overlay pane, forwarding the origin cwd the same way
  `open-preview.sh` does.
- `scripts/recents-pane.sh` (new, beyond this sub-goal's original scope edges - see
  "Deviation" below): the `recents-pick` pane. Has the real TTY. `command -v fzf`
  present: fzf-picks over `recents_list` (most-recent-first). Absent: reopens the
  latest with no interactive step. Either way, hands off to `preview-pane.sh` via
  `exec` in the SAME pane (not a new one), so a reopened entry re-runs the exact
  resolve+render+`record_open` path a fresh open uses (recency-bump for free).
- `scripts/preview-pane.sh` + `scripts/open-in-viewer.sh`: added `record_open "$raw"`
  to the `browser` mode arm in both (SG-01 already wired `file`/`command`/`viewer`;
  browser was the one gap, since "every successful open" in this sub-goal's Outcome
  doesn't carve out browser mode).
- `herdr-plugin.toml`: new `recents` action + `recents-pick` pane.
- `tests/recents.bats` (new): 22 cases.
- `README.md`: a "Recents" section, the `prefix+shift+v` keybinding block, and a
  one-line mention in "How it works".

## Deviation from the goal file's scope edges

The goal file's Touches list expected one new file, `scripts/recents.sh`. Building it
surfaced a real constraint: herdr runs an action's own command WITHOUT a TTY (every
existing action/pane pair in this manifest is already split for exactly this reason -
`preview` action -> `open-preview.sh` opens the `preview` pane -> `preview-pane.sh` is
where `bare-name.sh`'s fzf actually runs; the installed `jt.command-palette` plugin
documents the identical constraint for its own fzf picker). Shipping `recents.sh` alone
with fzf logic inside it would have shipped a picker that silently does nothing in
production (no TTY to draw fzf into). Fixed by splitting into `recents.sh` (action, no
TTY) + `scripts/recents-pane.sh` (pane, real TTY) - the same shape as every other
action/pane pair here. Full reasoning in DECISIONS.md ("SG-07 recents: two new scripts,
not one").

## Run-table

| Command | Result |
|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean (rc 0) |
| `bats tests/` | `82` passed, `0` failed (60 pre-existing + 22 new in `tests/recents.bats`) |

### tests/recents.bats (22 new cases)

```
ok 1 recents_state_dir: honors XDG_STATE_HOME, namespaced under herdr-quicklook
ok 2 recents_state_file: lives inside the state dir
ok 3 record_open: creates the state file and writes the token
ok 4 record_open: a second distinct token becomes the latest
ok 5 record_open: dedups - reopening an existing token moves it to the front, no duplicate line
ok 6 record_open: caps at RECENTS_MAX, oldest entries drop off
ok 7 record_open: empty token is a no-op (no file created)
ok 8 record_open: is best-effort when the state dir cannot be created
ok 9 recents_list: missing file returns nothing, rc 0
ok 10 recents_latest: empty log returns empty
ok 11 recents_list: an unreadable state file degrades to empty, never crashes
ok 12 recents_path_is_safe: a path outside any repo is safe
ok 13 recents_path_is_safe: a path inside a git working tree is unsafe
ok 14 record_open: refuses to write when XDG_STATE_HOME resolves inside a repo (the guard fires end to end)
ok 15 preview-pane.sh: a browser-mode open (generic URL) is recorded
ok 16 open-in-viewer.sh: a browser-mode open (generic URL) is recorded
ok 17 recents.sh: opens the recents-pick overlay pane
ok 18 recents.sh: forwards argv building a recents-pick pane-open (via herdr stub echoing argv)
ok 19 recents-pane.sh: no recents yet -> pause_close message, no crash
ok 20 recents-pane.sh: no fzf on PATH -> reopens the latest with no interactive step
ok 21 recents-pane.sh: fzf present -> the picked candidate is what gets reopened
ok 22 recents-pane.sh: reopening a recents entry re-records it (recency bump via preview-pane.sh's own record_open)
```

Full suite: 82 total (1..82), all `ok`.
