### PR TITLE
fix: force UTF-8 pager charset in server-spawned panes

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -353,6 +353,13 @@ HANDLER_KINDS=(github vcs url dir path)
 # unset) so render_command_in_pager below can find ../lesskey the same way
 # the pane scripts locate it from their own script_dir.
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# herdr's server-spawned panes carry no login env, so less falls back to a
+# non-UTF-8 charset and prints multibyte characters as raw bytes (<E2><86><92>
+# for a plain arrow). Force UTF-8 for every pager/render path that sources
+# this file; an explicit user locale still wins.
+export LESSCHARSET="${LESSCHARSET:-utf-8}"
+[ -n "${LANG:-}" ] || export LANG=en_US.UTF-8
 for _herdr_handler in "$LIB_DIR"/handlers/*.sh; do
   # shellcheck disable=SC1090
   [ -f "$_herdr_handler" ] && . "$_herdr_handler"

--- a/tests/dispatch.bats
+++ b/tests/dispatch.bats
@@ -74,3 +74,15 @@ teardown() {
   # `open` above) received exactly the original ghost URL, unmodified.
   [ "$(cat "$OPEN_LOG")" = "https://github.com/owner/ghostrepo/blob/main/nope.md" ]
 }
+
+@test "pager env: sourcing lib.sh forces a UTF-8 charset for less" {
+  run bash -c "unset LESSCHARSET LANG; . scripts/lib.sh; printf %s::%s \"\$LESSCHARSET\" \"\$LANG\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "utf-8::en_US.UTF-8" ]]
+}
+
+@test "pager env: an explicit user locale is not clobbered" {
+  run bash -c "export LESSCHARSET=latin1 LANG=fr_FR.UTF-8; . scripts/lib.sh; printf %s::%s \"\$LESSCHARSET\" \"\$LANG\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "latin1::fr_FR.UTF-8" ]]
+}


### PR DESCRIPTION
herdr server panes carry no login env, so less falls back to a non-UTF-8 charset and renders multibyte chars as raw bytes (<E2><86><92> for →) in the preview popup. lib.sh now exports LESSCHARSET=utf-8 + a LANG fallback for every path that sources it; an explicit user locale still wins.

| Command | Exit | Result |
|---|---|---|
| shellcheck -x scripts/*.sh scripts/handlers/*.sh | 0 | clean |
| bats tests/ | 0 | 173 ok (171 + 2 new env pins) |