### PR TITLE
feat: directory tokens open herdr-file-viewer, or an eza/ls tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A few things that make it more than a pager:
 | `path/file.md:123` | Opens with line 123 highlighted (`:123` jump in the viewer) |
 | a path under one of your `QUICKLOOK_ROOTS` | Resolved against each configured root |
 | `filename.md` (bare, no directory) | Repo-wide search of tracked files: one hit opens; several hits open an fzf pick |
+| `some/dir` (a directory, not a file) | Opens herdr-file-viewer rooted there when installed, else an `eza --tree`/`ls -la` listing in the popup |
 
 Resolution runs top-down: exact paths win before any fuzzy matching, and the first hit stops the chain.
 

--- a/scripts/handlers/dir.sh
+++ b/scripts/handlers/dir.sh
@@ -1,11 +1,72 @@
 # shellcheck shell=bash
-# dir.sh: STUB for SG-04 (dir-targets). Reserved shape: a token that resolves
-# to a directory opens the file-viewer rooted there (render-mode `viewer`),
-# or an eza/ls tree in the popup when the viewer is absent (render-mode
-# `command`). Registered in HANDLER_KINDS now, ahead of path.sh's catch-all,
-# so SG-04 only needs to edit this file: a real match_dir + handle_dir body,
-# no lib.sh or pane-script changes required. Must test file first, dir
-# second, so it never shadows path.sh's file resolution.
+# dir.sh: a token that resolves to a DIRECTORY (not a file) opens the
+# herdr-file-viewer rooted there when that plugin is installed (render-mode
+# `viewer`), else pages an `eza --tree` (fallback `ls -la`) listing in the
+# popup (render-mode `command`). Registered ahead of path.sh's catch-all in
+# HANDLER_KINDS (see lib.sh) - `_resolve_dir` below must never shadow a real
+# file: it walks the SAME candidate order path.sh's own resolve() uses (as-is,
+# $PWD, every worktree, each QUICKLOOK_ROOTS) and tests -f before -d at every
+# step, declining the whole search the instant a FILE wins a step, so a
+# directory hit at a LATER root can never jump ahead of an EARLIER root's file.
+# shellcheck disable=SC2034  # RESOLVED_* are consumed by the caller (resolve_any_token's caller)
 
-match_dir() { return 1; }
-handle_dir() { return 1; }
+# _dir_candidates <raw> -> one ABSOLUTE candidate path per line, in the same
+# effective priority order path.sh's own resolve() walks (as-is/$PWD, every
+# worktree, each QUICKLOOK_ROOTS). Always absolute so a downstream
+# containment check (open-in-viewer.sh: "is target under the repo root")
+# compares against an absolute root, same reason resolve() itself absolutizes.
+_dir_candidates() {
+  local p="$1" w r
+  case "$p" in
+    /*) printf '%s\n' "$p" ;;
+    *) printf '%s\n' "$PWD/$p" ;;
+  esac
+  while IFS= read -r w; do
+    printf '%s\n' "$w/$p"
+  done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+  local IFS=':'
+  for r in ${QUICKLOOK_ROOTS:-}; do
+    [ -n "$r" ] && printf '%s\n' "$r/$p"
+  done
+}
+
+# _resolve_dir <raw> -> absolute directory path on stdout, rc 0. rc 1 when no
+# candidate is a directory, OR when an earlier-priority candidate is a
+# regular file instead (that file always wins its step - see header comment).
+_resolve_dir() {
+  local raw="$1" cand
+  while IFS= read -r cand; do
+    [ -f "$cand" ] && return 1
+    [ -d "$cand" ] && { printf '%s' "$cand"; return 0; }
+  done < <(_dir_candidates "$raw")
+  return 1
+}
+
+# _dir_viewer_available -> rc 0 if herdr-file-viewer is installed, the same
+# check open-in-viewer.sh's own soft-dependency gate uses.
+# shellcheck disable=SC2154  # herdr_bin is set by lib.sh before this file is sourced
+_dir_viewer_available() {
+  "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1
+}
+
+match_dir() {
+  _resolve_dir "$1" >/dev/null
+}
+
+handle_dir() {
+  local dir
+  dir="$(_resolve_dir "$1")" || return 1
+  RESOLVED_TARGET="$dir"
+  RESOLVED_LINE=""
+  if _dir_viewer_available; then
+    RESOLVED_MODE="viewer"
+    return 0
+  fi
+  RESOLVED_MODE="command"
+  if command -v eza >/dev/null 2>&1; then
+    RESOLVED_CMD=(eza --tree "$dir")
+  else
+    RESOLVED_CMD=(ls -la "$dir")
+  fi
+  return 0
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -44,21 +44,20 @@
 #             for command-mode specifically, see the viewer caveat below).
 #             No handler emits this yet (SG-02/vcs.sh is a stub).
 #   viewer  - RESOLVED_TARGET is a directory to root the file-viewer at.
-#             preview-pane.sh's safe DEGRADE (no handler drives the real
-#             file-viewer socket protocol yet) pages an `eza --tree` /
-#             `ls -la` listing of RESOLVED_TARGET via render_command_in_pager
-#             , the same shape SG-04's own goal file already documents as
-#             its no-viewer-installed fallback. open-in-viewer.sh cannot do
-#             even that (no pager of its own) and cannot safely forward the
-#             raw token the way command-mode does either: path.sh's
-#             resolve() only matches regular files (`-f`), so a directory
-#             token would fail to re-resolve there and silently read as "not
-#             found". It notifies the user and stops instead. Neither arm
-#             ever falls through to file-rendering on a directory ,
-#             the concrete bug this widening exists to prevent. Real
-#             viewer-rooting over the herdr socket is SG-04's own feature;
-#             expect it to replace these degrade bodies. No handler emits
-#             this yet (SG-04/dir.sh is a stub).
+#             dir.sh only emits this mode when herdr-file-viewer is
+#             confirmed installed (else it emits `command` with an
+#             eza/ls tree instead, see below). preview-pane.sh (the popup)
+#             still cannot drive ANOTHER pane's file-viewer socket - it has
+#             only its own TTY, a pager - so its viewer arm is a permanent
+#             safe DEGRADE, paging an `eza --tree` / `ls -la` listing of
+#             RESOLVED_TARGET via render_command_in_pager, the same shape as
+#             dir.sh's own no-viewer-installed fallback. open-in-viewer.sh
+#             CAN drive another pane, so its viewer arm reuses the same
+#             goto-path send-keys sequence the file case already uses (f ->
+#             type <repo-relative path> -> Enter) to land the viewer's
+#             cursor on the directory. Neither arm ever falls through to
+#             file-rendering on a directory , the concrete bug this
+#             widening exists to prevent.
 #
 # resolve_any_token <raw> walks HANDLER_KINDS in order and dispatches to the
 # first handler whose match_<kind> accepts the token, returning that
@@ -257,8 +256,8 @@ resolve() {
 
 # Registry order (first match wins): specific-shape kinds before the
 # catch-all. `path` MUST stay last (see the contract comment at the top of
-# this file). vcs/dir are registered now as stubs (SG-02/SG-04 fill in their
-# match_/handle_ bodies later, one file each, no registry-line edit needed).
+# this file). `vcs` is still a stub (SG-02 fills in its match_/handle_ body
+# later, one file, no registry-line edit needed); `dir` is real (SG-04).
 HANDLER_KINDS=(github url vcs dir path)
 
 # LIB_DIR: this file's own directory (== scripts/), kept around (not

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -59,19 +59,21 @@ if resolve_any_token "$raw"; then
       # RESOLVED_CMD empty is a handler bug; fall through to "not found".
       ;;
     viewer)
-      # RESOLVED_TARGET is a directory. Driving the file-viewer at an
-      # arbitrary directory root, or even paging a tree listing, both need a
-      # real pane with a TTY, which this action script does not have. Unlike
-      # command-mode above, forwarding the raw token through
-      # scripts/open-preview.sh is NOT safe here: path.sh's resolve() only
-      # matches regular files (`-f`), so a directory token fails to
-      # re-resolve there and would silently read as "not found". No handler
-      # emits this mode yet (dir.sh is a stub; SG-04 owns the real behavior,
-      # including whichever pane ends up rendering it). Never fall through
-      # to the file-driving code below on a directory target , notify and
-      # stop instead.
-      notify "directory viewer not wired yet: $RESOLVED_TARGET"
-      exit 0
+      # RESOLVED_TARGET is a directory. herdr-file-viewer is confirmed
+      # installed already (the soft-dependency gate at the top of this
+      # script degrades to the preview overlay before we ever reach here
+      # otherwise), so dir.sh always emits `viewer` in this context - reuse
+      # the SAME goto-path send-keys sequence the file case below already
+      # uses and tests (f -> type <repo-relative path> -> Enter) to land the
+      # viewer's cursor on the directory; there is no separate "root at a
+      # directory" verb in the socket protocol. Directories have no line
+      # number, so CLIP_LINE stays empty and the `:N` step below is skipped
+      # naturally. This falls into the SAME containment / control-char
+      # checks below as a file target - a directory outside this repo's
+      # tree still gets "outside this repo's tree: use the preview overlay
+      # instead".
+      target="$RESOLVED_TARGET"
+      CLIP_LINE=""
       ;;
     *)
       target="$RESOLVED_TARGET"

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -46,13 +46,14 @@ if resolve_any_token "$raw"; then
       # argv to run); fall through and treat it like an unresolved token.
       ;;
     viewer)
-      # RESOLVED_TARGET is a directory. No handler drives the real
-      # file-viewer socket protocol yet (SG-04 owns that); never fall
-      # through to the file-render path below on a directory target, that
-      # is the exact `exec less <directory>` bug this arm exists to
-      # prevent. Safe degrade: page a tree/listing of it instead, the same
-      # shape SG-04's own goal file already documents as its no-viewer
-      # fallback.
+      # RESOLVED_TARGET is a directory. This popup has no way to drive
+      # ANOTHER pane's herdr-file-viewer socket (it only has its own TTY, a
+      # pager) - that real rooting happens in open-in-viewer.sh's own viewer
+      # arm instead. Never fall through to the file-render path below on a
+      # directory target, that is the exact `exec less <directory>` bug this
+      # arm exists to prevent. Safe degrade: page a tree/listing of it
+      # instead, the same shape dir.sh falls back to itself when
+      # herdr-file-viewer isn't installed at all (RESOLVED_MODE=command).
       record_open "$raw"
       if command -v eza >/dev/null 2>&1; then
         render_command_in_pager eza --tree "$RESOLVED_TARGET"

--- a/tests/dispatch-modes.bats
+++ b/tests/dispatch-modes.bats
@@ -4,8 +4,10 @@
 # kit:advisor CRITICAL on PR #7: a mode-unaware pane script would either
 # reject a valid command-mode result on its empty RESOLVED_TARGET, or fall
 # through to `exec less <directory>` for a viewer-mode result). No real
-# handler emits these modes yet (vcs.sh/dir.sh are stubs), so this drops a
-# TEMPORARY test-only handler file into the real scripts/handlers/ directory
+# handler emits `command` yet (vcs.sh is still a stub); dir.sh (SG-04) emits
+# `viewer`/`command` for real now, see tests/handlers-dir.bats for its own
+# coverage. This file still drops a TEMPORARY test-only handler into the real
+# scripts/handlers/ directory
 # for the duration of each test (glob-discovered by lib.sh at source time,
 # same as any real handler) and removes it in teardown , the only way to
 # exercise the full pane-script dispatch as a fresh process, same style as
@@ -132,8 +134,9 @@ teardown() {
   [[ "$output" != *"LESS_ARGS:"*"somedir"* ]]
 }
 
-# ---- open-in-viewer.sh: command / viewer modes never touch the file-viewer
-# send-keys path (which types a token in as if it were a repo-relative FILE)
+# ---- open-in-viewer.sh: command mode never touches the file-viewer
+# send-keys path (which types a token in as if it were a repo-relative FILE);
+# viewer mode (SG-04) reuses that SAME send-keys path on purpose, see below.
 
 @test "open-in-viewer command mode: hands off to the preview overlay, does not send-keys" {
   cat > "$STUB/jq" <<'JQ'
@@ -153,13 +156,30 @@ JQ
   ! grep -q "pane_id" <<<"$output"
 }
 
-@test "open-in-viewer viewer mode: notifies and stops, does not send-keys" {
+@test "open-in-viewer viewer mode: reuses the file case's goto-path send-keys sequence" {
   cat > "$STUB/jq" <<'JQ'
 #!/usr/bin/env bash
 printf '{}'
 JQ
   chmod +x "$STUB/jq"
+  local hlog
+  hlog="$(mktemp)"
+  cat > "$STUB/herdr" <<HERDR
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$hlog"
+exit 0
+HERDR
+  chmod +x "$STUB/herdr"
   export QUICKLOOK_TOKEN="TEST_VIEWER_TOKEN"
   run bash "$VIEWER"
   [ "$status" -eq 0 ]
+  # SG-04's dir.sh only emits `viewer` once herdr-file-viewer is confirmed
+  # installed, so this arm no longer notifies-and-stops (that was the
+  # pre-SG-04 placeholder) - it falls into the SAME containment + send-keys
+  # flow as a file target. This synthetic target ($FIX/myrepo/somedir) is
+  # inside the fixture repo, so it reaches send-keys; the out-of-repo and
+  # real-dir.sh cases are covered in tests/handlers-dir.bats.
+  grep -qF "pane send-keys {} f" "$hlog"
+  grep -qF "pane send-text {} somedir" "$hlog"
+  rm -f "$hlog"
 }

--- a/tests/handlers-dir.bats
+++ b/tests/handlers-dir.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# Tests for scripts/handlers/dir.sh (SG-04 dir-targets). Unit-style cases
+# source lib.sh directly and read the RESOLVED_* globals match_dir/handle_dir
+# communicate through, same fixture/pattern as tests/registry.bats (not
+# `run`, which would hide those globals in a subshell). Script-level cases
+# drive preview-pane.sh / open-in-viewer.sh as real fresh processes, same
+# style as tests/dispatch-modes.bats, to prove the render-mode a real dir.sh
+# picks actually reaches the right pane-script arm.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  PREVIEW="$BATS_TEST_DIRNAME/../scripts/preview-pane.sh"
+  VIEWER="$BATS_TEST_DIRNAME/../scripts/open-in-viewer.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/repo/adir/sub" "$FIX/roots/other" "$FIX/outside/adir"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello\n' > "$FIX/repo/adir/note.md"
+  printf 'a file\n' > "$FIX/repo/afile.md"
+  printf 'shadow file\n' > "$FIX/repo/shadowname"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+
+  STUB="$(mktemp -d)"
+  HLOG="$(mktemp)"
+  # herdr stub: logs every invocation (grep-able below); the herdr-file-viewer
+  # install check (`plugin action list --plugin herdr-file-viewer`) succeeds
+  # only when HERDR_VIEWER_INSTALLED=1, so each test controls it explicitly.
+  cat > "$STUB/herdr" <<HERDR
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$HLOG"
+if [ "\$1" = "plugin" ] && [ "\$2" = "action" ] && [ "\$3" = "list" ]; then
+  [ "\${HERDR_VIEWER_INSTALLED:-0}" = "1" ] && exit 0
+  exit 1
+fi
+exit 0
+HERDR
+  chmod +x "$STUB/herdr"
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\n' > "$STUB/less"
+  chmod +x "$STUB/less"
+  cat > "$STUB/jq" <<'JQ'
+#!/usr/bin/env bash
+printf '{}'
+JQ
+  chmod +x "$STUB/jq"
+
+  cd "$FIX/repo"
+  # deliberately excludes /opt/homebrew/bin (eza's real location on the dev
+  # box) so "eza absent" is the true default; individual tests add a fake
+  # eza into $STUB when they need the "eza present" branch.
+  export PATH="$STUB:/usr/bin:/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+  unset QUICKLOOK_TOKEN QUICKLOOK_ROOTS HERDR_VIEWER_INSTALLED
+  bat() { return 127; }
+  export -f bat 2>/dev/null || true
+
+  # shellcheck disable=SC1090
+  . "$LIB"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+  rm -f "$HLOG"
+}
+
+# ---- a dir token resolves to the dir + render-mode ----
+
+@test "match_dir accepts a directory" {
+  rc=0
+  match_dir "adir" || rc=$?
+  [ "$rc" -eq 0 ]
+}
+
+@test "handle_dir resolves the absolute dir path with no RESOLVED_LINE" {
+  handle_dir "adir"
+  [ "$RESOLVED_TARGET" = "$FIX/repo/adir" ]
+  [ -z "$RESOLVED_LINE" ]
+}
+
+@test "handle_dir: herdr-file-viewer installed -> RESOLVED_MODE=viewer" {
+  export HERDR_VIEWER_INSTALLED=1
+  handle_dir "adir"
+  [ "$RESOLVED_MODE" = "viewer" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/adir" ]
+}
+
+@test "handle_dir resolves via QUICKLOOK_ROOTS when not present locally" {
+  mkdir -p "$FIX/roots/other/onlyinroots"
+  export QUICKLOOK_ROOTS="$FIX/roots/other"
+  rc=0
+  match_dir "onlyinroots" || rc=$?
+  [ "$rc" -eq 0 ]
+  handle_dir "onlyinroots"
+  [ "$RESOLVED_TARGET" = "$FIX/roots/other/onlyinroots" ]
+}
+
+# ---- a file token still resolves as file, dir never shadows it ----
+
+@test "match_dir declines a regular file" {
+  rc=0
+  match_dir "afile.md" || rc=$?
+  [ "$rc" -eq 1 ]
+}
+
+@test "resolve_any_token: a plain file token still resolves as mode=file" {
+  resolve_any_token "afile.md"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/afile.md" ]
+}
+
+# ---- negative control: an earlier-priority file always beats a
+# later-priority directory of the same name (the quality bar's "resolution
+# tests file first, dir second" requirement) ----
+
+@test "negative control: a QUICKLOOK_ROOTS directory never shadows a higher-priority local file of the same name" {
+  mkdir -p "$FIX/roots/other/shadowname"
+  export QUICKLOOK_ROOTS="$FIX/roots/other"
+  rc=0
+  match_dir "shadowname" || rc=$?
+  [ "$rc" -eq 1 ]
+  resolve_any_token "shadowname"; rc2=$?
+  [ "$rc2" -eq 0 ]
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/shadowname" ]
+}
+
+# ---- negative control: an unresolvable token is declined cleanly, not
+# accidentally accepted as a directory ----
+
+@test "negative control: a token matching neither file nor dir falls through with no globals set" {
+  rc=0
+  resolve_any_token "no/such/thing" || rc=$?
+  [ "$rc" -eq 1 ]
+  [ -z "$RESOLVED_TARGET" ]
+  [ -z "$RESOLVED_MODE" ]
+}
+
+# ---- eza-absent falls back to ls ----
+
+@test "handle_dir: herdr-file-viewer absent + eza absent -> command mode runs ls -la" {
+  handle_dir "adir"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${RESOLVED_CMD[0]}" = "ls" ]
+  [ "${RESOLVED_CMD[1]}" = "-la" ]
+  [ "${RESOLVED_CMD[2]}" = "$FIX/repo/adir" ]
+}
+
+@test "handle_dir: herdr-file-viewer absent + eza present -> command mode runs eza --tree" {
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/eza"
+  chmod +x "$STUB/eza"
+  handle_dir "adir"
+  [ "$RESOLVED_MODE" = "command" ]
+  [ "${RESOLVED_CMD[0]}" = "eza" ]
+  [ "${RESOLVED_CMD[1]}" = "--tree" ]
+  [ "${RESOLVED_CMD[2]}" = "$FIX/repo/adir" ]
+}
+
+# ---- viewer-absent falls back to the popup tree (script-level, real dir.sh) ----
+
+@test "preview-pane: a directory token pages a tree listing when herdr-file-viewer is absent" {
+  export QUICKLOOK_TOKEN="adir"
+  run bash "$PREVIEW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  # the directory never appears as a trailing `less` file argument - that
+  # would be the exec-less-on-a-directory bug the viewer/command arms exist
+  # to prevent; it's piped into less's stdin instead.
+  [[ "$output" != *"LESS_ARGS:"*"adir"* ]]
+}
+
+# ---- viewer-root helper: open-in-viewer.sh drives the real file-viewer
+# pane at the directory when the plugin is installed ----
+
+@test "open-in-viewer: a directory inside the repo sends the goto-path keys" {
+  export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_TOKEN="adir"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -qF "pane send-keys {} f" "$HLOG"
+  grep -qF "pane send-text {} adir" "$HLOG"
+  grep -qF "pane send-keys {} Enter" "$HLOG"
+}
+
+@test "negative control: a directory outside the repo notifies and never sends keys" {
+  export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_TOKEN="$FIX/outside/adir"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -q "notification show quicklook --body outside this repo" "$HLOG"
+  ! grep -q "pane send-keys" "$HLOG"
+}


### PR DESCRIPTION
A directory token opens herdr-file-viewer rooted there (or an eza/ls tree in the popup when
the viewer is absent). New registry handler; file/URL kinds unaffected.

## What changed

- `scripts/handlers/dir.sh`: `match_dir`/`handle_dir` are now real. A token resolving to a
  directory sets `RESOLVED_TARGET` to the absolute dir path. Mode is decided dynamically:
  `viewer` when herdr-file-viewer is installed, else `command` with `eza --tree` (fallback
  `ls -la`). Resolution walks the same as-is/`$PWD`/worktree/`QUICKLOOK_ROOTS` priority order
  path.sh uses, testing `-f` before `-d` at every step and declining outright the instant an
  earlier-priority candidate is a file, so a directory can never shadow a real file.
- `scripts/open-in-viewer.sh`: the `viewer`-mode arm no longer just notifies "not wired yet".
  It's confirmed herdr-file-viewer is installed by the time it gets here (the script's own
  soft-dependency gate already handles the absent case), so it reuses the SAME goto-path
  send-keys sequence the file case uses (`f` -> type `<repo-relative path>` -> Enter) to land
  the viewer's cursor on the directory. Falls into the same containment + control-char checks
  as a file target (a directory outside the repo still gets "outside this repo's tree").
- `scripts/preview-pane.sh`: no behavior change; its `viewer` arm was already the permanent
  safe degrade (it has no way to drive another pane's socket) and stays that way regardless
  of which mode dir.sh emits.
- `scripts/lib.sh`: comment-only accuracy fixes (the `viewer` mode contract block and the
  `HANDLER_KINDS` comment referenced `dir.sh` as a stub; it's real now).
- `README.md`: one row added to the "What it opens" table.
- `tests/handlers-dir.bats` (new): unit + script-level coverage.
- `tests/dispatch-modes.bats`: the one pre-existing viewer-mode test whose name/assertion
  ("notifies and stops, does not send-keys") this change invalidated is corrected to verify
  the new send-keys behavior instead (using the same synthetic-handler fixture as before).

## Post-merge reconciliation

`main` moved twice while this branch was in flight (PR #8 hosts, #9 vcs, #10 recents, #12
dirty-diff all landed). Merged in two steps (base moved again mid-merge) via
`git merge origin/main` in the worktree, two merge commits, no rebase/force-push. One real
conflict, in `scripts/lib.sh`'s `HANDLER_KINDS` line + its preceding comment: kept `main`'s
`vcs`-before-`url` ordering (`(github vcs url dir path)` , a PR URL must reach `vcs.sh`
before the generic `url.sh` catch-all), with `dir` staying in its existing slot; folded in
the reorder rationale from both sides plus a note that `dir` is real now too. Also refreshed
one adjacent stale comment in the same contract block (`command` mode's "no handler emits
this yet (SG-02/vcs.sh is a stub)" , vcs.sh is real on `main` now) while in the area. No
other files conflicted; `open-in-viewer.sh`/`preview-pane.sh`'s `record_open` call sites
(added by the recents PR) merged cleanly and a successful `viewer`-mode open still calls
`record_open` (falls through to the shared tail call in `open-in-viewer.sh`; explicit call
in `preview-pane.sh`'s own arm) , reverified below, not just asserted.

## Run-table

| Check | Command | Result |
|---|---|---|
| Full bats suite (post-merge, integrated tree) | `bats tests/*.bats` | **154/154 pass** (141 from `main` + 13 new in `handlers-dir.bats`, 0 delta from the corrected `dispatch-modes.bats` case since it renames/reasserts an existing test rather than adding one) |
| shellcheck (post-merge) | `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean |
| Final `HANDLER_KINDS` | `grep '^HANDLER_KINDS=' scripts/lib.sh` | `HANDLER_KINDS=(github vcs url dir path)` |

Pre-merge baseline (this branch alone, before `main` moved): 73/73 pass (60 pre-existing + 13
new), shellcheck clean.

## Negative controls (Rung 2)

- A regular file token is declined by `match_dir` (does not shadow `path.sh`).
- A `QUICKLOOK_ROOTS` directory of the same name as a higher-priority local **file** never
  wins , `match_dir` declines and `resolve_any_token` still resolves the file.
- A token matching neither file nor dir falls through cleanly (no globals set).
- A directory **outside** the current repo, in `open-in-viewer.sh`, notifies and never
  reaches the send-keys sequence.

## Coverage delta

- New: `match_dir`/`handle_dir` (both branches: viewer-installed, viewer-absent x
  eza-present/absent), the file-over-dir shadow priority rule, `open-in-viewer.sh`'s new
  viewer-arm send-keys path (in-repo and out-of-repo), `preview-pane.sh`'s tree-listing
  degrade driven by a real (not synthetic) `dir.sh` result.
- Unaffected, reverified on the integrated tree: all 141 cases from `main` (file/URL/github/
  vcs/hosts dispatch, editor escalation, dirty-diff, recents, registry ordering) still pass
  unchanged alongside the 13 new `dir.sh` cases.
