### PR TITLE
fix: bare domains classify as urls and open the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Bare domains (hermes.d.foundation, herdr.dev) classify as urls and open
+  the browser with an https scheme, gated on a TLD allowlist so file
+  extensions (.md, .go, .sh) never misclassify.
+
 - A visible-but-unresolvable clipboard path now drops into the fzf finder
   pre-seeded as the query (partial/typo paths land on their closest match).
 

--- a/scripts/handlers/url.sh
+++ b/scripts/handlers/url.sh
@@ -9,6 +9,11 @@ match_url() {
 
 handle_url() {
   RESOLVED_TARGET="$1"
+  # A bare domain has no scheme; the browser opener needs one.
+  case "$1" in
+    http://* | https://*) ;;
+    *) RESOLVED_TARGET="https://$1" ;;
+  esac
   RESOLVED_LINE=""
   RESOLVED_MODE="browser"
   return 0

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -233,12 +233,20 @@ pick_token() {
 }
 
 # classify_token <raw> -> github | url | path
+# Bare domains (hermes.d.foundation, herdr.dev) are urls too, gated on a TLD
+# allowlist so file extensions never misclassify (README.md, main.go, run.sh
+# stay paths). Curated, not exhaustive: extend the list when a real domain
+# misses. A local FILE named like a domain loses to the domain - acceptable.
+_BARE_DOMAIN_RE='^([A-Za-z0-9-]+\.)+(com|net|org|io|ai|co|app|dev|so|ws|xyz|info|foundation|cloud|network|systems|site|tech|online|me|vn)(:[0-9]+)?(/[^[:space:]]*)?$'
+
 classify_token() {
   case "$1" in
     https://github.com/*/blob/* | https://github.com/*/raw/* | https://raw.githubusercontent.com/*)
       printf 'github' ;;
     http://* | https://*) printf 'url' ;;
-    *) printf 'path' ;;
+    *)
+      if [[ "$1" =~ $_BARE_DOMAIN_RE ]]; then printf 'url'; else printf 'path'; fi
+      ;;
   esac
 }
 

--- a/tests/pick-scan.bats
+++ b/tests/pick-scan.bats
@@ -124,6 +124,29 @@ teardown() {
   [ "$output" = "$(printf '~/somewhere/deep/nothing	path	1')" ]
 }
 
+@test "bare domain -> kind url, in both scan modes" {
+  run pick_scan_text <<<'visit hermes.d.foundation today'
+  [ "$output" = "$(printf 'hermes.d.foundation\turl\t1')" ]
+  QUICKLOOK_SCAN_FAST=1 run pick_scan_text <<<'visit hermes.d.foundation today'
+  [ "$output" = "$(printf 'hermes.d.foundation\turl\t1')" ]
+}
+
+@test "bare domain with an extension-looking TLD (herdr.dev) is a url, not a path" {
+  QUICKLOOK_SCAN_FAST=1 run pick_scan_text <<<'docs at herdr.dev now'
+  [ "$output" = "$(printf 'herdr.dev\turl\t1')" ]
+}
+
+@test "file extensions never misclassify as domains (md, go stay path-shaped)" {
+  QUICKLOOK_SCAN_FAST=1 run pick_scan_text <<<'see CHANGELOG.md and missing/x.go here'
+  [[ "$output" != *"url"* ]]
+}
+
+@test "resolve: a bare domain opens the browser with an https scheme" {
+  resolve_any_token 'hermes.d.foundation'
+  [ "$RESOLVED_MODE" = "browser" ]
+  [ "$RESOLVED_TARGET" = "https://hermes.d.foundation" ]
+}
+
 @test "fast mode: a github blob URL stays a url (no local-checkout probe)" {
   QUICKLOOK_SCAN_FAST=1 run pick_scan_text <<<'https://github.com/o/repo/blob/main/sub/inrepo.md'
   [ "$output" = "$(printf 'https://github.com/o/repo/blob/main/sub/inrepo.md\turl\t1')" ]


### PR DESCRIPTION
## Summary

- `hermes.d.foundation` on screen produced NO hint (match_url required an http(s) scheme; the path shape caps extensions at 8 chars so `.foundation` fell through), and worse, `herdr.dev` WAS hinted but as a path (opened as a file, 'not a file I can find', never the browser).
- Fix in one place (url is ahead of path in HANDLER_KINDS, so classify_token feeds both the scanner and the resolver): bare domains match a curated TLD allowlist (com/net/org/io/ai/dev/so/ws/foundation/..., optional :port and /path), and handle_url prefixes `https://` when the scheme is missing. File extensions (.md/.go/.sh) are deliberately NOT in the allowlist so filenames never misclassify.

## Validation

- `bats tests/` - full suite green (4 new tests: both scan modes, the extension-looking TLD, the no-misclassify negative, and the https-prefixed browser resolve)