### PR TITLE
test: move pager-env pins to their own file, absolute sourcing

### DIFF
--- a/tests/dispatch.bats
+++ b/tests/dispatch.bats
@@ -75,14 +75,3 @@ teardown() {
   [ "$(cat "$OPEN_LOG")" = "https://github.com/owner/ghostrepo/blob/main/nope.md" ]
 }
 
-@test "pager env: sourcing lib.sh forces a UTF-8 charset for less" {
-  run bash -c "unset LESSCHARSET LANG; . scripts/lib.sh; printf %s::%s \"\$LESSCHARSET\" \"\$LANG\""
-  [ "$status" -eq 0 ]
-  [[ "$output" == "utf-8::en_US.UTF-8" ]]
-}
-
-@test "pager env: an explicit user locale is not clobbered" {
-  run bash -c "export LESSCHARSET=latin1 LANG=fr_FR.UTF-8; . scripts/lib.sh; printf %s::%s \"\$LESSCHARSET\" \"\$LANG\""
-  [ "$status" -eq 0 ]
-  [[ "$output" == "latin1::fr_FR.UTF-8" ]]
-}

--- a/tests/pager-env.bats
+++ b/tests/pager-env.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+# UTF-8 pager charset pins (see scripts/lib.sh). Own file: dispatch.bats's
+# setup() rewires PATH/cwd, which broke relative sourcing here.
+
+@test "pager env: sourcing lib.sh forces a UTF-8 charset for less" {
+  run bash -c "unset LESSCHARSET LANG; . '$BATS_TEST_DIRNAME/../scripts/lib.sh'; printf %s::%s \"\$LESSCHARSET\" \"\$LANG\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "utf-8::en_US.UTF-8" ]]
+}
+
+@test "pager env: an explicit user locale is not clobbered" {
+  run bash -c "export LESSCHARSET=latin1 LANG=fr_FR.UTF-8; . '$BATS_TEST_DIRNAME/../scripts/lib.sh'; printf %s::%s \"\$LESSCHARSET\" \"\$LANG\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "latin1::fr_FR.UTF-8" ]]
+}


### PR DESCRIPTION
The two UTF-8 pager pins from #16 lived in dispatch.bats, whose setup() rewires PATH/cwd for its stub fixtures, so the relative `. scripts/lib.sh` stopped resolving depending on invocation context (flaky by placement, caught during #17). Moved to tests/pager-env.bats with $BATS_TEST_DIRNAME-anchored sourcing.

| Command | Exit | Result |
|---|---|---|
| bats tests/pager-env.bats | 0 | 2 ok |
| bats tests/ | 0 | 173 ok |