### PR TITLE
render registry: one entry per file type, full v0.4 roster pre-registered

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -85,6 +85,68 @@
 # from before this refactor. See DECISIONS.md.
 # -----------------------------------------------------------------------
 
+# -----------------------------------------------------------------------
+# Render-registry contract (v0.4, SG-01)
+#
+# The handler registry above resolves a token down to RESOLVED_MODE=file +
+# a local path; the render registry sits one layer downstream and decides
+# HOW to draw that path. A file TYPE lives in its own
+# scripts/renderers/<kind>.sh and exports two functions:
+#
+#   match_render_<kind> <path>       -> rc 0 iff this renderer owns the
+#                                        file's TYPE **and** its required
+#                                        external tool is on PATH. No
+#                                        resolution work, no side effects.
+#                                        May key on extension and/or
+#                                        `file --mime-type` /
+#                                        `file --mime-encoding`.
+#   render_<kind> <path> [line]      -> DRIVES the pane (it owns the real
+#                                        TTY). Free to `exec less <file>`,
+#                                        pipe a formatter through
+#                                        render_command_in_pager, or run an
+#                                        inline renderer then pause. Returns
+#                                        the exit status (a renderer that
+#                                        `exec`s never actually returns -
+#                                        the process image is replaced, same
+#                                        as preview-pane.sh's own pre-SG-01
+#                                        `exec less`). The optional [line]
+#                                        is the RESOLVED_LINE jump target;
+#                                        only text/markdown/pdf-text consume
+#                                        it.
+#
+# render_any <path> [line] (below) walks RENDER_KINDS in order and
+# dispatches to the FIRST match_render_<kind> that accepts the path,
+# returning that renderer's rc. Order matters, most-specific first, `text`
+# second-to-last, `fallback` last as the always-0 catch-all (never let a
+# broad kind shadow a specific one). scripts/renderers/*.sh is
+# auto-sourced by a glob at source time (below), the SAME mechanism as
+# scripts/handlers/*.sh above - adding a kind never edits the sourcing
+# mechanism, only RENDER_KINDS + one new file.
+#
+# preview-pane.sh's RESOLVED_MODE=file arm calls
+# `render_any "$target" "$CLIP_LINE"` and exits with its return code; it no
+# longer owns any render logic itself (that used to be the inline
+# lesskey/bat/`exec less` tail - it now lives in scripts/renderers/text.sh
+# verbatim, byte-for-byte behavior parity: o/d/e overlay keys, +LINE jump,
+# bat LESSOPEN highlighting, plain `less -N` when bat is absent).
+# open-in-viewer.sh is untouched - it drives the external herdr-file-viewer
+# pane, never an inline render.
+#
+# The FULL v0.4 type roster is pre-registered now (this sub-goal's whole
+# job - it is what makes every later renderer a single new-file edit):
+# markdown, image, gif, svg, pdf, archive, csv, json, ipynb, office, media,
+# sqlite, plist, text, fallback. Every kind except text/fallback ships as a
+# declining stub today (match_render_<kind> always returns 1, render_<kind>
+# is an unreachable no-op) - Wave 2/3 fills each one in as a single-file
+# change, RENDER_KINDS/render_any/the sourcing glob/preview-pane.sh stay
+# untouched.
+#
+# RENDER_HINTS (see render_hint_for_ext below) is an extension -> recommended
+# external-tool map for the full planned roster, consulted ONLY by the
+# fallback renderer (a "you might want X" hint when nothing else claimed the
+# file); no other renderer touches it.
+# -----------------------------------------------------------------------
+
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 
 clip_read() {
@@ -413,6 +475,12 @@ resolve() {
 # comment above.
 HANDLER_KINDS=(github vcs url dir path)
 
+# Render-registry order (first match wins): see the render-registry contract
+# comment at the top of this file. Most-specific kinds first; `text` second-
+# to-last, `fallback` last (the always-0 catch-all must not shadow a
+# specific kind - same rule HANDLER_KINDS's own ordering follows above).
+RENDER_KINDS=(markdown image gif svg pdf archive csv json ipynb office media sqlite plist text fallback)
+
 # LIB_DIR: this file's own directory (== scripts/), kept around (not
 # unset) so render_command_in_pager below can find ../lesskey the same way
 # the pane scripts locate it from their own script_dir.
@@ -429,6 +497,14 @@ for _herdr_handler in "$LIB_DIR"/handlers/*.sh; do
   [ -f "$_herdr_handler" ] && . "$_herdr_handler"
 done
 unset _herdr_handler
+
+# Auto-source every render-registry kind, same glob-at-source-time mechanism
+# as the handlers loop above - adding a kind never edits this loop.
+for _herdr_renderer in "$LIB_DIR"/renderers/*.sh; do
+  # shellcheck disable=SC1090
+  [ -f "$_herdr_renderer" ] && . "$_herdr_renderer"
+done
+unset _herdr_renderer
 
 # render_command_in_pager <argv...> -> runs argv, pages its combined
 # stdout+stderr through less (color preserved via -R, so a command that
@@ -469,6 +545,54 @@ resolve_any_token() {
     fi
   done
   return 1
+}
+
+# render_any <path> [line] -> see the render-registry contract at the top of
+# this file. Walks RENDER_KINDS in order and dispatches to the first
+# match_render_<kind> that claims <path>, running that renderer's
+# render_<kind> and returning its exit status. `fallback` is always last and
+# always matches, so this only returns 1 if RENDER_KINDS itself was emptied
+# out from under it (never true in shipped code) - every real call ends in
+# some renderer driving the pane.
+render_any() {
+  local path="$1" line="${2:-}" kind
+  for kind in "${RENDER_KINDS[@]}"; do
+    if "match_render_$kind" "$path"; then
+      "render_$kind" "$path" "$line"
+      return $?
+    fi
+  done
+  return 1
+}
+
+# render_hint_for_ext <ext> -> prints the recommended external tool for a
+# file extension on stdout, rc 1 if the extension has no hint. See the
+# RENDER_HINTS note in the render-registry contract above: consulted only by
+# scripts/renderers/fallback.sh. A plain case statement, not a bash
+# associative array (`declare -A`/`local -A` is bash 4+; macOS ships bash
+# 3.2 at /bin/bash - see the BASH 3.2 REWRITE note further down this file
+# for the same constraint elsewhere). <ext> is matched case-insensitively
+# via `tr` (a single call per fallback render, not a per-span hot loop, so
+# this is not the fork-avoidance concern that note is about).
+render_hint_for_ext() {
+  local ext
+  ext="$(printf '%s' "${1#.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    md) printf 'glow' ;;
+    png | jpg | jpeg | webp | bmp) printf 'chafa' ;;
+    gif) printf 'chafa' ;;
+    svg) printf 'rsvg-convert' ;;
+    pdf) printf 'poppler' ;;
+    zip | tar | tgz | jar) printf '(builtin)' ;;
+    csv | tsv) printf 'qsv' ;;
+    json) printf 'jq' ;;
+    ipynb) printf 'jupyter/nbconvert' ;;
+    docx | xlsx) printf 'pandoc' ;;
+    mp4 | mov | mp3) printf 'ffmpeg' ;;
+    sqlite | db) printf 'sqlite3' ;;
+    plist) printf '(builtin)' ;;
+    *) return 1 ;;
+  esac
 }
 
 # -----------------------------------------------------------------------

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -95,18 +95,11 @@ fi
 
 record_open "$raw"
 
-# Render with less driving the real FILE (not a bat pipe), so less keeps the
-# filename and its `visual` command works: `o` (or `v`) escalates to the
-# herdr-file-viewer pane via scripts/escalate.sh. bat becomes the LESSOPEN
-# preprocessor for syntax highlighting; without bat, plain less -N.
-lesskey_args=()
-[ -f "$script_dir/../lesskey" ] && lesskey_args=(--lesskey-src="$script_dir/../lesskey")
-
-export VISUAL="$script_dir/escalate.sh"
-# Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
-export QUICKLOOK_EDITOR_SCRIPT="$script_dir/escalate-editor.sh"
-if command -v bat >/dev/null 2>&1; then
-  export LESSOPEN='|bat --color=always --style=numbers,header %s'
-  exec less -R "${lesskey_args[@]}" ${CLIP_LINE:++$CLIP_LINE} "$target"
-fi
-exec less -N "${lesskey_args[@]}" ${CLIP_LINE:++$CLIP_LINE} "$target"
+# Render through the render registry (scripts/renderers/, contract
+# documented in lib.sh next to the handler-registry one): render_any walks
+# RENDER_KINDS and dispatches to the first renderer whose match_render_<kind>
+# claims $target. text.sh is today's real body (the old inline
+# lesskey/bat/`exec less` tail, moved in verbatim); fallback.sh is the
+# always-0 catch-all. Most renderers `exec`, so this call does not return.
+render_any "$target" "$CLIP_LINE"
+exit $?

--- a/scripts/renderers/archive.sh
+++ b/scripts/renderers/archive.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# archive.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real archive renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_archive() {
+  return 1
+}
+
+render_archive() {
+  # unreachable: match_render_archive always declines.
+  return 1
+}

--- a/scripts/renderers/csv.sh
+++ b/scripts/renderers/csv.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# csv.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real csv renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_csv() {
+  return 1
+}
+
+render_csv() {
+  # unreachable: match_render_csv always declines.
+  return 1
+}

--- a/scripts/renderers/fallback.sh
+++ b/scripts/renderers/fallback.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+# fallback.sh: the always-on catch-all render-registry renderer (v0.4, SG-01).
+# Real body now (a minimal one), not a stub: an unknown/binary file must
+# never dump raw bytes into the pane, even before any later Wave has a real
+# renderer for it. match_render_fallback always matches; RENDER_KINDS keeps
+# `fallback` last (see the render-registry contract comment at the top of
+# lib.sh) so it only ever runs once every more-specific kind has declined.
+
+match_render_fallback() {
+  return 0
+}
+
+# render_fallback <path> [line]: a `file(1)` one-line type description plus
+# an optional RENDER_HINTS-derived "you might want X" hint by extension -
+# never the file's raw bytes. `line` is accepted (for signature parity with
+# every other render_<kind>) but unused: a byte-safe type description has no
+# concept of a line to jump to.
+render_fallback() {
+  local path="$1" desc hint ext
+  desc="$(file -b -- "$path" 2>/dev/null)"
+  [ -n "$desc" ] || desc="unknown file type"
+  printf 'quicklook: no specific renderer for this file yet\n'
+  printf '  path: %s\n' "$path"
+  printf '  type: %s\n' "$desc"
+  ext="${path##*.}"
+  if [ "$ext" != "$path" ] && hint="$(render_hint_for_ext "$ext")" && [ -n "$hint" ]; then
+    printf '  hint: consider %s\n' "$hint"
+  fi
+  read -r -n1 -p 'press any key to close' _ 2>/dev/null || sleep 2
+  return 0
+}

--- a/scripts/renderers/gif.sh
+++ b/scripts/renderers/gif.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# gif.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real gif renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_gif() {
+  return 1
+}
+
+render_gif() {
+  # unreachable: match_render_gif always declines.
+  return 1
+}

--- a/scripts/renderers/image.sh
+++ b/scripts/renderers/image.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# image.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real image renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_image() {
+  return 1
+}
+
+render_image() {
+  # unreachable: match_render_image always declines.
+  return 1
+}

--- a/scripts/renderers/ipynb.sh
+++ b/scripts/renderers/ipynb.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# ipynb.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real ipynb renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_ipynb() {
+  return 1
+}
+
+render_ipynb() {
+  # unreachable: match_render_ipynb always declines.
+  return 1
+}

--- a/scripts/renderers/json.sh
+++ b/scripts/renderers/json.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# json.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real json renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_json() {
+  return 1
+}
+
+render_json() {
+  # unreachable: match_render_json always declines.
+  return 1
+}

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# markdown.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real markdown renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_markdown() {
+  return 1
+}
+
+render_markdown() {
+  # unreachable: match_render_markdown always declines.
+  return 1
+}

--- a/scripts/renderers/media.sh
+++ b/scripts/renderers/media.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# media.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real media renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_media() {
+  return 1
+}
+
+render_media() {
+  # unreachable: match_render_media always declines.
+  return 1
+}

--- a/scripts/renderers/office.sh
+++ b/scripts/renderers/office.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# office.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real office renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_office() {
+  return 1
+}
+
+render_office() {
+  # unreachable: match_render_office always declines.
+  return 1
+}

--- a/scripts/renderers/pdf.sh
+++ b/scripts/renderers/pdf.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# pdf.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real pdf renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_pdf() {
+  return 1
+}
+
+render_pdf() {
+  # unreachable: match_render_pdf always declines.
+  return 1
+}

--- a/scripts/renderers/plist.sh
+++ b/scripts/renderers/plist.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# plist.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real plist renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_plist() {
+  return 1
+}
+
+render_plist() {
+  # unreachable: match_render_plist always declines.
+  return 1
+}

--- a/scripts/renderers/sqlite.sh
+++ b/scripts/renderers/sqlite.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# sqlite.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real sqlite renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_sqlite() {
+  return 1
+}
+
+render_sqlite() {
+  # unreachable: match_render_sqlite always declines.
+  return 1
+}

--- a/scripts/renderers/svg.sh
+++ b/scripts/renderers/svg.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# svg.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
+# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
+# see the render-registry contract comment at the top of lib.sh. Wiring a
+# real svg renderer is a single-file edit to THIS file only - RENDER_KINDS,
+# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+
+match_render_svg() {
+  return 1
+}
+
+render_svg() {
+  # unreachable: match_render_svg always declines.
+  return 1
+}

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+# text.sh: the reference render-registry renderer (v0.4, SG-01). This is the
+# preview pane's original "render a local file" behavior - less driving the
+# real FILE (not a bat pipe), so less keeps the filename and its `visual`
+# command works: `o` (or `v`) escalates to the herdr-file-viewer pane via
+# scripts/escalate.sh. bat becomes the LESSOPEN preprocessor for syntax
+# highlighting; without bat, plain `less -N`. Moved here VERBATIM from
+# preview-pane.sh's old RESOLVED_MODE=file tail - byte-for-byte behavior
+# parity (o/d/e overlay keys via lesskey, +LINE jump, bat highlighting, the
+# no-bat fallback). See the render-registry contract comment at the top of
+# lib.sh.
+
+# match_render_text <path>: this renderer owns anything file(1) reports as a
+# text encoding (utf-8, us-ascii, iso-8859-1, ...); "binary" (and an
+# unreadable/missing path) declines, leaving the always-0 `fallback`
+# renderer as the catch-all (RENDER_KINDS keeps `text` second-to-last, see
+# lib.sh).
+match_render_text() {
+  local path="$1" enc
+  [ -f "$path" ] || return 1
+  enc="$(file -b --mime-encoding -- "$path" 2>/dev/null)"
+  [ "$enc" != "binary" ] && [ -n "$enc" ]
+}
+
+render_text() {
+  local target="$1" line="${2:-}"
+  local lesskey_args=()
+  [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
+
+  export VISUAL="$LIB_DIR/escalate.sh"
+  # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
+  export QUICKLOOK_EDITOR_SCRIPT="$LIB_DIR/escalate-editor.sh"
+  if command -v bat >/dev/null 2>&1; then
+    export LESSOPEN='|bat --color=always --style=numbers,header %s'
+    exec less -R "${lesskey_args[@]}" ${line:++$line} "$target"
+  fi
+  exec less -N "${lesskey_args[@]}" ${line:++$line} "$target"
+}

--- a/tests/render-registry.bats
+++ b/tests/render-registry.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# Tests for the render-registry dispatch (scripts/lib.sh render_any +
+# scripts/renderers/*.sh). Sources lib.sh directly, same fixture shape as
+# tests/registry.bats (the handler-registry's own test file).
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  RENDERERS_DIR="$BATS_TEST_DIRNAME/../scripts/renderers"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf 'hello world\nline two\n' > "$FIX/text.md"
+  # a real binary file (null + high bytes) so file(1) reports mime-encoding
+  # "binary", not a text encoding - see match_render_text/match_render_fallback.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/blob.bin"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# ---- text/fallback real bodies (the only two non-stub renderers) ----
+
+@test "render-registry: text renderer matches a text file" {
+  match_render_text "$FIX/text.md"
+}
+
+@test "render-registry: fallback renderer matches a binary file (text declines it)" {
+  ! match_render_text "$FIX/blob.bin"
+  match_render_fallback "$FIX/blob.bin"
+}
+
+@test "render-registry: fallback always matches, even a plain text file" {
+  # fallback is the always-0 catch-all; RENDER_KINDS ordering (text before
+  # fallback), not fallback's own predicate, is what keeps it from shadowing
+  # text - see the ordering test below.
+  match_render_fallback "$FIX/text.md"
+}
+
+# ---- an unmatched-by-specific-kind file falls through to text/fallback ----
+
+@test "render-registry: every declining stub actually declines a plain text file (proves the fallthrough is real, not a no-op chain)" {
+  local kind
+  for kind in markdown image gif svg pdf archive csv json ipynb office media sqlite plist; do
+    if "match_render_$kind" "$FIX/text.md"; then
+      echo "kind $kind unexpectedly claimed a plain text file" >&2
+      return 1
+    fi
+  done
+}
+
+@test "render-registry: render_any dispatches a plain text file to the text renderer" {
+  # render_text itself execs less (the real TTY-driving body) - overridden
+  # here to a plain marker so this test exercises render_any's DISPATCH
+  # decision, not the pager.
+  run bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/text.md'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT-RENDERED:$FIX/text.md" ]
+}
+
+@test "render-registry: render_any dispatches a binary file to the fallback renderer" {
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/blob.bin'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK-RENDERED:$FIX/blob.bin" ]
+}
+
+@test "render-registry: the real fallback renderer never dumps raw bytes, only a file(1) type line" {
+  run bash -c ". '$LIB'; render_fallback '$FIX/blob.bin' <<<'x'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no specific renderer"* ]]
+  [[ "$output" == *"type:"* ]]
+  # blob.bin's raw bytes spell the ASCII substring "binary" on purpose (see
+  # setup); if render_fallback ever `cat`'d the file instead of describing
+  # it, that literal substring would leak into the output. A short,
+  # line-bounded summary (never a byte-for-byte dump) is the point.
+  [[ "$output" != *"binary"* ]]
+  [ "$(printf '%s\n' "$output" | wc -l)" -le 4 ]
+}
+
+# ---- a registered renderer wins / first-match ordering ----
+
+@test "render-registry: a registered renderer wins over every later kind (including fallback)" {
+  match_render_zzz() { return 0; }
+  render_zzz() { printf 'ZZZ-RENDERED:%s\n' "$1"; return 0; }
+  RENDER_KINDS=(zzz "${RENDER_KINDS[@]}")
+
+  run render_any "$FIX/text.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ZZZ-RENDERED:$FIX/text.md" ]
+}
+
+@test "render-registry: first-match ordering - position decides, not the target's real type" {
+  # zzz claims EVERYTHING; since it is FIRST in RENDER_KINDS it must win even
+  # for a target (a binary file) that would otherwise resolve to fallback.
+  match_render_zzz() { return 0; }
+  render_zzz() { printf 'ZZZ\n'; return 0; }
+  RENDER_KINDS=(zzz "${RENDER_KINDS[@]}")
+
+  run render_any "$FIX/blob.bin"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ZZZ" ]
+}
+
+# ---- contract-compliance: every renderer exports match_render_<kind> + render_<kind> ----
+
+@test "render-registry: every scripts/renderers/*.sh exports match_render_<kind> and render_<kind>" {
+  local f kind
+  for f in "$RENDERERS_DIR"/*.sh; do
+    kind="$(basename "$f" .sh)"
+    kind="${kind//-/_}"
+    declare -F "match_render_$kind" >/dev/null || {
+      echo "missing match_render_$kind in $f" >&2
+      return 1
+    }
+    declare -F "render_$kind" >/dev/null || {
+      echo "missing render_$kind in $f" >&2
+      return 1
+    }
+  done
+}
+
+@test "render-registry: RENDER_KINDS has fallback last and text second-to-last" {
+  local n="${#RENDER_KINDS[@]}"
+  [ "${RENDER_KINDS[$((n - 1))]}" = "fallback" ]
+  [ "${RENDER_KINDS[$((n - 2))]}" = "text" ]
+}
+
+@test "render-registry: RENDER_KINDS pre-registers the full v0.4 roster" {
+  local expected="markdown image gif svg pdf archive csv json ipynb office media sqlite plist text fallback"
+  [ "${RENDER_KINDS[*]}" = "$expected" ]
+}


### PR DESCRIPTION
## Summary

Refactor: extract the preview pane's file-render step into one `lib.sh` entry (`render_any`) + a
renderer registry (`scripts/renderers/`), so a new file TYPE is one file. No behavior change; the
current text/source rendering (less + bat + o/d/e keys) moves into `renderers/text.sh` with parity;
existing tests pass unchanged. Pre-registers the full v0.4 type roster as declining stubs + lands
the always-on binary-safe `fallback`. Run-table below. Foundation for the v0.4 render types.

## Run-table

| Command | Exit | Result |
|---|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh scripts/renderers/*.sh` | 0 | clean |
| `bats tests/ </dev/null` | 0 | 260 ok, 0 not ok (248 pre-existing + 12 new in `tests/render-registry.bats`) |
| `bats tests/render-registry.bats </dev/null` | 0 | 12 ok, 0 not ok |
| `grep -vE '^\s*#' scripts/preview-pane.sh \| grep -n "exec less"` | 1 (no match) | confirms no inline `exec less` remains in `preview-pane.sh` (the two hits on a plain `grep -n "exec less"` are comment mentions only) |

## Contract

`render_any <path> [line]` lives in `scripts/lib.sh:557` (post-refactor). Each
`scripts/renderers/<kind>.sh` exports `match_render_<kind> <path>` (rc 0 iff it owns the file's
TYPE and its tool is on PATH) and `render_<kind> <path> [line]` (drives the pane). `RENDER_KINDS`
pre-registers the full roster (`markdown image gif svg pdf archive csv json ipynb office media
sqlite plist text fallback`); every kind except `text`/`fallback` ships as a declining stub. `text`
is the byte-parity reference renderer (less + bat LESSOPEN + lesskey `o`/`d`/`e` + `+LINE`, moved in
verbatim); `fallback` is a minimal real body (a `file(1)` type line, never a raw byte dump) that
always matches. `RENDER_HINTS` (`render_hint_for_ext`) gives the fallback renderer an
extension -> recommended-tool hint for the full planned roster. The contract is documented in a
comment block at the top of `lib.sh`, next to the handler-registry one.

`preview-pane.sh`'s `RESOLVED_MODE=file` arm now calls `render_any "$target" "$CLIP_LINE"` instead
of the old inline lesskey/bat/`exec less` tail. `open-in-viewer.sh`, the handler registry, lesskey,
and recents are untouched.

## Deviations from the goal file

- The goal file's "Handoff on completion" section (flip ROADMAP 01 to `[x]`, overwrite HANDOFF.md,
  append to DECISIONS.md) was **not** done from this worker: those files live in the private
  `ops-toolkit` mega-goal folder, and this worker's dispatch instructions explicitly said not to
  write into `ops-toolkit`. Left for the mega-goal orchestrator to reconcile after merge.
- No other deviations; the roster, ordering, stub/real split, and `RENDER_HINTS` map match the goal
  file verbatim.
