### PR TITLE
feat: reroute pluck-chain degrade to the native pick overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `pluck-chain`'s degrade now routes to the native pick overlay; herdr-pluck fully optional.
+
 ## 0.3.0 (2026-07-17)
 
 - `prefix+shift+y` chains herdr-pluck's hint overlay straight into the preview overlay: pick a token and it opens immediately, no separate keypress to consume the pick. Degrades to the plain clipboard flow when herdr-pluck isn't installed. Demo GIFs for every main use case (token dispatch, the three in-overlay keys, recents, the pluck chain) replace the single preview recording. (#15)

--- a/scripts/pluck-chain.sh
+++ b/scripts/pluck-chain.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Action `pluck-chain`: show herdr-pluck's hint overlay, then open the picked
 # token immediately in the preview overlay - no separate keypress to consume
-# it. Degrades to the plain clipboard flow (identical to the `preview`
-# action) when herdr-pluck is not installed.
+# it. herdr-pluck is a pure enhancement with NO hard dependency: when it is
+# not installed, or when triggering it fails, this reroutes to the native
+# `pick` action (scan-the-pane, pick-anywhere) instead of the plain clipboard
+# flow, so the same key always lands on a working pick-anywhere experience.
 #
 # herdr-pluck's ONLY output channel is the system clipboard (confirmed in its
 # own README/source: pbcopy/wl-copy/xclip, no other IPC), and its `open`
@@ -13,7 +15,8 @@
 # straight into open-preview.sh's existing QUICKLOOK_TOKEN channel. See
 # DECISIONS.md for the "no clipboard hop" framing and the one disclosed edge
 # case (re-picking a value already on the clipboard is indistinguishable from
-# "nothing picked").
+# "nothing picked"), and for why the reroute below targets the `pick` PLUGIN
+# ACTION id rather than execing scripts/pick.sh directly.
 set -u
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -30,17 +33,29 @@ clip_read_now() {
   fi 2>/dev/null
 }
 
+# The one reroute arm: invoked both when herdr-pluck is absent and when
+# triggering it fails. Targets the `pick` action by ID (not
+# `scripts/pick.sh` by path) so this script never needs to know where that
+# script lives or whether it exists yet.
+reroute_to_pick() {
+  exec "$herdr_bin" plugin action invoke pick --plugin herdr-quicklook
+}
+
 # Soft dependency: without herdr-pluck there is no hint overlay to chain
-# from, so this degrades to the plain clipboard flow instead of doing
-# nothing (same idiom as open-in-viewer.sh's herdr-file-viewer gate).
+# from, so this reroutes to the native pick-anywhere overlay instead of doing
+# nothing (same idiom as open-in-viewer.sh's herdr-file-viewer gate, which
+# used to degrade to the plain clipboard flow here too).
 if ! "$herdr_bin" plugin action list --plugin rmarganti.herdr-pluck >/dev/null 2>&1; then
-  notify "herdr-pluck not installed; opening the clipboard flow"
-  exec bash "$script_dir/open-preview.sh"
+  notify "herdr-pluck not installed; opening the pick-anywhere overlay"
+  reroute_to_pick
 fi
 
 before="$(clip_read_now)"
 
-"$herdr_bin" plugin action invoke pluck --plugin rmarganti.herdr-pluck >/dev/null 2>&1
+if ! "$herdr_bin" plugin action invoke pluck --plugin rmarganti.herdr-pluck >/dev/null 2>&1; then
+  notify "herdr-pluck failed to open; opening the pick-anywhere overlay"
+  reroute_to_pick
+fi
 
 # Poll for a clipboard change. Knobs are overridable for tests (fast, no real
 # sleep) and for a slower human on a loaded machine (QUICKLOOK_PLUCK_TIMEOUT).

--- a/tests/pluck-chain.bats
+++ b/tests/pluck-chain.bats
@@ -1,10 +1,16 @@
 #!/usr/bin/env bats
 # Script-level tests for scripts/pluck-chain.sh: the herdr-pluck-absent
-# fallback, a successful pick forwarded with no extra keypress, and the
-# no-selection (cancel/timeout) degrade. A stub `herdr` plays both the
-# "is herdr-pluck installed" probe and the pick itself (writing a new value
-# into a fake clipboard file, the same side effect pluck's own pbcopy has);
-# a stub `pbpaste` reads that file so no real system clipboard is touched.
+# reroute, the invoke-failure reroute, a successful pick forwarded with no
+# extra keypress, and the no-selection (cancel/timeout) degrade. A stub
+# `herdr` plays the "is herdr-pluck installed" probe, the pluck invoke
+# itself (writing a new value into a fake clipboard file, the same side
+# effect pluck's own pbcopy has), and falls through to echoing argv for any
+# other invocation (including the `pick` action-invoke reroute below, so its
+# argv is directly assertable without scripts/pick.sh needing to exist in
+# this worktree - SG-02 owns that file); a stub `pbpaste` reads the fake
+# clipboard file so no real system clipboard is touched. PATH is pinned to
+# just $STUB (no /opt/homebrew/bin, no system herdr/pbpaste) so a real
+# herdr-pluck or pbpaste installed on the dev machine can never leak in.
 
 setup() {
   SCRIPT="$BATS_TEST_DIRNAME/../scripts/pluck-chain.sh"
@@ -22,10 +28,12 @@ elif [ "$1" = "plugin" ] && [ "$2" = "action" ] && [ "$3" = "invoke" ] && [ "$4"
   if [ -n "${PLUCK_PICK_VALUE+x}" ]; then
     printf '%s' "$PLUCK_PICK_VALUE" > "$CLIP_FILE"
   fi
-  exit 0
+  exit "${PLUCK_INVOKE_EXIT:-0}"
 elif [ "$1" = "notification" ]; then
   exit 0
 else
+  # Catch-all, including `plugin action invoke pick --plugin herdr-quicklook`
+  # (the reroute): echo argv so the caller's exact invocation is assertable.
   printf '%s\n' "$@"
 fi
 SH
@@ -37,23 +45,34 @@ cat "$CLIP_FILE"
 SH
   chmod +x "$STUB/pbpaste"
 
-  PATH="$STUB:$PATH"
+  # Deliberately NOT /opt/homebrew/bin (see NOTES.md's PATH-stub gotcha):
+  # keeps a real herdr-pluck-adjacent binary from ever being reachable.
+  # git/awk/sleep/mktemp/cat resolve fine from /usr/bin:/bin:/usr/local/bin
+  # alone; `herdr` itself is always the stub via HERDR_BIN_PATH regardless.
+  PATH="$STUB:/usr/bin:/bin:/usr/local/bin"
   export PATH HERDR_BIN_PATH="$STUB/herdr" CLIP_FILE
   # Fast polling for every test; individual tests still override the
   # timeout where they need more than one iteration's worth of headroom.
   export QUICKLOOK_PLUCK_POLL_INTERVAL=0
   export QUICKLOOK_PLUCK_TIMEOUT=0.3
-  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD PLUCK_PICK_VALUE
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD PLUCK_PICK_VALUE PLUCK_INVOKE_EXIT
 }
 
 teardown() { rm -rf "$STUB"; }
 
-@test "pluck-chain: herdr-pluck absent -> degrades to the plain clipboard flow, no pluck invoke" {
+@test "pluck-chain: herdr-pluck absent -> reroutes to the native pick action, no pluck invoke" {
   export PLUCK_INSTALLED_EXIT=1
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  grep -q -- 'pane' <<<"$output"
-  ! grep -q -- '--env' <<<"$output"
+  [ "$output" = "$(printf 'plugin\naction\ninvoke\npick\n--plugin\nherdr-quicklook')" ]
+}
+
+@test "pluck-chain: herdr-pluck present but triggering it fails -> reroutes to the native pick action" {
+  export PLUCK_INSTALLED_EXIT=0
+  export PLUCK_INVOKE_EXIT=1
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'plugin\naction\ninvoke\npick\n--plugin\nherdr-quicklook')" ]
 }
 
 @test "pluck-chain: a pick lands on the clipboard -> forwarded to the preview overlay, no extra keypress" {


### PR DESCRIPTION
Makes herdr-pluck a pure enhancement with no hard dependency: `pluck-chain`'s pluck-absent degrade now routes to the native `pick` overlay (was the bare clipboard preview), so the same key gives pick-anywhere with or without herdr-pluck installed. Also reroutes on a herdr-pluck invoke *failure* (installed but fails to actually open), not just absence. pluck-present behavior is unchanged (the existing one-key hint->open flow). One-file edit to `pluck-chain.sh` (plus its bats); existing pluck-chain tests stay green + two new reroute cases. Wiring decision recorded in the mega DECISIONS.

The reroute targets the `pick` plugin-action id (`herdr plugin action invoke pick --plugin herdr-quicklook`), not `scripts/pick.sh` by path, since that file belongs to a parallel sub-goal and this keeps the two disjoint (see DECISIONS.md).

## Run table (post-merge, integrated with #20's pick action + pick-pane overlay)

| Check | Command | Result |
|---|---|---|
| shellcheck | `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean, exit 0 |
| pluck-chain suite | `bats tests/pluck-chain.bats` | 4/4 pass |
| full suite | `bats tests/` | 215/215 pass |

Merged `origin/main` (`1fde615`, PR #20) into this branch to integrate SG-02's `pick` action + `pick-pane.sh` overlay, which this branch's reroute targets. Only conflict was the shared `CHANGELOG.md` `## Unreleased` section (both branches appended a line); resolved by keeping both entries. `scripts/pluck-chain.sh` and `tests/pluck-chain.bats` merged clean, untouched by #20. Confirmed post-merge: `herdr-plugin.toml` now registers `id = "pick"` -> `command = ["bash", "scripts/pick.sh"]`, exactly the action id `reroute_to_pick()` invokes, so the reroute now resolves against a real, shipped action rather than a not-yet-existing one.

## COVERAGE-DELTA

- `tests/pluck-chain.bats`: 3 -> 4 tests (+1 new: invoke-failure fallback). The pre-existing absence test was rewritten to assert the new reroute's exact argv (was: `grep -q -- 'pane'`, now: full expected multi-line `plugin action invoke pick --plugin herdr-quicklook` output) instead of being counted as a separate case.
- Full repo suite pre-merge (base `8c302b9`): 203 -> 204 bats tests, 204/204 pass.
- Full repo suite post-merge (integrated with #20, base `1fde615`): 214 -> 215 bats tests, 215/215 pass (0 pre-existing failures, 0 new failures, 0 regressions).

## Files changed
- `scripts/pluck-chain.sh`: one new `reroute_to_pick()` helper + two call sites (absence gate, invoke-failure gate).
- `tests/pluck-chain.bats`: PATH-stub gotcha applied (drops `/opt/homebrew/bin`), new `PLUCK_INVOKE_EXIT` stub knob, absence test tightened, new invoke-failure test.
- `CHANGELOG.md`: one `## Unreleased` line (append-shared).
