### PR TITLE
find: fzf file finder with live preview through quicklook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- New `find` action: fzf over tracked files with live bat preview; Enter
+  renders the pick through the preview overlay.
+
 - The `hint` picker replaces `pick`, `pluck-chain`, and the separate `linkify`
   overlay: one pluck-style in-place overlay (dim pane, one-letter hints on the
   token's first character, bright-yellow `#fffd01` badges), keyboard and

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Every hinted token is also an OSC-8 link on this plugin's `.invalid` sentinel tr
 
 Repository URLs (GitHub blob/raw/PR, GitLab blob, Bitbucket source) are ALSO Ctrl+clickable directly in any pane, no overlay needed: narrow link handlers route them through the quicklook resolver, opening a local checkout or `gh pr view` when possible before falling back to the browser.
 
+## Find a file (`prefix+/` suggested)
+
+The `find` action opens an fzf overlay over the repo's tracked files (outside a repo, a bounded `find`), with a live bat preview rendering WHILE you type. Enter opens the pick in the same preview overlay as every other open, so `o`/`e`/`d` keep working; Esc closes. This is the proactive complement to the passive bare-name fallback (a copied ambiguous filename already fzf-picks among its matches).
+
 ## Agent suggestions (opt-in)
 
 Set `QUICKLOOK_AGENT_SUGGESTIONS=notify` to watch herdr's low-volume `pane.agent_status_changed` event. When an agent starts working, quicklook records a transcript baseline. When it reaches `done` or `idle`, only text added during that turn is scanned; the highest-confidence token is saved as the latest suggestion and shown in a herdr notification. The `agent-suggestion` action opens it later using the producing pane's cwd.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -69,6 +69,19 @@ title = "Hint-pick anything openable on screen"
 description = "Overlay every openable token on screen with a one-key hint label; press the key (or Ctrl+click the row) to resolve + open it immediately. No fzf, no herdr-pluck."
 command = ["bash", "scripts/hint.sh"]
 
+[[panes]]
+id = "find-pane"
+title = "Find"
+placement = "overlay"
+command = ["bash", "scripts/find-pane.sh"]
+
+[[actions]]
+id = "find"
+platforms = ["linux", "macos"]
+title = "Fuzzy-find a file to quick-look"
+description = "fzf over the repo's tracked files with a live bat preview; Enter renders the pick in the preview overlay."
+command = ["bash", "scripts/find.sh"]
+
 [[actions]]
 id = "open-link"
 platforms = ["linux", "macos"]

--- a/scripts/find-pane.sh
+++ b/scripts/find-pane.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Pane `find-pane`: the fuzzy file finder overlay (real TTY). Opened by the
+# `find` action (scripts/find.sh), which forwarded the origin repo cwd.
+#
+# fzf over the repo's tracked files (git ls-files; outside a repo, a bounded
+# find), with a live bat preview while typing. Enter hands the pick to
+# preview-pane.sh via QUICKLOOK_TOKEN, exec'd IN THIS SAME PANE, so the file
+# resolves + renders + records exactly like every other quicklook open (and
+# the o/e/d escalation keys keep working). Esc closes.
+#
+# No herdr RPC here (a server RPC from a server-spawned overlay pane
+# deadlocks); git/fzf/bat are all local.
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck disable=SC1091
+. "$script_dir/lib.sh"
+
+load_config
+
+if [ -n "${QUICKLOOK_FIND_CWD:-}" ] && [ -d "$QUICKLOOK_FIND_CWD" ]; then
+  cd "$QUICKLOOK_FIND_CWD" || true
+fi
+
+tty_in=/dev/tty
+[ -r "$tty_in" ] || tty_in=/dev/stdin
+
+pause_close() {
+  printf '%s\n\n(press any key to close)' "$*"
+  read -rsn1 _ <"$tty_in" 2>/dev/null || sleep 2
+  exit 0
+}
+
+command -v fzf >/dev/null 2>&1 || pause_close "quicklook find needs fzf (brew install fzf)"
+
+# File list: tracked files when inside a repo (fast, no noise), else a
+# bounded find. ponytail: depth 6 cap outside repos, tune if it ever bites.
+list_files() {
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    git ls-files
+  else
+    find . -maxdepth 6 -type f -not -path '*/.git/*' 2>/dev/null | sed 's|^\./||'
+  fi
+}
+
+preview_cmd='bat --color=always --style=numbers {} 2>/dev/null || cat {} 2>/dev/null'
+command -v bat >/dev/null 2>&1 || preview_cmd='cat {} 2>/dev/null'
+
+pick="$(list_files | fzf \
+  --prompt="quicklook find ▸ " --reverse --height=100% \
+  --preview "$preview_cmd" --preview-window='right,60%,border-left')" || exit 0
+[ -z "$pick" ] && exit 0
+
+export QUICKLOOK_TOKEN="$pick"
+exec bash "$script_dir/preview-pane.sh"

--- a/scripts/find.sh
+++ b/scripts/find.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Action `find`: fuzzy-find a file to quick-look. Opens the find-pane overlay
+# (fzf over the repo's tracked files, live bat preview while typing); Enter
+# renders the pick through the same preview path as every other open.
+#
+# Same action/pane split as hint.sh: the action has no TTY, the overlay runs
+# fzf. The origin cwd rides as an env var, never --cwd (--cwd breaks the
+# pane's relative command resolution and the pane flash-closes).
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/lib.sh
+. "$script_dir/lib.sh"
+
+ctx="${HERDR_PLUGIN_CONTEXT_JSON:-}"
+
+repo=""
+if [ -n "$ctx" ] && command -v jq >/dev/null 2>&1; then
+  repo="$(printf '%s' "$ctx" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null || true)"
+fi
+[ -n "$repo" ] || repo="${HERDR_WORKSPACE_CWD:-}"
+
+set -- plugin pane open \
+  --plugin herdr-quicklook \
+  --entrypoint find-pane \
+  --placement overlay \
+  --focus
+
+if [ -n "$repo" ] && [ -d "$repo" ]; then
+  set -- "$@" --env "QUICKLOOK_FIND_CWD=$repo"
+fi
+
+exec "$herdr_bin" "$@"

--- a/tests/find.bats
+++ b/tests/find.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# The `find` fuzzy file finder: action/pane wiring + degrade paths.
+
+setup() {
+  ROOT="$BATS_TEST_DIRNAME/.."
+  FIND="$ROOT/scripts/find.sh"
+  FIND_PANE="$ROOT/scripts/find-pane.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/repo/src"
+  git -C "$FIX/repo" init -q -b main
+  printf 'hello find\n' >"$FIX/repo/src/target.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm fixture
+
+  STUB="$(mktemp -d)"
+  cat >"$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@"
+SH
+  chmod +x "$STUB/herdr"
+  export PATH="$STUB:/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin"
+  export HERDR_BIN_PATH="$STUB/herdr"
+  unset QUICKLOOK_TOKEN QUICKLOOK_FIND_CWD HERDR_PLUGIN_CONTEXT_JSON
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+@test "find action forwards the origin cwd as env, never --cwd" {
+  export HERDR_PLUGIN_CONTEXT_JSON
+  HERDR_PLUGIN_CONTEXT_JSON="$(jq -cn --arg cwd "$FIX/repo" '{focused_pane_cwd:$cwd}')"
+  run bash "$FIND"
+  [ "$status" -eq 0 ]
+  grep -qx 'find-pane' <<<"$output"
+  grep -qx "QUICKLOOK_FIND_CWD=$FIX/repo" <<<"$output"
+  ! grep -qx -- '--cwd' <<<"$output"
+}
+
+@test "find pane without fzf degrades to a message, no crash" {
+  export PATH="$STUB:/usr/bin:/bin"
+  export QUICKLOOK_FIND_CWD="$FIX/repo"
+  run bash "$FIND_PANE" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"needs fzf"* ]]
+}
+
+@test "find pane renders the fzf pick through the preview path" {
+  cat >"$STUB/fzf" <<'SH'
+#!/usr/bin/env bash
+cat >/dev/null
+printf 'src/target.md\n'
+SH
+  cat >"$STUB/less" <<'SH'
+#!/usr/bin/env bash
+printf 'LESS_ARGS: %s\n' "$*"
+SH
+  chmod +x "$STUB/fzf" "$STUB/less"
+  export PATH="$STUB:/usr/bin:/bin"
+  export QUICKLOOK_FIND_CWD="$FIX/repo"
+  run bash "$FIND_PANE" </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESS_ARGS:"*"src/target.md"* ]]
+}
+
+@test "manifest registers the find overlay and action" {
+  python3 - "$ROOT/herdr-plugin.toml" <<'PY'
+import sys
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+actions = {item["id"]: item for item in data["actions"]}
+panes = {item["id"]: item for item in data["panes"]}
+assert actions["find"]["command"] == ["bash", "scripts/find.sh"]
+assert panes["find-pane"]["placement"] == "overlay"
+PY
+}


### PR DESCRIPTION
## Summary

- New `find` action + `find-pane` overlay: fzf over the repo's tracked files (bounded `find` outside a repo) with a live bat preview while typing; Enter renders the pick through the same preview overlay as every other open (o/e/d escalations intact), Esc closes.
- Degrades honestly without fzf (message) and without bat (cat preview).
- Complements the existing passive bare-name fzf fallback with a proactive finder.

## Validation

- `shellcheck -x scripts/find.sh scripts/find-pane.sh` - clean
- `bats tests/` - full suite green (4 new tests: env-not-cwd forwarding, no-fzf degrade, fzf-pick-to-preview, manifest)