### PR TITLE
docs: v0.3 README/DESIGN/CHANGELOG + a Han-triggered release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## Unreleased
 
-- `e` in the preview overlay opens the current file, at the current line, in `$EDITOR` (config `QUICKLOOK_EDITOR` beats `$EDITOR` beats `zed --wait`); the overlay resumes once the editor exits. Bound via less's `pshell` shell-escape (a `^P`-suppressed `#` command), since the single `visual` slot is already `o`'s.
-- GitHub blob/raw URLs (`github.com/o/r/blob/<ref>/<path>#L<n>`, `/raw/`, `raw.githubusercontent.com`) open the LOCAL checkout at the line when one resolves (current repo by name, plain resolve chain, `QUICKLOOK_ROOTS/<repo>`); refs containing `/` are handled by successive splits; unresolvable URLs fall back to the browser. `#L42-L60` ranges keep the start line. A crafted URL cannot smuggle an absolute or `..`-traversal path (guarded).
-- Agent-push: token priority is `$QUICKLOOK_TOKEN` env > script argument > clipboard, in both actions; `preview` forwards an argument into the pane via `--env`. Agents can now put a file on the human's screen without touching the clipboard.
+- Token dispatch refactored into a `scripts/lib.sh` entry point (`resolve_any_token`) plus a one-file-per-kind handler registry (`scripts/handlers/*.sh`); `RESOLVED_MODE` widened to `file` / `browser` / `command` / `viewer` so a token kind can render as a paged command or root a directory, not just open a file or a URL. Internal refactor, no user-facing behavior change on its own. (#7)
+- GitHub blob/raw URLs (`github.com/o/r/blob/<ref>/<path>#L<n>`, `/raw/`, `raw.githubusercontent.com`) open the LOCAL checkout at the line when one resolves (current repo by name, plain resolve chain, `QUICKLOOK_ROOTS/<repo>`); refs containing `/` are handled by successive splits; unresolvable URLs fall back to the browser. `#L42-L60` ranges keep the start line. A crafted URL cannot smuggle an absolute or `..`-traversal path (guarded). (#5)
+- GitLab (`gitlab.com/o/r/-/blob/<ref>/<path>#L<n>`) and Bitbucket (`bitbucket.org/o/r/src/<ref>/<path>#lines-<n>`) blob URLs resolve the same way, sharing the GitHub resolver and traversal guard. (#8)
+- `e` in the preview overlay opens the current file, at the current line, in `$EDITOR` (config `QUICKLOOK_EDITOR` beats `$EDITOR` beats `zed --wait`); the overlay resumes once the editor exits. Bound via less's `pshell` shell-escape (a `^P`-suppressed `#` command), since the single `visual` slot is already `o`'s. (#6)
+- `d` in the preview overlay opens a nested pager on `git diff` for the current file (delta-colored when installed, else git's own `--color=always`); pressing `d` again (or `q`) closes the diff and resumes the file view. Bound via less's `shell` action (the third and last available shell-escape slot, after `visual`/`o` and `pshell`/`e`); a clean file prints a no-changes notice instead of an empty diff. (#12)
+- A bare commit SHA opens `git show` for that commit; `#123` or a GitHub PR URL opens `gh pr view`; both render in the popup's pager (`RESOLVED_MODE=command`). The token is always passed as a single argv element, never interpolated into a shell string. (#9)
+- A directory token opens herdr-file-viewer rooted there when that plugin is installed, else an `eza --tree` (fallback `ls -la`) listing pages in the popup. (#11)
+- `prefix+shift+v` reopens the most recently quick-looked path/URL/command, or fzf-picks among the last 20 when fzf is installed; the log is deduped (reopening bumps an entry back to the front), bounded, and lives outside any git repo at `${XDG_STATE_HOME:-~/.local/state}/herdr-quicklook/recents`. (#10)
+- Agent-push: token priority is `$QUICKLOOK_TOKEN` env > script argument > clipboard, in both actions; `preview` forwards an argument into the pane via `--env`. Agents can now put a file on the human's screen without touching the clipboard. (#3)
 - `resolve` always returns an absolute path (fixes a latent case where a cwd-relative hit failed open-in-viewer's repo-containment check).
 - `open-in-viewer` refuses filenames containing control characters before typing them into the file-viewer TUI.
-- bats test suite (`bats tests/`) over the resolve chain, token parsing, and priority; shellcheck + bats documented as the dev loop.
+- bats test suite (`bats tests/`) over the resolve chain, token parsing, priority, the handler registry, and every in-popup key; shellcheck + bats documented as the dev loop. 154 cases across the series.
 
 ## 0.1.0 (2026-07-16)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,242 @@
+# DESIGN.md
+
+Architecture of herdr-quicklook: how a clipboard token turns into a rendered
+file, a browser tab, or a paged command. User-facing behavior lives in
+[README.md](README.md); this is the "how", for anyone extending it.
+
+## Token flow
+
+Every action (`preview`, `open-in-viewer`, `recents`) ends up calling the
+same two functions in `scripts/lib.sh`: `pick_token` to get a raw string,
+`resolve_any_token` to classify and resolve it.
+
+```mermaid
+flowchart TD
+    A["$QUICKLOOK_TOKEN env / script arg / clipboard"] --> B["pick_token()"]
+    B --> C["resolve_any_token(raw)"]
+    C --> D{"walk HANDLER_KINDS\ngithub -> vcs -> url -> dir -> path"}
+    D -->|"match_github"| H1["github.sh\n(GitHub / GitLab / Bitbucket blob URLs)"]
+    D -->|"match_vcs"| H2["vcs.sh\n(SHA / #123 / PR URL)"]
+    D -->|"match_url"| H3["url.sh\n(any other http(s)://)"]
+    D -->|"match_dir"| H4["dir.sh\n(a directory, not a file)"]
+    D -->|"match_path (catch-all)"| H5["path.sh\n(filesystem path, optional :line)"]
+    H1 --> R["RESOLVED_TARGET / RESOLVED_LINE /\nRESOLVED_MODE / RESOLVED_CMD"]
+    H2 --> R
+    H3 --> R
+    H4 --> R
+    H5 --> R
+    R --> S{"pane script's RESOLVED_MODE case"}
+    S -->|"file"| T1["less renders the file\n(bat as LESSOPEN)"]
+    S -->|"browser"| T2["url_open() -> default browser"]
+    S -->|"command"| T3["render_command_in_pager RESOLVED_CMD\n(git show / gh pr view / eza --tree)"]
+    S -->|"viewer"| T4["herdr-file-viewer pane,\nor an eza/ls tree degrade"]
+    C -->|"rc 1: no handler matched\n(preview-pane.sh only)"| U["handle_bare_name()\nfuzzy git-ls-files + fzf pick"]
+```
+
+`resolve_any_token` returns 1 only when a `path`-shaped token's `resolve()`
+can't find a file anywhere (github/url/vcs/dir always resolve one way or
+another: worst case `github.sh`/`url.sh` fall back to `browser` mode). Only
+`preview-pane.sh` has a TTY to run an interactive fzf pick in, so the
+bare-name fallback is opt-in and called directly there, never wired into
+`HANDLER_KINDS`: wiring it into the registry would have changed
+`open-in-viewer.sh`'s behavior too, which never had the fuzzy fallback
+before this architecture existed.
+
+## Handler registry
+
+A token *kind* lives entirely in one file, `scripts/handlers/<kind>.sh`,
+and exports exactly two functions:
+
+```sh
+match_<kind> <raw>    # rc 0 if this handler owns the token's shape.
+                      # No resolution work, no side effects.
+handle_<kind> <raw>   # resolves the token. On success sets RESOLVED_TARGET /
+                      # RESOLVED_LINE / RESOLVED_MODE (+ RESOLVED_CMD for
+                      # command mode) and returns 0. Returns 1 if it owns the
+                      # shape but couldn't resolve a target.
+```
+
+`scripts/lib.sh` auto-sources every `scripts/handlers/*.sh` at source time
+(a glob loop), so a new kind never touches the sourcing mechanism, only
+`HANDLER_KINDS` and the new file:
+
+```sh
+HANDLER_KINDS=(github vcs url dir path)
+```
+
+**Order matters.** `resolve_any_token` walks the array and dispatches to the
+first `match_<kind>` that accepts the token. Two rules keep that safe:
+
+- `path` is the catch-all (`match_path` always returns 0) and **must stay
+  last**, or every later-registered kind becomes dead code.
+- A more specific, host-aware kind checks before a generic one. `vcs` sits
+  before `url` because a GitHub PR URL (`https://github.com/o/r/pull/42`)
+  structurally also matches `url.sh`'s generic `http(s)://` predicate; if
+  `url` were checked first it would claim every PR URL for the browser
+  before `vcs` ever got a look.
+
+### RESOLVED_MODE: the four render shapes
+
+| Mode | Meaning | Set by | Pane-script behavior |
+|---|---|---|---|
+| `file` | `RESOLVED_TARGET` is a local path (`RESOLVED_LINE` optional) | `github.sh`, `path.sh` | rendered/driven directly |
+| `browser` | `RESOLVED_TARGET` is a URL | `github.sh` (no local checkout), `url.sh` | `url_open "$RESOLVED_TARGET"` |
+| `command` | `RESOLVED_CMD` (a bash **array**, not a string) is the argv to run; its output is paged | `vcs.sh`, `dir.sh` (no viewer installed) | `preview-pane.sh` pages it directly (`render_command_in_pager`); `open-in-viewer.sh` has no pager, so it re-invokes the same raw token through `open-preview.sh` |
+| `viewer` | `RESOLVED_TARGET` is a directory to root the file-viewer at | `dir.sh` (viewer installed) | `open-in-viewer.sh` reuses the file case's goto-path send-keys sequence; `preview-pane.sh` can't drive another pane's socket, so it permanently degrades to paging an `eza --tree`/`ls -la` listing |
+
+`RESOLVED_CMD` is a real array, never a flattened string, because a
+command-mode handler runs an external tool (`git show`, `gh pr view`)
+against **untrusted clipboard input**. Rebuilding an argv from a joined
+string would reopen exactly the shell-injection surface the mode exists to
+avoid, see `vcs.sh`'s anchored regexes and its own comment on `git show
+--end-of-options` vs `git show --`.
+
+### Adding a new kind
+
+A purely additive kind (mode `file` or `browser` only) needs zero edits to
+either pane script:
+
+1. `scripts/handlers/<kind>.sh` with `match_<kind>` / `handle_<kind>`.
+2. One line: insert `<kind>` into `HANDLER_KINDS` in `scripts/lib.sh`, before `path`.
+
+A kind that wants to emit `command` or `viewer` for the first time (or that
+needs a token-kind-specific interactive fallback, like `bare-name.sh`) is
+the one exception where the pane scripts' own `RESOLVED_MODE` case blocks
+may need a look, those bodies are the single place all four modes render.
+
+## The lesskey three-slot map
+
+The preview overlay is `less`, driven by a `lesskey`-compiled binding file.
+`less` exposes exactly **three** independent slots that can shell out to an
+external script, and this plugin uses all three:
+
+```
+┌─────┬────────────────┬───────────────────────┬──────────────────────────────┐
+│ Key │ less action     │ Script                │ How it resumes                │
+├─────┼────────────────┼───────────────────────┼──────────────────────────────┤
+│ o/v │ visual (1 slot) │ escalate.sh            │ kills the parent less          │
+│     │  $VISUAL        │  -> open-in-viewer.sh  │ (hand-off, overlay closes)     │
+├─────┼────────────────┼───────────────────────┼──────────────────────────────┤
+│ e   │ pshell (`#`)    │ escalate-editor.sh     │ `^P`-suppressed "done" prompt, │
+│     │                 │  -> $EDITOR            │ overlay resumes on exit        │
+├─────┼────────────────┼───────────────────────┼──────────────────────────────┤
+│ d   │ shell (`!`)     │ dirty-diff.sh          │ `^P`-suppressed "done" prompt, │
+│     │                 │  -> nested less, git   │ `d`/`q`/Esc-Esc all close the  │
+│     │                 │     diff (or delta)    │ nested pager, resuming the file│
+└─────┴────────────────┴───────────────────────┴──────────────────────────────┘
+```
+
+Three distinct actions, not three bindings of the same one, because `less`
+only lets one script own `visual`. `o` claimed it first (escalating to
+herdr-file-viewer needs the file+line `%f`/`%lm` expansion that `visual`
+gives for free); `e` and `d` each needed their own independent shell-escape,
+so they moved to `pshell` and `shell` respectively, the only two other
+slots `less` has. **A fourth in-popup key would have nowhere left to bind**
+without inventing a dispatcher script that reads a flag file, or similar;
+that has not been needed yet.
+
+The two shell-escape slots (`pshell`/`shell`) use **different** `%`-expansion
+syntax: `pshell` uses the two-char prompt-style codes (`%g`, `%lm`, …, the
+same expansion `visual` gets); `shell` uses a bare, single-char `%` for the
+current filename. Mixing them up either glues a stray `g` onto the filename
+or splits a spaced filename into two argv elements, both were hit and fixed
+empirically while building `d` (a real `less` session, not just a unit
+test); see `scripts/dirty-diff.sh`'s header comment for the exact failure
+modes.
+
+`\020` (octal for `^P`, CONTROL-P) prefixes both the `pshell` and `shell`
+extra strings. Without it, a shell-escape prints `"...done (press
+RETURN)"` and waits for a keypress before resuming the pager; `^P`
+suppresses that prompt so `e` and `d` resume exactly as seamlessly as `o`'s
+hand-off does.
+
+## Panes and actions topology
+
+`herdr-plugin.toml` declares three actions (run by the herdr server with
+**no TTY**) and two overlay panes (each a real TTY):
+
+```mermaid
+flowchart LR
+    subgraph Actions["actions (no TTY)"]
+        A1["preview"]
+        A2["open-in-viewer"]
+        A3["recents"]
+    end
+    subgraph Panes["overlay panes (real TTY)"]
+        P1["preview pane\n(preview-pane.sh)"]
+        P2["recents-pick pane\n(recents-pane.sh)"]
+    end
+    A1 -- "plugin pane open" --> P1
+    A3 -- "plugin pane open" --> P2
+    P2 -- "exec, SAME pane/TTY\n(not a third pane)" --> P1
+    A2 -. "herdr socket:\nsend-keys / send-text\nto another plugin's pane" .-> V["herdr-file-viewer pane\n(a different plugin)"]
+```
+
+`open-in-viewer` and `recents` have no TTY of their own to run interactive
+work in (`bat`'s fzf pick, `less`), so each either opens its own overlay
+pane (`recents`) or drives an *existing* pane over the herdr socket
+(`open-in-viewer`, which never opens a pane of its own, it manipulates
+`herdr-file-viewer`'s). `recents-pane.sh`, once it has a chosen token,
+`exec`s `preview-pane.sh` in the same process/TTY rather than opening a
+third pane, reusing the resolve+render+`record_open` path verbatim means a
+reopened entry bumps to the front of the log exactly like a fresh open,
+with no separate "is this a reopen" bookkeeping.
+
+## Recents state
+
+Every successful open, `file`, `browser`, or `command`/`viewer`, is
+recorded to a small, bounded, deduped log:
+
+```
+${XDG_STATE_HOME:-~/.local/state}/herdr-quicklook/recents
+```
+
+One raw token per line, **most-recent-last** on disk (`recents_list` reverses
+it for readers). Writes are atomic: a temp file in the same directory, then
+`mv -f` over the real file, so a concurrent reader never sees a
+half-written log.
+
+Two guards make this safe to run unattended:
+
+- **`recents_path_is_safe`**: walks every ancestor directory of the state
+  file looking for a `.git` entry (a directory for a normal repo, a file
+  for a worktree/submodule gitlink). If any ancestor is a git working tree,
+  `record_open` refuses to write. This is the hard rule: recents state must
+  never land inside a repo, however `XDG_STATE_HOME`/`$HOME` ends up
+  configured on a given machine.
+- **Best-effort, always**: an unwritable state dir, a failed guard check, or
+  any write failure is silently swallowed. Recording a "recent" must never
+  block the open it is recording.
+
+## Security notes (cross-cutting, not one handler's job)
+
+- **`command`-mode argv safety**: `RESOLVED_CMD` is always a bash array built
+  by quoting the raw token as one element (`git show --end-of-options
+  "$sha"`, `gh pr view "$n"`), never a string later re-split. `vcs.sh`'s
+  regexes are anchored (`^...$`) so an accepted token can never itself look
+  like a flag, and the argv-array contract holds independent of that regex
+  (see `tests/handlers-vcs.bats`' "argv shape control" case, which calls
+  `handle_vcs` directly, bypassing `match_vcs`, to prove the quoting itself
+  is what keeps a space-containing value one argv element).
+- **`--end-of-options`, not `--`**: `git show --end-of-options "$sha"`
+  rejects a hex-shaped-but-fake SHA loudly. `git show -- "$sha"` would
+  instead silently reinterpret the bad SHA as a pathspec on `HEAD` and print
+  a real-looking (wrong) commit, worse than an error, because it looks
+  like data.
+- **Path-traversal guard** (`unsafe_relpath`): a GitHub/GitLab/Bitbucket URL
+  path is always repo-relative; an absolute or `..`-traversal candidate is a
+  smuggled path and is refused before it ever reaches a `-f` test.
+- **Control-character guard**: `open-in-viewer.sh` refuses a resolved
+  filename containing a control byte (e.g. an embedded newline) before
+  typing it into the file-viewer TUI over the herdr socket, a control byte
+  there would inject extra keystrokes into that plugin.
+
+## Testing
+
+`bats tests/` sources `scripts/lib.sh` directly for unit-level coverage
+(the resolve chain, token parsing, priority) and runs the actual scripts
+under `run`/stubbed tools for script-level coverage (dispatch wiring,
+pane-script `RESOLVED_MODE` case blocks, real `lesskey`/`less` sessions for
+the in-popup keys). `shellcheck -x scripts/*.sh scripts/handlers/*.sh` is
+the companion static check. Both run in `./scripts/release.sh` before it
+mutates anything.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A few things that make it more than a pager:
 
 | Clipboard content | What happens |
 |---|---|
-| a GitHub **blob/raw URL** (`github.com/o/r/blob/main/src/x.go#L42`) | Opens the file in your **local checkout** at that line when one exists (current repo, worktrees, `QUICKLOOK_ROOTS/<repo>`); otherwise the browser |
+| a GitHub / GitLab / Bitbucket **blob or raw URL** (`github.com/o/r/blob/main/x.go#L42`, `gitlab.com/o/r/-/blob/main/x.go#L42`, `bitbucket.org/o/r/src/main/x.go#lines-42`, `raw.githubusercontent.com/…`) | Opens the file in your **local checkout** at that line when one exists (current repo, worktrees, `QUICKLOOK_ROOTS/<repo>`); otherwise the browser |
+| a bare commit **SHA** (7-40 hex chars) | `git show` for that commit, paged in the popup |
+| `#123`, or a GitHub **PR URL** (`github.com/o/r/pull/123`) | `gh pr view`, paged in the popup |
 | any other `https://…` / `http://…` | Opens in your default browser |
 | `/absolute/path/file.md` | Preview (or viewer) at that file |
 | `relative/path/file.md` | Resolved against the focused pane's cwd, then its git root |
@@ -30,7 +32,7 @@ A few things that make it more than a pager:
 | `filename.md` (bare, no directory) | Repo-wide search of tracked files: one hit opens; several hits open an fzf pick |
 | `some/dir` (a directory, not a file) | Opens herdr-file-viewer rooted there when installed, else an `eza --tree`/`ls -la` listing in the popup |
 
-Resolution runs top-down: exact paths win before any fuzzy matching, and the first hit stops the chain.
+Resolution runs top-down: exact paths win before any fuzzy matching, and the first hit stops the chain. See [DESIGN.md](DESIGN.md) for how a token kind maps to its handler.
 
 ## Install
 
@@ -66,6 +68,7 @@ Reload with `herdr server reload-config`.
 | `q` or `Esc Esc` | Close the overlay (a bare Esc cannot coexist with arrow-key scrolling in less, so quit is double-Esc) |
 | `o` (or `v`) | **Escalate**: close the overlay and open this file, at the same line, in the herdr-file-viewer pane (when that plugin is installed) |
 | `e` | **Edit**: open this file, at the same line, in `$EDITOR` (config-overridable, default `zed --wait`); the overlay resumes when the editor exits |
+| `d` | **Diff**: open a nested pager on `git diff` for this file (delta-colored if installed, else git's own color); press `d` again (or `q`) to close it and resume the file view. A clean file just prints a no-changes notice |
 | `/`, `n`, `N` | Search inside the file |
 | arrows / PgUp / PgDn | Scroll |
 
@@ -114,6 +117,22 @@ shellcheck -x scripts/*.sh && bats tests/   # brew install shellcheck bats-core
 
 The bats suite sources `scripts/lib.sh` directly (temp git repo + worktree + roots fixture), so it exercises the exact production resolve chain.
 
+## Release
+
+Maintainer-only, run by hand, no CI trigger:
+
+```sh
+./scripts/release.sh 0.3.0
+```
+
+One command: sanity checks (clean tree, on `main`, shellcheck + bats green, tag
+doesn't already exist), bumps `herdr-plugin.toml`'s version, moves
+`CHANGELOG.md`'s `## Unreleased` section into a dated `## 0.3.0 (…)` section,
+commits `chore(release): v0.3.0`, tags it, pushes commit + tag, and cuts a
+GitHub release (`gh release create`) with that changelog section as the notes
+body. Refuses to run against a dirty tree, a non-`main` branch, or an
+already-tagged version.
+
 ## Demo
 
 ![quick look: copy a path, pop the file at the right line](demo/preview.gif)
@@ -135,10 +154,12 @@ Everything else is optional, and the plugin degrades instead of failing:
 
 ## How it works
 
-- **preview** opens a plugin overlay pane (a real TTY) that reads the clipboard, resolves the token, and renders it with `less` (bat as the `LESSOPEN` colorizer). Esc-to-quit ships via a `lesskey` file. `o` escalates via less's single `visual` slot (`$VISUAL` -> `escalate.sh`); `e` cannot reuse that slot, so it is bound directly to less's `pshell` shell-escape action instead (`escalate-editor.sh`, with a `^P` extra-string prefix that suppresses the shell-escape's normal "done" prompt so the overlay resumes cleanly).
-- **open-in-viewer** has no goto-file API to call, so it drives the viewer's own keys over the herdr socket: it ensures a `Files` pane exists in the focused tab (opening one via the viewer's action if needed), then sends `f`, types the repo-relative path, and presses Enter; `path:123` follows up with the viewer's `:` goto-line. This is UI-scripting by nature: if the viewer's keymap changes upstream, this action needs a revisit.
+- **preview** opens a plugin overlay pane (a real TTY) that reads the clipboard, resolves the token through the [handler registry](DESIGN.md#handler-registry), and renders it per `RESOLVED_MODE`: a `file` opens in `less` (bat as the `LESSOPEN` colorizer), a `browser` URL is handed to `url_open` and the overlay closes, a `command` token (vcs) or `viewer` degrade (a directory without herdr-file-viewer installed) pages its output through `less -R`. Esc-to-quit and the three in-popup shell-escapes ship via a `lesskey` file: `o` escalates via less's single `visual` slot (`$VISUAL` -> `escalate.sh`); `e` and `d` cannot reuse that slot, so `e` is bound to less's `pshell` action (`escalate-editor.sh`) and `d` to its `shell` action (`dirty-diff.sh`), each with a `^P` extra-string prefix that suppresses the shell-escape's normal "done" prompt so the overlay resumes cleanly. See [DESIGN.md](DESIGN.md#the-lesskey-three-slot-map) for why there are only three slots to go around.
+- **open-in-viewer** has no goto-file API to call, so it drives the viewer's own keys over the herdr socket: it ensures a `Files` pane exists in the focused tab (opening one via the viewer's action if needed), then sends `f`, types the repo-relative path, and presses Enter; `path:123` follows up with the viewer's `:` goto-line. A directory token reuses the same goto-path sequence to root the viewer there. This is UI-scripting by nature: if the viewer's keymap changes upstream, this action needs a revisit.
 - **recents** has no TTY of its own either (herdr runs every action's command headless), so it opens a second overlay pane (`recents-pick`) just for the fzf pick; the chosen entry is then handed to the SAME `preview` overlay-rendering code (`preview-pane.sh`, `exec`'d in place, not a third pane) so a reopened entry resolves and records exactly like a fresh open.
 - No event hooks, no daemons, nothing runs until you press your key.
+
+Full architecture, the token-flow diagram, and the handler contract for adding a new token kind: [DESIGN.md](DESIGN.md).
 
 ## Limitations
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# release.sh: the ENTIRE release path for herdr-quicklook, run by hand.
+#   ./scripts/release.sh X.Y.Z
+#
+# No CI trigger, no automation watching for a tag push: this script IS the
+# trigger. Sanity checks first (clean tree, on main, the tag doesn't already
+# exist locally or on origin, shellcheck + bats both green) - nothing is
+# mutated until every one of those passes. Then: bump the version in
+# herdr-plugin.toml, move CHANGELOG.md's "## Unreleased" section into a
+# dated "## X.Y.Z (date)" section (Unreleased itself stays, now empty, at
+# the top for the next cycle), commit `chore(release): vX.Y.Z`, tag, push
+# commit + tag, and cut a GitHub release with the moved section as the
+# notes body.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+die() {
+  printf 'release: %s\n' "$1" >&2
+  exit 1
+}
+
+version="${1:-}"
+[ -n "$version" ] || die "usage: $0 X.Y.Z"
+# Anchored: a leading 'v', a pre-release/build suffix, or anything non-numeric
+# is refused rather than silently mangled into a tag name.
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be X.Y.Z (semver, no leading 'v'), got: $version"
+tag="v$version"
+
+command -v git >/dev/null 2>&1 || die "git not found"
+command -v gh >/dev/null 2>&1 || die "gh not found"
+[ -f herdr-plugin.toml ] || die "herdr-plugin.toml not found (run from a repo checkout)"
+[ -f CHANGELOG.md ] || die "CHANGELOG.md not found"
+
+# ---- sanity checks: read-only, nothing below this block is mutated until
+# every check passes ----
+
+branch="$(git branch --show-current)"
+[ "$branch" = "main" ] || die "refusing: on branch '$branch', not main"
+
+[ -z "$(git status --porcelain)" ] || die "refusing: working tree is not clean (commit or stash first)"
+
+# Idempotence guard: a tag that already exists, locally or on origin, means
+# this version was released before (or someone beat us to the name).
+git rev-parse -q --verify "refs/tags/$tag" >/dev/null 2>&1 &&
+  die "refusing: tag $tag already exists locally"
+git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1 &&
+  die "refusing: tag $tag already exists on origin"
+
+grep -q '^## Unreleased$' CHANGELOG.md ||
+  die "CHANGELOG.md has no '## Unreleased' section to release"
+
+echo "release: shellcheck ..."
+shellcheck -x scripts/*.sh scripts/handlers/*.sh || die "shellcheck failed"
+
+echo "release: bats tests/ ..."
+bats tests/ || die "bats suite failed"
+
+# ---- rewrite CHANGELOG.md: move the Unreleased section's body into a new
+# dated section, leaving Unreleased itself empty at the top. Streams the
+# file line-by-line rather than slurping it into an awk multi-line variable,
+# so this stays a plain, readable bash loop instead of a second scripting
+# language embedded in a heredoc. ----
+
+today="$(date +%Y-%m-%d)"
+changelog_tmp="$(mktemp)"
+notes_file="$(mktemp)"
+trap 'rm -f "$changelog_tmp" "$notes_file"' EXIT
+
+render_changelog() {
+  local in_unreleased=0 header_done=0 pending_blank=0 line
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$header_done" -eq 0 ] && [ "$line" = "## Unreleased" ]; then
+      printf '## Unreleased\n\n## %s (%s)\n' "$version" "$today"
+      in_unreleased=1
+      header_done=1
+      continue
+    fi
+    if [ "$in_unreleased" -eq 1 ]; then
+      if [[ "$line" == "## "* ]]; then
+        in_unreleased=0
+        printf '\n'
+        # fall through: print this next-section header line below
+      else
+        if [ -z "$line" ]; then
+          pending_blank=1
+          continue
+        fi
+        if [ "$pending_blank" -eq 1 ]; then
+          printf '\n'
+          pending_blank=0
+        fi
+        printf '%s\n' "$line"
+        continue
+      fi
+    fi
+    printf '%s\n' "$line"
+  done <CHANGELOG.md
+}
+
+render_changelog >"$changelog_tmp"
+[ -s "$changelog_tmp" ] || die "changelog rewrite produced an empty file, aborting before overwrite"
+grep -q "^## $version (" "$changelog_tmp" ||
+  die "changelog rewrite did not produce a '## $version (...)' section, aborting"
+
+# The dated section's own body, trimmed of its trailing blank line, becomes
+# the GitHub release notes body.
+awk -v hdr="## $version (" '
+  index($0, hdr) == 1 { grab = 1; next }
+  grab && /^## / { exit }
+  grab && !started && $0 == "" { next }
+  grab { started = 1; print }
+' "$changelog_tmp" >"$notes_file"
+
+mv -f "$changelog_tmp" CHANGELOG.md
+
+# ---- version bump ----
+
+sed -i.bak -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"$version\"/" herdr-plugin.toml
+rm -f herdr-plugin.toml.bak
+grep -q "^version = \"$version\"\$" herdr-plugin.toml ||
+  die "version bump did not take (herdr-plugin.toml has no version = \"$version\" line, aborting before commit)"
+
+# ---- commit, tag, push, release ----
+
+git add herdr-plugin.toml CHANGELOG.md
+git commit -m "chore(release): $tag"
+git tag "$tag"
+git push origin "$branch"
+git push origin "$tag"
+
+gh release create "$tag" --title "$tag" --generate-notes --notes-file "$notes_file"
+
+echo "release: $tag shipped"

--- a/tests/release.bats
+++ b/tests/release.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# Tests for scripts/release.sh: argv parsing and the refusal guards (dirty
+# tree, wrong branch, an already-existing tag), plus the happy path's argv
+# shape (right version bump, right tag name, right git/gh calls). git and gh
+# are stubbed for every case here, so nothing pushes anywhere real; the
+# refusal tests additionally never reach the git-mutating half of the script
+# at all (they die() before it).
+
+setup() {
+  SCRIPT_SRC="$BATS_TEST_DIRNAME/../scripts/release.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/repo/scripts/handlers" "$FIX/repo/tests"
+  cp "$SCRIPT_SRC" "$FIX/repo/scripts/release.sh"
+  chmod +x "$FIX/repo/scripts/release.sh"
+
+  cat >"$FIX/repo/herdr-plugin.toml" <<'EOF'
+id = "herdr-quicklook"
+name = "herdr-quicklook"
+version = "0.1.0"
+EOF
+
+  cat >"$FIX/repo/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## Unreleased
+
+- feature one (#1)
+- feature two (#2)
+
+## 0.1.0 (2026-07-16)
+
+Initial release.
+
+- initial thing
+EOF
+
+  git -C "$FIX/repo" init -q -b main
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm init
+
+  # Stubs: shellcheck/bats always pass (the sanity-check gate is not what
+  # this suite is testing), git/gh log every invocation to $FIX/git.log /
+  # $FIX/gh.log and otherwise no-op, so the happy-path test never touches a
+  # real remote or GitHub. shellcheck itself lints THIS script elsewhere.
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB/shellcheck"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB/bats"
+  chmod +x "$STUB/shellcheck" "$STUB/bats"
+
+  cd "$FIX/repo"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+# real_git_path: the refusal tests want REAL git semantics (an actual dirty
+# tree, an actual existing tag) rather than a canned stub answer, and they
+# never reach a mutating git call (the script dies() first), so real git is
+# safe here, no network, no push.
+real_git_path() {
+  export PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"
+}
+
+# stubbed_git_gh_path: for the happy-path test, git AND gh are both fully
+# fake, logging their argv to $FIX/git.log / $FIX/gh.log and no-oping.
+# Proves release.sh's OWN argv construction (tag name, commit message, gh
+# release call) without ever shelling out to real git or gh.
+stubbed_git_gh_path() {
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/git.log"\ncase "$1 $2" in\n  "branch --show-current") echo main ;;\n  "status --porcelain") : ;;\n  "rev-parse -q") exit 1 ;;\n  "ls-remote --exit-code") exit 1 ;;\nesac\nexit 0\n' "$FIX" >"$STUB/git"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/gh.log"\nexit 0\n' "$FIX" >"$STUB/gh"
+  chmod +x "$STUB/git" "$STUB/gh"
+  export PATH="$STUB:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"
+}
+
+@test "release.sh: no version argument -> usage error" {
+  real_git_path
+  run bash scripts/release.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "release.sh: a non-semver argument is refused" {
+  real_git_path
+  run bash scripts/release.sh v0.3.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"version must be X.Y.Z"* ]]
+}
+
+@test "release.sh: refuses a dirty working tree" {
+  real_git_path
+  echo "uncommitted" >>README-scratch.md
+  run bash scripts/release.sh 0.3.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"working tree is not clean"* ]]
+  # never reached the mutating half
+  [ "$(git tag -l)" = "" ]
+}
+
+@test "release.sh: refuses when not on branch main" {
+  real_git_path
+  git checkout -qb feat/other
+  run bash scripts/release.sh 0.3.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not main"* ]]
+}
+
+@test "release.sh: refuses when the tag already exists locally" {
+  real_git_path
+  git tag v0.3.0
+  run bash scripts/release.sh 0.3.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists locally"* ]]
+  # herdr-plugin.toml was never touched
+  grep -q 'version = "0.1.0"' herdr-plugin.toml
+}
+
+@test "release.sh: happy path builds the right tag name and argv" {
+  stubbed_git_gh_path
+  run bash scripts/release.sh 1.2.3
+  [ "$status" -eq 0 ]
+
+  # version bump landed
+  grep -q 'version = "1.2.3"' herdr-plugin.toml
+
+  # CHANGELOG moved Unreleased's body into a dated 1.2.3 section, Unreleased
+  # itself left empty at the top
+  grep -q '^## Unreleased$' CHANGELOG.md
+  grep -q '^## 1.2.3 (' CHANGELOG.md
+  ! awk '/^## Unreleased$/{f=1;next} /^## /{f=0} f && NF' CHANGELOG.md | grep -q .
+
+  # right tag, built as v<version> not <version>
+  grep -q '^tag v1.2.3$' "$FIX/git.log"
+  grep -q '^push origin v1.2.3$' "$FIX/git.log"
+  grep -q '^commit -m chore(release): v1.2.3$' "$FIX/git.log"
+
+  # gh release create was called for the same tag, notes-file, not raw --notes
+  grep -q 'release create v1.2.3' "$FIX/gh.log"
+  grep -q -- '--notes-file' "$FIX/gh.log"
+}
+
+@test "release.sh: happy path never calls a bare 'git push origin main' before the tag exists" {
+  # Regression guard for push ordering: the commit must be pushed, then the
+  # tag, in that order, both to origin - never the tag before the commit
+  # that introduces it.
+  stubbed_git_gh_path
+  run bash scripts/release.sh 4.5.6
+  [ "$status" -eq 0 ]
+  push_lines="$(grep -n '^push origin' "$FIX/git.log")"
+  first_line="$(printf '%s\n' "$push_lines" | head -1)"
+  second_line="$(printf '%s\n' "$push_lines" | tail -1)"
+  [[ "$first_line" == *"origin main"* ]]
+  [[ "$second_line" == *"origin v4.5.6"* ]]
+}


### PR DESCRIPTION
## Summary

- README: complete the v0.3 feature table (vcs tokens, GitLab/Bitbucket blob URLs, the `d` key, recents picker, config vars) and an accurate install/keybinding walkthrough; links out to DESIGN.md for the architecture.
- DESIGN.md (new): the token-flow diagram, the handler-registry contract (how to add a new token kind in one file), the lesskey three-slot map (`o`=visual, `e`=pshell+`^P`, `d`=shell+bare-`%`), the panes/actions topology, recents state, and the cross-cutting security guards. Mermaid diagrams (GitHub-native rendering), spot-checked with `@mermaid-js/mermaid-cli`.
- CHANGELOG.md: filled in every v0.3 feature under `## Unreleased` with PR refs (#3, #5-#12), Keep-a-Changelog shape matching the file's existing style.
- `scripts/release.sh` (new): the single manual trigger for a release, `./scripts/release.sh X.Y.Z`. Sanity checks (clean tree, on `main`, tag doesn't already exist locally/on origin, shellcheck + bats green) before anything is mutated; then bumps `herdr-plugin.toml`'s version, moves CHANGELOG's `Unreleased` section into a dated section, commits `chore(release): vX.Y.Z`, tags, pushes commit+tag, and cuts a GitHub release (`gh release create --generate-notes --notes-file <the moved section>`). No CI automation, by design (Han's own call: a manual trigger, not a tag-push watcher).
- `tests/release.bats` (new): argv/guard coverage for `release.sh` with fully stubbed `git`/`gh`, no real pushes anywhere.

## Test plan

- [x] `shellcheck -x scripts/*.sh scripts/handlers/*.sh` clean
- [x] `bats tests/` all green (161/161: 154 pre-existing + 7 new in `release.bats`)
- [x] Both DESIGN.md mermaid blocks parsed successfully by `@mermaid-js/mermaid-cli`
- [x] `scripts/release.sh` smoke-tested end to end against a throwaway fixture repo + local bare "origin" (real git, stubbed `gh`): version bump, CHANGELOG `Unreleased` -> dated section move, commit, tag, push, `gh release create` argv all verified correct.

## Run table

| Command | Result |
|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean, no findings |
| `bats tests/` | `1..161`, all `ok` (154 pre-existing + `release.bats`'s 7 new: no-arg usage, non-semver refusal, dirty-tree refusal, wrong-branch refusal, existing-tag refusal, happy-path argv shape, push ordering) |
| `npx @mermaid-js/mermaid-cli` on both DESIGN.md diagrams | both rendered to SVG with no parse errors |
| `scripts/release.sh 1.2.3` against a throwaway fixture (stubbed git+gh) | `herdr-plugin.toml` bumped to `1.2.3`; `CHANGELOG.md` `## Unreleased` left empty, `## 1.2.3 (date)` holds the moved bullets with correct blank-line spacing before the next section; git log shows `commit -m chore(release): v1.2.3`, `tag v1.2.3`, `push origin main` then `push origin v1.2.3` (commit before tag); `gh release create v1.2.3 --generate-notes --notes-file <path>` |

## Deviations / notes

- CHANGELOG's `Unreleased` section stays `Unreleased` in this PR (not pre-emptively renamed to `0.3.0`) - the release script itself performs that rename when Han runs `./scripts/release.sh 0.3.0`, matching the environment note that this is docs-and-tooling, not the release trigger itself.
- Added PR refs to the two pre-existing CHANGELOG bullets (#3 agent-push, #5 GitHub URLs) that didn't have them, for consistency with the new entries.
- `scripts/release.sh` refuses on branch, tree, and tag-existence before running shellcheck/bats or mutating anything, so a bad invocation fails fast without wasting the test run.
