### PR TITLE
feat: pick-anywhere action + overlay picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `prefix+shift+p` opens the `pick` overlay: lists every openable token currently on screen (ranked path > url > sha > ref > dir > name) with a count-by-kind header; the clipboard token is preselected as row 1 when it resolves; `Enter` opens the pick through the existing preview overlay, `Esc` closes without opening anything.
+
 ## 0.3.0 (2026-07-17)
 
 - `prefix+shift+y` chains herdr-pluck's hint overlay straight into the preview overlay: pick a token and it opens immediately, no separate keypress to consume the pick. Degrades to the plain clipboard flow when herdr-pluck isn't installed. Demo GIFs for every main use case (token dispatch, the three in-overlay keys, recents, the pluck chain) replace the single preview recording. (#15)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ command = "herdr plugin action invoke recents --plugin herdr-quicklook"
 key = "prefix+shift+y"
 type = "shell"
 command = "herdr plugin action invoke pluck-chain --plugin herdr-quicklook"
+
+[[keys.command]]              # pick anything openable currently on screen
+key = "prefix+shift+p"
+type = "shell"
+command = "herdr plugin action invoke pick --plugin herdr-quicklook"
 ```
 
 Reload with `herdr server reload-config`.
@@ -90,6 +95,10 @@ The log lives outside any git repo, at `${XDG_STATE_HOME:-~/.local/state}/herdr-
 Pairs this plugin with [herdr-pluck](https://github.com/rmarganti/herdr-pluck) as one action instead of two keystrokes. Press the binding and herdr-pluck's Vimium-style hint labels appear over every copyable token in the pane; type a hint and the picked token opens in the preview overlay immediately, no separate `prefix+v` needed to consume it.
 
 Mechanically, herdr-pluck's only output channel is the system clipboard (there is no other IPC), so the chain fires the pluck action, polls the clipboard for a change, and forwards whatever lands there straight into the preview overlay via the same `QUICKLOOK_TOKEN` channel [agent-push](#agent-push-programmatic-tokens) uses. Without herdr-pluck installed, the binding degrades to the plain clipboard flow (identical to `preview`) instead of doing nothing.
+
+## Pick anything on screen (`prefix+shift+p`)
+
+Lists every openable token currently visible in the pane, ranked by confidence (a resolvable path first, then URLs, commit SHAs, `#refs`, directories, and unique bare filenames last), with a count-by-kind header (`12 on screen · 5 path · 4 url · 2 sha · 1 dir`). If the clipboard already holds a token that resolves, it is preselected as row 1 (labeled `clipboard: <token>`) and deduped out of the on-screen list below it. `Enter` opens the highlighted pick through the same preview overlay as every other open; `Esc` closes without opening anything. With no [`fzf`](https://github.com/junegunn/fzf) installed, the top row opens directly, no interactive step.
 
 ## Configuration
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -54,6 +54,19 @@ title = "Reopen a recent quicklook"
 description = "Reopen the most recently opened path/URL, or fzf-pick among the last N when fzf is installed."
 command = ["bash", "scripts/recents.sh"]
 
+[[panes]]
+id = "pick-pane"
+title = "Pick"
+placement = "overlay"
+command = ["bash", "scripts/pick-pane.sh"]
+
+[[actions]]
+id = "pick"
+platforms = ["linux", "macos"]
+title = "Pick anything openable on screen"
+description = "List every openable token currently on screen (path, URL, SHA, #ref, dir, filename), clipboard-preselected when it resolves; Enter opens the pick in the preview overlay."
+command = ["bash", "scripts/pick.sh"]
+
 [[actions]]
 id = "pluck-chain"
 platforms = ["linux", "macos"]

--- a/scripts/pick-pane.sh
+++ b/scripts/pick-pane.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Pane `pick-pane`: runs inside an overlay (real TTY, same placement as the
+# `preview` pane). Opened by the `pick` action (scripts/pick.sh), which has
+# no TTY of its own to run fzf from - see the header comment there. Mirrors
+# scripts/recents-pane.sh's action/pane split.
+#
+# Lists everything openable currently on screen in the ORIGIN pane - the
+# pane pick.sh captured BEFORE this overlay stole focus, forwarded via
+# QUICKLOOK_PICK_ORIGIN_PANE (herdr pane current would return THIS overlay
+# by the time this script runs, not the origin - see HANDOFF.md). Ranking
+# comes from pick_acquire/pick_scan_text (lib.sh). Row 1 is the clipboard
+# token when it resolves (label `clipboard: <tok>`, preselected - fzf
+# --reverse starts the pointer on row 1, so Enter opens it immediately);
+# rows 2..N are the ranked on-screen candidates, with the clipboard token
+# deduped out of them. Enter hands the chosen raw token to preview-pane.sh
+# via QUICKLOOK_TOKEN, `exec`'d IN THIS SAME PANE/TTY (not a new pane) -
+# identical hand-off to recents-pane.sh, so a pick resolves/renders/records
+# exactly like any other open.
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck disable=SC1091
+. "$script_dir/lib.sh"
+
+load_config
+
+pause_close() {
+  printf '%s\n' "$*"
+  read -r -n1 -p "press any key to close" _ 2>/dev/null || sleep 2
+  exit 0
+}
+
+# fzf row shape: <raw-token>\t<display label> - a hidden raw column plus
+# the shown label (--delimiter/--with-nth below), so a labeled clipboard
+# row still carries its real token through to Enter.
+rows=()
+
+clip="${QUICKLOOK_PICK_CLIP:-}"
+clip_resolved=0
+if [ -n "$clip" ] && resolve_any_token "$clip" >/dev/null 2>&1; then
+  clip_resolved=1
+  rows+=("$(printf '%s\t%s' "$clip" "clipboard: $clip")")
+fi
+
+scan_output="$(pick_acquire "${QUICKLOOK_PICK_ORIGIN_PANE:-}")"
+header="$(pick_count_header <<<"$scan_output")"
+
+while IFS=$'\t' read -r raw _ _; do
+  [ -z "$raw" ] && continue
+  # Dedup: the clipboard row above already carries this raw token.
+  [ "$clip_resolved" -eq 1 ] && [ "$raw" = "$clip" ] && continue
+  rows+=("$(printf '%s\t%s' "$raw" "$raw")")
+done <<<"$scan_output"
+
+[ "${#rows[@]}" -eq 0 ] && pause_close "quicklook: nothing openable on screen"
+
+if command -v fzf >/dev/null 2>&1; then
+  selection="$(printf '%s\n' "${rows[@]}" | fzf \
+    --prompt="pick ▸ " --reverse --cycle --height=100% \
+    --delimiter=$'\t' --with-nth=2 \
+    --header="$header")" || exit 0
+  [ -z "$selection" ] && exit 0
+else
+  # No fzf: same degrade shape as recents-pane.sh - no interactive step,
+  # takes row 1 (the clipboard token if it resolved, else the
+  # highest-ranked on-screen candidate).
+  selection="${rows[0]}"
+fi
+
+pick="${selection%%$'\t'*}"
+
+export QUICKLOOK_TOKEN="$pick"
+exec bash "$script_dir/preview-pane.sh"

--- a/scripts/pick.sh
+++ b/scripts/pick.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Action `pick`: opens the `pick-pane` overlay, the native one-key
+# "see everything openable on screen -> pick -> open" flow (v0.5).
+#
+# herdr runs an action's own command WITHOUT a TTY (the same constraint
+# scripts/recents.sh documents for its own picker) - so the interactive fzf
+# step cannot run here. This script only:
+#   1. captures the ORIGIN pane id, BEFORE the overlay opens. `herdr pane
+#      current` returns the FOCUSED pane; the instant pick-pane is focused,
+#      that becomes the overlay, not the origin (see HANDOFF.md). `herdr
+#      pane read <id>` takes an explicit id and is focus-independent, so
+#      pick-pane.sh scans with the id forwarded here.
+#   2. reads the clipboard token, for the clipboard-first preselected row.
+#   3. opens the pick-pane overlay, forwarding the origin pane id + cwd +
+#      clipboard token via --env/--cwd.
+# Mirrors scripts/recents.sh's action/pane split verbatim.
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/lib.sh
+. "$script_dir/lib.sh"
+
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
+
+# 1. Origin pane id, captured HERE - before focus moves to the overlay.
+origin_pane=""
+if command -v jq >/dev/null 2>&1; then
+  origin_pane="$("$herdr_bin" pane current 2>/dev/null | jq -r '.result.pane.pane_id // empty' 2>/dev/null)"
+fi
+if [ -z "$origin_pane" ] && [ -n "$ctx" ] && command -v jq >/dev/null 2>&1; then
+  # Fallback when `pane current` is unavailable: the context JSON's own
+  # focused-pane field, same shape as the .focused_pane_cwd fallback below.
+  origin_pane="$(printf '%s' "$ctx" | jq -r '.focused_pane_id // empty' 2>/dev/null || true)"
+fi
+
+# 2. The clipboard token, forwarded so pick-pane.sh doesn't need its own
+# clipboard read.
+clip="$(clip_read)"
+
+repo=""
+if [ -n "$ctx" ] && command -v jq >/dev/null 2>&1; then
+  repo="$(printf '%s' "$ctx" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || repo="${HERDR_WORKSPACE_CWD:-}"
+
+set -- plugin pane open \
+  --plugin herdr-quicklook \
+  --entrypoint pick-pane \
+  --placement overlay \
+  --focus
+
+if [ -n "$repo" ] && [ -d "$repo" ]; then
+  set -- "$@" --cwd "$repo"
+fi
+
+if [ -n "$origin_pane" ]; then
+  set -- "$@" --env "QUICKLOOK_PICK_ORIGIN_PANE=$origin_pane"
+fi
+
+if [ -n "$clip" ]; then
+  set -- "$@" --env "QUICKLOOK_PICK_CLIP=$clip"
+fi
+
+exec "$herdr_bin" "$@"

--- a/tests/pick-pane.bats
+++ b/tests/pick-pane.bats
@@ -1,0 +1,346 @@
+#!/usr/bin/env bats
+# Tests for the `pick` feature (SG-02, v0.5): scripts/pick.sh (the no-TTY
+# action, mirrors scripts/recents.sh) and scripts/pick-pane.sh (the
+# fzf-capable overlay pane it opens, mirrors scripts/recents-pane.sh),
+# plus a manifest sanity check for the two new herdr-plugin.toml blocks.
+#
+# Same PATH-stub idiom as recents.bats/pick-scan.bats: script_stubs()
+# deliberately drops /opt/homebrew/bin (this host has a real fzf/jq/herdr
+# there that must not shadow the stubs - the "absent" tests need
+# `command -v` to actually miss, see NOTES.md).
+#
+# pick_scan_text/pick_count_header (SG-01, v0.5) use `local -A` associative
+# arrays and `local -n` namerefs - both bash >=4.3 syntax. macOS SHIPS bash
+# 3.2.57 at /bin/bash (last GPLv2 release), and `bash script.sh` resolves
+# "bash" via $PATH at invocation time - normally Homebrew's modern bash
+# (/opt/homebrew/bin) leads a dev machine's PATH, but this file's own
+# script_stubs() deliberately restricts PATH to $STUB:/usr/bin:/bin:/usr/
+# local/bin (the NOTES.md gotcha, so a real fzf/jq/herdr can't leak
+# through), which resolves bash to the system 3.2 and breaks BOTH
+# functions outright (not a crash - `local -A`/`local -n` fail as plain
+# builtin errors under `set -u` alone with no `set -e`, so the script
+# limps on with broken state and silently wrong output, e.g. header
+# "0 on screen" instead of the real count). find_modern_bash() below locates
+# a real bash >=4 via the PATH captured before script_stubs narrows it, and
+# script_stubs() stubs `$STUB/bash` to exec it directly (shebang points at
+# the modern bash's own absolute path, not `/usr/bin/env bash`, so the exec
+# doesn't re-enter the restricted PATH and self-loop) - every OTHER tool
+# name in $STUB stays a fully controlled stub. See DECISIONS.md: this is a
+# latent bash-version requirement in the shipped SG-01 lib, outside this
+# sub-goal's `## Touches`, flagged for the conductor/Han rather than
+# patched here.
+
+setup() {
+  ORIGINAL_PATH="$PATH"
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/state" "$FIX/repo/sub"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello\n' >"$FIX/repo/sub/inrepo.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+
+  export XDG_STATE_HOME="$FIX/state"
+  unset QUICKLOOK_TOKEN QUICKLOOK_PICK_ORIGIN_PANE QUICKLOOK_PICK_CLIP QUICKLOOK_PICK_SOURCE QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# find_modern_bash: the first bash >=4 found on the ORIGINAL PATH (must be
+# called before script_stubs narrows $PATH). See the file header comment.
+find_modern_bash() {
+  local candidate ver saved_ifs
+  saved_ifs="$IFS"
+  IFS=:
+  for candidate in $ORIGINAL_PATH; do
+    [ -x "$candidate/bash" ] || continue
+    ver="$("$candidate/bash" -c 'printf %s "${BASH_VERSINFO[0]}"' 2>/dev/null)"
+    case "$ver" in
+      [4-9] | [1-9][0-9]*)
+        IFS="$saved_ifs"
+        printf '%s/bash' "$candidate"
+        return 0
+        ;;
+    esac
+  done
+  IFS="$saved_ifs"
+  return 1
+}
+
+script_stubs() {
+  STUB="$(mktemp -d)"
+  local modern_bash
+  modern_bash="$(find_modern_bash)" || modern_bash="/bin/bash"
+  printf '#!%s\nexec %s "$@"\n' "$modern_bash" "$modern_bash" >"$STUB/bash"
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS: %%s\\n" "$*"\n' >"$STUB/less"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB/herdr"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB/open"
+  # No clipboard by default (exit 1, no output); tests that need a
+  # clipboard token override this.
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$STUB/pbpaste"
+  chmod +x "$STUB/bash" "$STUB/less" "$STUB/herdr" "$STUB/open" "$STUB/pbpaste"
+  # Deliberately NOT /opt/homebrew/bin (NOTES.md's PATH-stub gotcha): this
+  # host has a real fzf/jq/herdr there that must not shadow the stubs. The
+  # $STUB/bash shim above is the one deliberate exception (see file header).
+  export PATH="$STUB:/usr/bin:/bin:/usr/local/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+}
+
+jq_stub() {
+  cat >"$STUB/jq" <<'SH'
+#!/usr/bin/env bash
+exec /opt/homebrew/bin/jq "$@"
+SH
+  chmod +x "$STUB/jq"
+}
+
+# ---- scripts/pick.sh (the no-TTY action) ----
+
+@test "pick.sh: opens the pick-pane overlay" {
+  script_stubs
+  cd "$FIX/repo"
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "pick.sh: forwards the origin pane id, cwd, and clipboard token on the pane-open argv" {
+  script_stubs
+  jq_stub
+  cat >"$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "pane" ] && [ "$2" = "current" ]; then
+  printf '{"result":{"pane":{"pane_id":"origin-1"}}}\n'
+else
+  printf '%s\n' "$@"
+fi
+SH
+  chmod +x "$STUB/herdr"
+  cat >"$STUB/pbpaste" <<'SH'
+#!/usr/bin/env bash
+printf 'sub/inrepo.md\n'
+SH
+  chmod +x "$STUB/pbpaste"
+  cd "$FIX/repo"
+  export HERDR_PLUGIN_CONTEXT_JSON
+  HERDR_PLUGIN_CONTEXT_JSON="$(printf '{"focused_pane_cwd":"%s"}' "$FIX/repo")"
+  unset HERDR_WORKSPACE_CWD
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick.sh"
+  [ "$status" -eq 0 ]
+  grep -qx -- 'pick-pane' <<<"$output"
+  grep -qx -- 'overlay' <<<"$output"
+  grep -qx -- '--cwd' <<<"$output"
+  grep -qx -- "$FIX/repo" <<<"$output"
+  grep -qx -- 'QUICKLOOK_PICK_ORIGIN_PANE=origin-1' <<<"$output"
+  grep -qx -- 'QUICKLOOK_PICK_CLIP=sub/inrepo.md' <<<"$output"
+}
+
+@test "pick.sh: empty clipboard emits no QUICKLOOK_PICK_CLIP flag" {
+  script_stubs
+  cat >"$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@"
+SH
+  chmod +x "$STUB/herdr"
+  cd "$FIX/repo"
+  unset HERDR_PLUGIN_CONTEXT_JSON HERDR_WORKSPACE_CWD
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick.sh"
+  [ "$status" -eq 0 ]
+  ! grep -q -- 'QUICKLOOK_PICK_CLIP' <<<"$output"
+}
+
+# ---- scripts/pick-pane.sh (the TTY-holding picker) ----
+
+# A herdr stub whose `pane read` reply is the fixed screen text below (one
+# real resolvable path, one URL - two kinds, so the count header can be
+# asserted on both). No blank lines (see the file header comment).
+pane_read_herdr_stub() {
+  cat >"$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "pane" ] && [ "$2" = "read" ]; then
+  printf 'open sub/inrepo.md now\n'
+  printf 'see https://example.com/a/b for docs\n'
+else
+  exit 0
+fi
+SH
+  chmod +x "$STUB/herdr"
+}
+
+@test "pick-pane.sh: clipboard row is preselected (row 1) and deduped out of the on-screen list; header reflects the on-screen scan" {
+  script_stubs
+  pane_read_herdr_stub
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  export QUICKLOOK_PICK_CLIP="sub/inrepo.md"
+  ROWS_LOG="$(mktemp)"
+  ARGV_LOG="$(mktemp)"
+  cat >"$STUB/fzf" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$ARGV_LOG"
+cat > "$ROWS_LOG"
+sed -n '1p' "$ROWS_LOG"
+SH
+  chmod +x "$STUB/fzf"
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  # row 1 is the clipboard row: hidden raw col = the clip token, display =
+  # "clipboard: <token>"
+  [ "$(sed -n '1p' "$ROWS_LOG")" = "$(printf 'sub/inrepo.md\tclipboard: sub/inrepo.md')" ]
+  # the on-screen scan ALSO found sub/inrepo.md (kind path) - deduped out,
+  # so it must not appear a second time as its own row anywhere below row 1
+  dupes="$(tail -n +2 "$ROWS_LOG" | grep -c $'^sub/inrepo.md\t' || true)"
+  [ "$dupes" -eq 0 ]
+  # the generic URL from the same screen is still listed (only the
+  # clipboard token itself is deduped, not the whole on-screen list)
+  grep -qx $'https://example.com/a/b\thttps://example.com/a/b' "$ROWS_LOG"
+  # count header: 2 on screen (the path counted even though its ROW is
+  # deduped - the header describes what's ON SCREEN, not the picker rows)
+  grep -qx -- '--header=2 on screen · 1 path · 1 url' "$ARGV_LOG"
+}
+
+@test "pick-pane.sh: a clipboard token that does NOT resolve is skipped - no clipboard row, on-screen list still shown" {
+  script_stubs
+  pane_read_herdr_stub
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  export QUICKLOOK_PICK_CLIP="totally-nonexistent-file-xyz.md"
+  ROWS_LOG="$(mktemp)"
+  cat >"$STUB/fzf" <<SH
+#!/usr/bin/env bash
+cat > "$ROWS_LOG"
+sed -n '1p' "$ROWS_LOG"
+SH
+  chmod +x "$STUB/fzf"
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  ! grep -q 'clipboard:' "$ROWS_LOG"
+  # the on-screen candidates are still present (path ranks above url)
+  [ "$(sed -n '1p' "$ROWS_LOG")" = "$(printf 'sub/inrepo.md\tsub/inrepo.md')" ]
+}
+
+@test "pick-pane.sh: Enter opens the picked row through preview-pane.sh, using the RAW token (not a 'clipboard: ' label)" {
+  script_stubs
+  pane_read_herdr_stub
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  export QUICKLOOK_PICK_CLIP="sub/inrepo.md"
+  cat >"$STUB/fzf" <<'SH'
+#!/usr/bin/env bash
+# deterministically choose the URL row (proving Enter can pick something
+# other than the preselected row 1, and that the RAW column - not the
+# display label - is what crosses to preview-pane.sh)
+grep -F $'https://example.com/a/b\t'
+SH
+  chmod +x "$STUB/fzf"
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  # a URL resolves to RESOLVED_MODE=browser in preview-pane.sh: url_open
+  # (stubbed) is silent, but record_open still fires before it - the
+  # recents log is the observable proof the RAW token (not the clipboard
+  # row's display label) reached preview-pane.sh via QUICKLOOK_TOKEN.
+  run recents_latest
+  [ "$output" = "https://example.com/a/b" ]
+}
+
+@test "pick-pane.sh: Enter on the preselected clipboard row opens the raw token, not the display label" {
+  script_stubs
+  pane_read_herdr_stub
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  export QUICKLOOK_PICK_CLIP="sub/inrepo.md"
+  cat >"$STUB/fzf" <<'SH'
+#!/usr/bin/env bash
+sed -n '1p'
+SH
+  chmod +x "$STUB/fzf"
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"$FIX/repo/sub/inrepo.md"* ]]
+  run recents_latest
+  [ "$output" = "sub/inrepo.md" ]
+}
+
+@test "pick-pane.sh: Esc (fzf exits non-zero) opens nothing" {
+  script_stubs
+  pane_read_herdr_stub
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$STUB/fzf"
+  chmod +x "$STUB/fzf"
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"LESS_ARGS:"* ]]
+  run recents_latest
+  [ -z "$output" ]
+}
+
+@test "pick-pane.sh: zero on-screen candidates and no clipboard -> honest empty state, no crash, fzf never invoked" {
+  script_stubs
+  cat >"$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "pane" ] && [ "$2" = "read" ]; then
+  printf 'just some ordinary prose\n'
+  printf 'nothing here is a path, url, sha, ref, dir, or a real filename\n'
+else
+  exit 0
+fi
+SH
+  chmod +x "$STUB/herdr"
+  FZF_MARKER="$(mktemp)"
+  rm -f "$FZF_MARKER"
+  cat >"$STUB/fzf" <<SH
+#!/usr/bin/env bash
+touch "$FZF_MARKER"
+exit 1
+SH
+  chmod +x "$STUB/fzf"
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing openable on screen"* ]]
+  [ ! -e "$FZF_MARKER" ]
+}
+
+@test "pick-pane.sh: no fzf on PATH -> auto-opens row 1 (clipboard-preselected), no interactive step" {
+  script_stubs
+  pane_read_herdr_stub
+  cd "$FIX/repo"
+  export QUICKLOOK_PICK_ORIGIN_PANE="origin-1"
+  export QUICKLOOK_PICK_CLIP="sub/inrepo.md"
+  # script_stubs' PATH has no fzf.
+  run bash "$BATS_TEST_DIRNAME/../scripts/pick-pane.sh" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"$FIX/repo/sub/inrepo.md"* ]]
+}
+
+# ---- manifest sanity ----
+
+@test "herdr-plugin.toml: parses and contains the pick action + pick-pane overlay" {
+  python3 - "$BATS_TEST_DIRNAME/../herdr-plugin.toml" <<'PY'
+import sys
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+action_ids = [a["id"] for a in data["actions"]]
+pane_ids = [p["id"] for p in data["panes"]]
+assert "pick" in action_ids, action_ids
+assert "pick-pane" in pane_ids, pane_ids
+pick_action = next(a for a in data["actions"] if a["id"] == "pick")
+assert pick_action["command"] == ["bash", "scripts/pick.sh"], pick_action
+pick_pane = next(p for p in data["panes"] if p["id"] == "pick-pane")
+assert pick_pane["command"] == ["bash", "scripts/pick-pane.sh"], pick_pane
+PY
+}


### PR DESCRIPTION
## Summary

Adds the native pick-anywhere UX: a `pick` action (no TTY, captures the origin pane id) opens a `pick-pane` overlay that `herdr pane read`s the origin pane, lists every openable on-screen token (via the SG-01 scan lib) with a count-by-kind header, preselects the clipboard token when it resolves, and on Enter opens the pick through the shipped `preview-pane.sh` path (Esc opens nothing; a bare screen shows an honest empty state). Copies the recents action/pane split (herdr actions have no TTY). No hard dependency on herdr-pluck.

## Run table

| Check | Result |
|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | clean (0 issues) |
| `bats tests/` (full suite) | 214/214 pass |
| `bats tests/pick-pane.bats` (this sub-goal's new file) | 11/11 pass |
| Manifest sanity (`tomllib` load) | `pick` action + `pick-pane` pane present, correct `command` |

## COVERAGE-DELTA

- Base (`main@8c302b9`, SG-01 merged): 203 tests, 203 pass, 0 fail.
- This branch: 214 tests, 214 pass, 0 fail.
- Delta: +11 tests (new `tests/pick-pane.bats`), 0 regressions.

## Details

- `scripts/pick.sh`: captures the origin pane id (`herdr pane current | jq -r '.result.pane.pane_id'`) and the clipboard token BEFORE opening the `pick-pane` overlay, forwarding both plus the origin cwd via `--env`/`--cwd`.
- `scripts/pick-pane.sh`: builds the fzf row list (hidden raw-token column + shown display column via `--delimiter`/`--with-nth`), prepends the clipboard row (`clipboard: <token>`) when it resolves and dedups it out of the on-screen list, shows `pick_count_header`'s count-by-kind breakdown as `--header`, and on Enter hands the raw token to `preview-pane.sh` via `QUICKLOOK_TOKEN` (`exec`'d in place). No fzf installed: opens row 1 directly, no interactive step (mirrors `recents-pane.sh`'s degrade).
- `herdr-plugin.toml`: new `[[actions]] id = "pick"` + `[[panes]] id = "pick-pane"` blocks.
- `tests/pick-pane.bats`: script-level coverage for the argv forwarding, clipboard preselect + dedup, count header, Enter/Esc, the zero-candidate negative control, and the no-fzf degrade.
- README: new "Pick anything on screen" section + a `prefix+shift+p` keybinding example. CHANGELOG: one Unreleased bullet. Decisions recorded in the megagoal's `DECISIONS.md` (origin-pane-id fallback assumption, the fzf row-shape mechanism, and a latent bash-version requirement discovered in the shipped SG-01 lib, flagged for the conductor, not patched here).
