### PR TITLE
feat: d -> git diff toggle in the preview overlay

### DIFF
--- a/lesskey
+++ b/lesskey
@@ -10,7 +10,24 @@
 # mirrors LESSEDIT's own default expansion (current-line + shell-escaped
 # filename); QUICKLOOK_EDITOR_SCRIPT is exported by preview-pane.sh.
 # Verified against a real less 668 session (PR proof).
+#
+# `d` -> git diff: bound to `shell` (the `!` slot), a THIRD distinct action
+# from `o`'s `visual` and `e`'s `pshell`. `shell`'s extra string uses a
+# DIFFERENT %-expansion than pshell/visual: a bare `%` (not the two-char
+# `%g`) is replaced by the current filename , confirmed empirically (a real
+# less session, see the PR proof) to arrive as ONE argv element even with a
+# space in the name, so `%` (unquoted; wrapping it in our own quotes here
+# double-escapes and SPLITS a spaced filename into two args, verified the
+# same way) is correct, not `%g` (that two-char code isn't recognized here
+# and leaves a literal trailing "g" stuck to the filename , also verified
+# the hard way). Runs dirty-diff.sh (a sibling of escalate-editor.sh, path
+# derived from $QUICKLOOK_EDITOR_SCRIPT's directory so preview-pane.sh does
+# not need a new export), which opens a nested less on `git diff`
+# (delta-colored if installed, else less-colored) for a dirty file, or
+# prints a no-changes notice for a clean one. Same `\020` (^P) suppression
+# as `e`. See scripts/dirty-diff.sh for the toggle-back detail.
 #command
 \e\e quit
 o visual
 e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n
+d shell \020"$(dirname "$QUICKLOOK_EDITOR_SCRIPT")/dirty-diff.sh" %\n

--- a/scripts/dirty-diff.sh
+++ b/scripts/dirty-diff.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# dirty-diff.sh: invoked by less as a lesskey `shell` command when the user
+# presses `d` in the quick-look overlay (see ../lesskey). less expands the
+# bare `%` (the `shell` action's own filename token, distinct from pshell's
+# two-char `%g`) to the current filename before typing the extra string in;
+# verified empirically (real less session, PR proof) to arrive as exactly
+# ONE argv element even with a space in the name, the same injection
+# posture escalate-editor.sh relies on %g for with `e`.
+#
+# `d` is the THIRD, still-distinct less action used for shelling out here:
+# `o` claims the single `visual` slot, `e` claims `pshell` (see
+# DECISIONS.md, "SG-06 editor-escalate: `e` key mechanism"). `d` claims
+# `shell` (the default `!` slot) instead of adding a second `pshell`
+# binding, so the three in-popup escape hatches never share one action's
+# single extra-string.
+#
+# A dirty file opens a NESTED less: `git diff` piped through delta when
+# installed, else git's own --color=always rendering piped straight into
+# less -R (the "delta/less-colored" degrade the goal calls for). The nested
+# pager gets a purpose-built temp lesskey where q, Esc-Esc AND d all quit,
+# so pressing `d` again inside the diff view is the toggle back, same as
+# pressing `q`. Quitting hands control back to this script, which exits,
+# and the `\020` (^P) prefix on the outer lesskey binding (see ../lesskey)
+# suppresses the "(press RETURN)" prompt so resuming the file view feels
+# like `e`'s editor round-trip. A clean file has nothing to nest a pager
+# around, so it prints a one-line notice and waits for its own keypress
+# instead (a nested pager would have nothing to show).
+#
+# No env var wiring needed from preview-pane.sh: QUICKLOOK_EDITOR_SCRIPT is
+# already exported there (for `e`) and points at a sibling script in this
+# same scripts/ directory, so ../lesskey derives this script's own path
+# from it instead of preview-pane.sh growing a QUICKLOOK_DIRTY_DIFF_SCRIPT
+# export (out of this sub-goal's scope edges).
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/lib.sh
+. "$script_dir/lib.sh"
+
+load_config
+
+file="${1:-}"
+[ -z "$file" ] && exit 0
+
+repo_dir="$(dirname "$file")"
+diff_output="$(git -C "$repo_dir" diff --color=always -- "$file" 2>/dev/null)"
+
+if [ -z "$diff_output" ]; then
+  printf 'quicklook: no unstaged changes for %s\n' "$file"
+  # Same pause pattern as preview-pane.sh's pause_close(): plain stdin, no
+  # explicit /dev/tty (that would block forever with no controlling
+  # terminal, e.g. under a test harness); a closed/non-tty stdin fails the
+  # read immediately and the sleep gives a bounded, non-interactive pause
+  # instead of no pause at all.
+  read -r -n1 -p "(press any key to continue) " _ 2>/dev/null || sleep 2
+  exit 0
+fi
+
+diff_lesskey="$(mktemp)"
+trap 'rm -f "$diff_lesskey"' EXIT
+cat >"$diff_lesskey" <<'LESSKEY'
+#command
+\e\e quit
+q quit
+d quit
+LESSKEY
+
+if command -v delta >/dev/null 2>&1; then
+  printf '%s\n' "$diff_output" | delta --paging=never | less -R --lesskey-src="$diff_lesskey"
+else
+  printf '%s\n' "$diff_output" | less -R --lesskey-src="$diff_lesskey"
+fi

--- a/tests/dirty-diff.bats
+++ b/tests/dirty-diff.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Script-level tests for scripts/dirty-diff.sh (the lesskey `d` binding's
+# target, see ../lesskey). `git` is stubbed to record its argv ONE ARG PER
+# LINE (proving the target stays a single post-`--` element, no injection,
+# even when it contains a space) and to control the diff output; `less` and
+# `delta` are stubbed no-ops so the nested-pager legs never try to attach a
+# real TTY under bats. The clean-file path's own read-a-key pause degrades to
+# a bounded `sleep 2` with stdin closed (see the script's own comment), so
+# those two tests take ~2s each.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../scripts/dirty-diff.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/repo"
+
+  STUB="$(mktemp -d)"
+  GIT_LOG="$STUB/git.log"
+  # shellcheck disable=SC2016
+  cat >"$STUB/git" <<GITSTUB
+#!/usr/bin/env bash
+{
+  printf 'ARGC=%d\n' "\$#"
+  i=0
+  for a in "\$@"; do
+    i=\$((i + 1))
+    printf 'ARG%d=[%s]\n' "\$i" "\$a"
+  done
+  printf -- '---\n'
+} >> "$GIT_LOG"
+if [ -n "\${DIRTY_DIFF_STUB_OUTPUT:-}" ]; then
+  printf '%s\n' "\$DIRTY_DIFF_STUB_OUTPUT"
+fi
+GITSTUB
+  chmod +x "$STUB/git"
+
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\ncat\n' >"$STUB/less"
+  chmod +x "$STUB/less"
+
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB/herdr"
+  chmod +x "$STUB/herdr"
+
+  # PATH deliberately excludes delta (not stubbed here): these tests exercise
+  # the no-delta fallback by default. A dedicated test below adds a delta
+  # stub to prove the other branch.
+  export PATH="$STUB:/usr/bin:/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+  unset QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+@test "dirty-diff: a dirty file pipes the diff through less (no delta)" {
+  export DIRTY_DIFF_STUB_OUTPUT="+CHANGED LINE"
+  run bash "$SCRIPT" "$FIX/repo/f.txt" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"CHANGED LINE"* ]]
+  # single post-`--` arg: git was called with exactly 6 args, the last one
+  # (ARG6) being the untouched file path, ARG5 being the bare `--` separator.
+  grep -qxF 'ARGC=6' "$GIT_LOG"
+  grep -qxF "ARG5=[--]" "$GIT_LOG"
+  grep -qxF "ARG6=[$FIX/repo/f.txt]" "$GIT_LOG"
+}
+
+@test "dirty-diff: delta is used when present on PATH" {
+  printf '#!/usr/bin/env bash\nprintf "DELTA_RAN\\n"\ncat >/dev/null\n' >"$STUB/delta"
+  chmod +x "$STUB/delta"
+  export DIRTY_DIFF_STUB_OUTPUT="+x"
+  run bash "$SCRIPT" "$FIX/repo/f.txt" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DELTA_RAN"* ]]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+}
+
+@test "dirty-diff: a clean file prints the no-changes notice, no pager" {
+  unset DIRTY_DIFF_STUB_OUTPUT
+  run bash "$SCRIPT" "$FIX/repo/f.txt" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no unstaged changes for $FIX/repo/f.txt"* ]]
+  [[ "$output" != *"LESS_ARGS:"* ]]
+  grep -qxF 'ARGC=6' "$GIT_LOG"
+}
+
+@test "dirty-diff: a filename with a space stays one arg (negative control)" {
+  export DIRTY_DIFF_STUB_OUTPUT="+x"
+  mkdir -p "$FIX/repo/sub dir"
+  run bash "$SCRIPT" "$FIX/repo/sub dir/my file.txt" </dev/null
+  [ "$status" -eq 0 ]
+  grep -qxF 'ARGC=6' "$GIT_LOG"
+  grep -qxF "ARG6=[$FIX/repo/sub dir/my file.txt]" "$GIT_LOG"
+  # and the containing dir (ARG2, the -C value) kept its space too
+  grep -qxF "ARG2=[$FIX/repo/sub dir]" "$GIT_LOG"
+}
+
+@test "dirty-diff: no file argument is a no-op" {
+  run bash "$SCRIPT" </dev/null
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ ! -f "$GIT_LOG" ]
+}


### PR DESCRIPTION
Adds a `d` key in the preview overlay to toggle a dirty file to `git diff -- <file>` and back. Single-arg (injection-safe), degrades without delta.

## Mechanism

`d` is bound to less's `shell` action (the `!` slot) in `lesskey`, a THIRD, distinct action from `o`'s `visual` and `e`'s `pshell` (see DECISIONS.md's SG-06 entry). It runs `scripts/dirty-diff.sh`, which:

- Dirty file: opens a **nested** `less` on `git diff --color=always -- <file>` (piped through `delta` when installed, else `less -R` renders git's own color directly, the delta/less-colored degrade). The nested pager has its own purpose-built temp lesskey where `q`, `Esc-Esc`, **and `d`** all quit, so pressing `d` again inside the diff view is the toggle back, same as `q`. Quitting hands control back to the outer `less` (the `\020`/^P prefix suppresses the "(press RETURN)" prompt, same trick as `e`).
- Clean file: prints a one-line notice and waits for a keypress (same bounded-pause pattern as `preview-pane.sh`'s `pause_close`), no pager opened.

**A real pitfall found and fixed along the way:** `shell`'s extra string does NOT use the same `%g` (prompt-style, shell-escaped) expansion that `pshell`/`visual` use, it uses a bare `%` (single char, replaced with the raw current filename). Using `%g` under `shell` leaves a literal trailing `g` glued to the filename (verified the hard way, see the raw pty dump in the run detail below); wrapping the bare `%` in extra quotes of our own also breaks it (splits a spaced filename into two argv elements). The correct, verified form is unquoted bare `%`.

No new `preview-pane.sh` export needed: `scripts/dirty-diff.sh`'s path is derived at lesskey-time from `$QUICKLOOK_EDITOR_SCRIPT`'s directory (already exported there for `e`), since both scripts live in the same `scripts/` directory.

## Reconciliation

Base was `feat/ql-01-dispatch`; this branch was fast-forwarded onto the current `origin/main` tip (which already carries SG-06's `e` binding plus SG-03/SG-07) before adding the `d` line, so the live `lesskey` now has all three custom bindings coexisting:

```
o visual
e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n
d shell \020"$(dirname "$QUICKLOOK_EDITOR_SCRIPT")/dirty-diff.sh" %\n
```

`git merge-tree` against `origin/main` produced zero conflict markers across the whole tree (README.md/herdr-plugin.toml auto-merged cleanly; `lesskey` itself wasn't touched by any commit in between, so no merge was even needed there).

## Run table

| Check | Command | Result |
|---|---|---|
| shellcheck | `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean, exit 0 |
| bats (new) | `bats tests/dirty-diff.bats` | 5/5 pass |
| bats (full suite) | `bats tests/` | 141/141 pass, 0 regressions |

```
1..5
ok 1 dirty-diff: a dirty file pipes the diff through less (no delta)
ok 2 dirty-diff: delta is used when present on PATH
ok 3 dirty-diff: a clean file prints the no-changes notice, no pager
ok 4 dirty-diff: a filename with a space stays one arg (negative control)
ok 5 dirty-diff: no file argument is a no-op
```

## Real-session proof (real `less` + real `lesskey` + real `git`/`delta`, pty-driven via `expect`)

Four scenarios, each spawning the actual production `lesskey` against a real dirty git working tree:

**1. Dirty file, delta installed, d enters diff, d again toggles back, q quits clean:**
```
spawn less -N --lesskey-src=.../lesskey .../sample.txt
      1 line1
      2 CHANGED
      3 line3
(END)
===MARKER: OUTER FILE VIEW SHOWED===
[user presses d]
Δ sample.txt
──────┐
 1: │
──────┘
│  1 │line1                              │  1 │line1
│  2 │line2 (removed, red)                │    │
│    │                                    │  2 │CHANGED (added, green)
│  3 │line3                              │  3 │line3
===MARKER: d ENTERED NESTED DIFF VIEW (old content visible)===
[user presses d again]
      1 line1
      2 CHANGED
      3 line3
(END)
===MARKER: d AGAIN TOGGLED BACK TO OUTER FILE VIEW===
[user presses q]
===MARKER: SESSION CLOSED CLEANLY===
```

**2. Clean file, d shows the notice, resumes on keypress:**
```
===MARKER: OUTER FILE VIEW SHOWED===
[d] -> "quicklook: no unstaged changes for .../f-clean.txt" / "(press any key to continue)"
===MARKER: CLEAN FILE NOTICE SHOWN===
[space] -> resumes the same file view
===MARKER: RESUMED OUTER FILE VIEW AFTER NOTICE===
[q]
===MARKER: SESSION CLOSED CLEANLY===
```

**3. Dirty file whose name AND containing directory both have a space (`sub dir/tracked file.txt`), real session, not just the bats negative control:**
```
===MARKER: OUTER FILE VIEW SHOWED (space-in-name file)===
[d] -> nested diff shows the old "beta" line
===MARKER: d ENTERED NESTED DIFF VIEW (old content, space-in-name file)===
[q] -> back to the outer file view
===MARKER: q TOGGLED BACK TO OUTER FILE VIEW===
[q]
===MARKER: SESSION CLOSED CLEANLY===
```

**4. Same dirty file, `delta` NOT on PATH, falls back to git's own `--color=always` via `less -R`, same toggle behavior:**
```
===MARKER: OUTER FILE VIEW SHOWED===
[d] -> nested pager shows git's own colored diff (no delta chrome)
===MARKER: d ENTERED NESTED DIFF VIEW (old content visible)===
[d] -> toggles back
===MARKER: d AGAIN TOGGLED BACK TO OUTER FILE VIEW===
[q]
===MARKER: SESSION CLOSED CLEANLY===
```

## Files changed
- `lesskey`, adds the `d shell ...` binding + a comment block (existing `o`/`e`/quit bindings untouched)
- `scripts/dirty-diff.sh` (new), the `d` target script
- `tests/dirty-diff.bats` (new), 5 cases: dirty+delta, dirty+no-delta, clean, space-in-filename negative control, no-arg no-op
