### PR TITLE
test: stop dispatch.bats from popping a real browser window

### DIFF
--- a/tests/dirty-diff.bats
+++ b/tests/dirty-diff.bats
@@ -96,6 +96,28 @@ teardown() {
   grep -qxF "ARG2=[$FIX/repo/sub dir]" "$GIT_LOG"
 }
 
+@test "dirty-diff: an untracked file (never added to git) shows no unstaged changes, same as a clean file" {
+  # Every test above drives a FAKE git that returns a canned
+  # DIRTY_DIFF_STUB_OUTPUT, so none of them prove what `git diff -- <path>`
+  # actually does for a path that was never added to the index (git diff
+  # only shows unstaged changes to TRACKED files, so an untracked file
+  # produces empty output too, same as a clean one - it does not error or
+  # print the file's full contents as a "whole file added" diff). Swap in
+  # the real git binary for this one test to pin that real behavior, not
+  # the stub's assumption of it.
+  printf '#!/usr/bin/env bash\nexec /usr/bin/git "$@"\n' >"$STUB/git"
+  chmod +x "$STUB/git"
+  git -C "$FIX/repo" init -q -b main
+  printf 'tracked\n' >"$FIX/repo/tracked.txt"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm init
+  printf 'never added\n' >"$FIX/repo/untracked.txt"
+  run bash "$SCRIPT" "$FIX/repo/untracked.txt" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no unstaged changes for $FIX/repo/untracked.txt"* ]]
+  [[ "$output" != *"LESS_ARGS:"* ]]
+}
+
 @test "dirty-diff: no file argument is a no-op" {
   run bash "$SCRIPT" </dev/null
   [ "$status" -eq 0 ]

--- a/tests/dispatch-modes.bats
+++ b/tests/dispatch-modes.bats
@@ -121,6 +121,29 @@ teardown() {
   [[ "$output" == *"not a file I can find"* ]]
 }
 
+@test "preview-pane command mode: a real vcs #ref whose gh lookup fails (nonexistent PR) degrades to a paged error, not a crash" {
+  # Not the synthetic zzz-test-only handler this file otherwise uses - this
+  # drives the REAL vcs.sh path (a #ref -> gh pr view, see handlers-vcs.bats)
+  # through the full preview-pane.sh dispatch, with gh stubbed to fail the
+  # way it does for a PR number that doesn't exist. render_command_in_pager
+  # pipes "$@" 2>&1 into less, so a failing gh's stderr must still reach the
+  # pager and the SCRIPT must still exit 0 - the exit code the pane script
+  # reports is less's, not gh's, and that must never look like a crash.
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\ncat\n' >"$STUB/less"
+  chmod +x "$STUB/less"
+  cat >"$STUB/gh" <<'GH'
+#!/usr/bin/env bash
+echo "GraphQL: Could not resolve to a PullRequest with the number of 999999." >&2
+exit 1
+GH
+  chmod +x "$STUB/gh"
+  export QUICKLOOK_TOKEN="#999999"
+  run bash "$PREVIEW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"Could not resolve to a PullRequest"* ]]
+}
+
 # ---- preview-pane.sh: viewer mode ----
 
 @test "preview-pane viewer mode: never reaches exec less on the directory" {

--- a/tests/dispatch.bats
+++ b/tests/dispatch.bats
@@ -19,11 +19,17 @@ setup() {
   git -C "$FIX/myrepo" -c user.email=t@t -c user.name=t commit -qm fix
 
   # stubs: `less` prints its args (so the target path is visible); `herdr`
-  # answers config-dir with empty; `bat` absent so preview-pane takes the less path.
+  # answers config-dir with empty; `bat` absent so preview-pane takes the less path;
+  # `open` logs the URL it was asked to open instead of actually launching a
+  # browser (the browser-fallback test below asserts against OPEN_LOG). Without
+  # this stub, a browser-mode token on a real macOS box would resolve PATH's
+  # /usr/bin/open and pop a real foreground browser window during `bats tests/`.
   STUB="$(mktemp -d)"
+  OPEN_LOG="$(mktemp)"
   printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\n' > "$STUB/less"
   printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/herdr"
-  chmod +x "$STUB/less" "$STUB/herdr"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$1" >> "%s"\n' "$OPEN_LOG" > "$STUB/open"
+  chmod +x "$STUB/less" "$STUB/herdr" "$STUB/open"
 
   cd "$FIX/myrepo"
   # keep git/coreutils reachable but force our less + no bat
@@ -38,6 +44,7 @@ setup() {
 teardown() {
   cd /
   rm -rf "$FIX" "$STUB"
+  rm -f "$OPEN_LOG"
 }
 
 @test "dispatch: github blob URL opens the local file at the line" {
@@ -57,9 +64,13 @@ teardown() {
   [[ "$output" == *"+2"* ]]
 }
 
-@test "dispatch: a github URL with no matching local checkout does not open a file" {
+@test "dispatch: a github URL with no matching local checkout falls back to the browser, not a file" {
   export QUICKLOOK_TOKEN="https://github.com/owner/ghostrepo/blob/main/nope.md"
   run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
   # no local file resolved -> browser fallback path, less never called with a target
   ! [[ "$output" == *"LESS_ARGS"*"nope.md"* ]]
+  # and it IS the browser fallback, not a silent no-op: url_open (stubbed as
+  # `open` above) received exactly the original ghost URL, unmodified.
+  [ "$(cat "$OPEN_LOG")" = "https://github.com/owner/ghostrepo/blob/main/nope.md" ]
 }

--- a/tests/quicklook.bats
+++ b/tests/quicklook.bats
@@ -218,3 +218,26 @@ teardown() {
   run unsafe_relpath "a/../b";       [ "$status" -eq 0 ]
   run unsafe_relpath "a/b/c.md";     [ "$status" -eq 1 ]
 }
+
+# The literal-`..`/`//` smuggles above are only half the surface: GH_REST is
+# urldecoded BEFORE unsafe_relpath ever sees it (map_github_url calls
+# urldecode, then resolve_github's caller passes the decoded GH_REST on), so
+# an ATTACKER-SUPPLIED %-encoded traversal must be caught too. This pins the
+# decode-then-check ORDER end to end through resolve_any_token (not just the
+# already-decoded unit above) - the one regression that would silently
+# reopen the smuggle is someone moving the unsafe_relpath check earlier than
+# the urldecode call, or adding a new host mapper that forgets to decode
+# first.
+
+@test "resolve_any_token: URL-encoded dotdot traversal (%2e%2e) in a github blob URL is refused, falls back to browser" {
+  resolve_any_token "https://github.com/o/repo/blob/main/%2e%2e/%2e%2e/etc/passwd"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://github.com/o/repo/blob/main/%2e%2e/%2e%2e/etc/passwd" ]
+}
+
+@test "resolve_any_token: URL-encoded absolute-slash smuggle (%2f) in a github blob URL is refused, falls back to browser" {
+  resolve_any_token "https://github.com/o/repo/blob/main%2f..%2f..%2fetc%2fpasswd"; rc=$?
+  [ "$rc" -eq 0 ]
+  [ "$RESOLVED_MODE" = "browser" ]
+}

--- a/tests/recents.bats
+++ b/tests/recents.bats
@@ -79,6 +79,23 @@ teardown() {
   [ "${#lines[@]}" -eq 3 ]
 }
 
+@test "record_open: at the REAL production default (20, not an overridden small cap), the 21st entry evicts the 1st" {
+  # The cap test above overrides RECENTS_MAX=3 for speed; that never proves
+  # the actual shipped default (QUICKLOOK_RECENTS_MAX unset -> 20 in lib.sh)
+  # evicts at the right boundary. setup() already sets RECENTS_MAX=20 to
+  # match that default literally (not a stand-in small number), so this
+  # pins the real cap: entry 21 must push entry 1 off, entries 2-21 survive.
+  local i
+  for i in $(seq 1 21); do
+    record_open "token-$i"
+  done
+  run recents_list
+  [ "${#lines[@]}" -eq 20 ]
+  [ "${lines[0]}" = "token-21" ]
+  [ "${lines[19]}" = "token-2" ]
+  ! grep -qxF "token-1" "$(recents_state_file)"
+}
+
 @test "record_open: empty token is a no-op (no file created)" {
   record_open ""
   [ ! -e "$(recents_state_file)" ]

--- a/tests/registry.bats
+++ b/tests/registry.bats
@@ -63,11 +63,48 @@ teardown() {
   [ "$RESOLVED_TARGET" = "https://github.com/o/ghostrepo/blob/main/nope.md" ]
 }
 
+@test "registry: non-http(s) schemes never reach mode=browser (url_open only ever fires on an http/https token)" {
+  # classify_token's url case is an explicit http://|https:// prefix match;
+  # everything else (including a scheme-looking string) falls to the path
+  # catch-all. This pins that a clipboard payload spoofing a URL scheme -
+  # javascript: (XSS-style), file:// (local-disclosure-style), data: (HTML
+  # payload), a non-browser scheme like ftp:// - can NEVER be handed to
+  # url_open via mode=browser; each is treated as an ordinary (unresolvable)
+  # path token instead, rc 1, no target set. The one regression this closes
+  # is classify_token's case pattern ever widening to a bare `*:*` match.
+  local t
+  for t in 'javascript:alert(document.cookie)' \
+           'file:///etc/passwd' \
+           'data:text/html,<script>alert(1)</script>' \
+           'ftp://evil.example/x'; do
+    rc=0
+    resolve_any_token "$t" || rc=$?
+    [ "$rc" -eq 1 ]
+    [ "$RESOLVED_MODE" != "browser" ]
+    [ -z "$RESOLVED_MODE" ]
+  done
+}
+
 # ---- an unmatched token falls through ----
 
 @test "registry: an unresolvable path token returns rc 1, no target set" {
   rc=0
   resolve_any_token "no/such/file.md" || rc=$?
+  [ "$rc" -eq 1 ]
+  [ -z "$RESOLVED_TARGET" ]
+  [ -z "$RESOLVED_MODE" ]
+}
+
+@test "registry: a whitespace-only token (bypasses the pane scripts' own [ -z ] empty guard) is a clean no-match, not a crash" {
+  # preview-pane.sh/open-in-viewer.sh only special-case a genuinely EMPTY
+  # raw token before ever calling resolve_any_token; "   " is non-empty so
+  # it reaches here untouched (QUICKLOOK_TOKEN is never trimmed the way
+  # clip_read's xargs trims a real clipboard read). It must fall through
+  # every handler (git even has no candidate path literally named "   ")
+  # and land on rc 1 with no RESOLVED_MODE set, same as any other unmatched
+  # path token above - never a spurious match or a crash.
+  rc=0
+  resolve_any_token "   " || rc=$?
   [ "$rc" -eq 1 ]
   [ -z "$RESOLVED_TARGET" ]
   [ -z "$RESOLVED_MODE" ]


### PR DESCRIPTION
## Summary

- Han's complaint: "there's one test that keeps open the git weblink at foreground, that's so annoying, please find another way to test it." Traced to `tests/dispatch.bats`'s "a github URL with no matching local checkout" case: its `STUB` dir never stubbed `open`, so `PATH` fell through to the real `/usr/bin/open` and launched a real foreground browser tab during `bats tests/`.
- Fix: stub `open` in that file's `setup()`, matching the idiom every other script-level bats file already uses (`tests/recents.bats` had this right). The stub now logs the URL it receives, and the affected test asserts the exact URL received, stronger, not just quieter.
- Coverage pass: 7 new cases pinning real, previously-untested failure modes (see COVERAGE-DELTA below). Zero production (`scripts/*.sh`) changes, everything here is test-only.
- Decisions logged: `ops-toolkit/experiments/herdr-quicklook/megagoals/quicklook-v03/DECISIONS.md`, SG-10 entry (private repo, not part of this diff).

## Run-table

| Command | Exit | Result |
|---|---|---|
| `bats tests/dispatch.bats` (post-fix, isolated) | 0 | 3 ok, 0 not ok |
| `bats tests/` (full suite, post-fix) | 0 | 161 ok, 0 not ok |
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | 0 | clean, no output |

Full-suite tail (verbatim, `bats tests/`):

```
ok 154 registry: an unresolvable github URL falls back to mode=browser
ok 155 registry: non-http(s) schemes never reach mode=browser (url_open only ever fires on an http/https token)
ok 156 registry: an unresolvable path token returns rc 1, no target set
ok 157 registry: a whitespace-only token (bypasses the pane scripts' own [ -z ] empty guard) is a clean no-match, not a crash
ok 158 registry: github is checked before url (github wins for a github-shaped URL)
ok 159 registry: a higher-priority handler always wins over a later one, any token
ok 160 registry: every scripts/handlers/*.sh exports match_<kind> and handle_<kind>
ok 161 registry: HANDLER_KINDS has path last (the catch-all must not shadow later kinds)
```

Plan line: `1..161`. Counts: `161 ok`, `0 not ok`.

## COVERAGE-DELTA

| Cases before | Cases after | Delta |
|---|---|---|
| 154 | 161 | +7 |

New cases, each pinning a distinct failure mode:

1. **`tests/dispatch.bats`** — strengthened (not just re-quieted): the browser-fallback test now asserts `url_open` received the exact ghost URL via the new `open` stub, in addition to the existing "less never got the file" negative.
2. **`tests/quicklook.bats`** ×2 — URL-encoded traversal (`%2e%2e`, `%2f`) through `github.sh`'s blob-URL path is refused end-to-end via `resolve_any_token`. `map_github_url` decodes `GH_REST` before `unsafe_relpath` checks it; every prior traversal test used the already-decoded literal form, so the decode-then-check order itself was never proven.
3. **`tests/registry.bats`** — a whitespace-only token (`"   "`) bypasses the pane scripts' own `[ -z ]` empty guard (only a genuinely empty string is caught there) and reaches `resolve_any_token` raw; pinned as a clean no-match, not a crash.
4. **`tests/registry.bats`** — non-http(s) schemes (`javascript:`, `file://`, `data:`, `ftp://`) never classify as `url`/`browser` mode, so a clipboard payload spoofing a URL scheme can never reach `url_open`.
5. **`tests/recents.bats`** — `record_open`'s cap at the real production default (20), not the `RECENTS_MAX=3` override the existing speed-focused test uses; pushes 21 entries and checks the eviction boundary.
6. **`tests/dirty-diff.bats`** — a genuinely untracked file (never `git add`ed) degrades to the same "no unstaged changes" message as a clean file, proven against the real `git` binary (every other case in this file drives a fake `git` returning a canned diff).
7. **`tests/dispatch-modes.bats`** — a failing `gh pr view` (nonexistent PR) degrades to a paged error message, not a crash; `render_command_in_pager`'s exit code is `less`'s, not the wrapped command's, and nothing previously exercised `gh` failing (only `git show` failing was covered, since `git` is local and deterministic).

## Test plan

- [x] `bats tests/dispatch.bats` in isolation, confirm 3/3 green, no browser window opened
- [x] `bats tests/` full suite, confirm 161/161 green
- [x] `shellcheck -x scripts/*.sh scripts/handlers/*.sh` clean
- [x] Confirmed zero `scripts/*.sh` diffs (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
