### PR TITLE
install-renderers: dry-run-default tiered tool installer + prereqs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,33 @@ Everything else is optional, and the plugin degrades instead of failing:
 | [`fzf`](https://github.com/junegunn/fzf) | picking among multiple bare-filename matches in the preview flow, and the `recents` list | single bare-filename matches still open, multiple are listed so you can copy an exact path; `recents` reopens the most recent entry directly |
 | [herdr-file-viewer](https://github.com/smarzban/herdr-file-viewer) plugin | the `open-in-viewer` action | the action falls back to the preview overlay automatically |
 
+## Prerequisites
+
+v0.4 renders non-text files (markdown, images, pdf, archives, csv, json, office docs, media, sqlite/plist, and more) in the preview overlay instead of paging raw bytes. Every renderer beyond the hard requirements above is optional and degrades gracefully: a missing tool never crashes the overlay, it falls back to a plainer render (or, at the floor, the always-on `file(1)` + `hexyl` guard) with a one-line install hint.
+
+```sh
+./scripts/install-renderers.sh            # preview only, installs nothing (the default)
+./scripts/install-renderers.sh --p1 --apply   # actually install just the P1 tier
+```
+
+`--dry-run` is the default (a bare invocation is identical); it previews the brew formula for each tier and skips anything already on `PATH`, touching nothing. `--apply` is the explicit opt-in that runs `brew install`. `--p1`/`--p2`/`--p3` are repeatable and select a tier; with none given, every tier is previewed/installed. No Homebrew? The script detects that and prints the manual (`apt`/`cargo`) fallback line as a comment instead of failing.
+
+| Tier | Tool | Powers | Without it |
+|---|---|---|---|
+| P1 | [`glow`](https://github.com/charmbracelet/glow) | markdown (`.md`/`.markdown`), and the rendered half of `.ipynb` (via `pandoc`'s markdown conversion) | falls back to the `file(1)`+`hexyl` guard with an install hint |
+| P1 | [`chafa`](https://github.com/hpjansson/chafa) | still images (`png`/`jpg`/`jpeg`/`webp`/`bmp`) and animated gif (`.gif`, first-frame still if `--animate` degrades) | images/gif fall back to the `file(1)`+`hexyl` guard with an install hint |
+| P1 | [`hexyl`](https://github.com/sharkdp/hexyl) | the first-KB hexdump in the always-on unknown-binary guard | the guard still shows the `file(1)` type line + install hint, just without the hexdump |
+| P2 | `rsvg-convert` (Homebrew `librsvg`) | svg (`.svg`) -> png -> `chafa` | falls back to the `file(1)`+`hexyl` guard with an install hint |
+| P2 | `pdftoppm` + `pdftotext` (Homebrew `poppler`) | pdf (`.pdf`): first-page image (`pdftoppm` -> `chafa`) plus extracted text | missing `pdftoppm` degrades to `pdftotext`-only text mode; missing both falls back to the `file(1)`+`hexyl` guard with an install hint |
+| P2 | [`qsv`](https://github.com/dathere/qsv) | csv/tsv (`.csv`/`.tsv`) as an aligned table | renders as plain text via `less`, then the guard if even that fails |
+| P2 | [`jq`](https://github.com/jqlang/jq) | minified json (`.json`), pretty-printed | renders as plain text via `less`, then the guard if even that fails |
+| P3 | [`pandoc`](https://pandoc.org/) | office docs (`docx`/`xlsx` -> markdown or csv) and `.ipynb` notebooks (-> markdown, then `glow`) | office docs fall back to the `file(1)`+`hexyl` guard with an install hint; notebooks degrade to plain text, then the guard |
+| P3 | `ffprobe` + `ffmpeg` (Homebrew `ffmpeg`) | media (`mp4`/`mov`/`mp3`): metadata plus a poster-frame image (never playback) | missing `ffmpeg` degrades to `ffprobe` metadata only; missing both falls back to the `file(1)`+`hexyl` guard with an install hint |
+| P3 | `sqlite3` (Homebrew `sqlite`) | sqlite databases (`.sqlite`/`.db`): schema + table listing | falls back to the `file(1)`+`hexyl` guard with an install hint |
+| , (base-system) | `unzip` / `tar` | archives (`zip`/`tar`/`tgz`/`jar`): content listing (`unzip -l` / `tar -tf`) | always present on macOS + Linux; not installed by this script |
+| , (base-system) | `plutil` | plist files (`.plist`): structured dump (`plutil -p`) | always present on macOS; not installed by this script |
+| , (base-system, hard dependency) | `file` | the mime/type discriminator every renderer (and the always-on fallback) is gated on | always present on macOS + Linux; not installed by this script |
+
 ## How it works
 
 - **preview** opens a plugin overlay pane (a real TTY), reads `$QUICKLOOK_TOKEN`, an argument, or the clipboard, resolves it through the [handler registry](DESIGN.md#handler-registry), and renders it per `RESOLVED_MODE`: a `file` opens in `less` (bat as the `LESSOPEN` colorizer), a `browser` URL is handed to `url_open` and the overlay closes, a `command` token (vcs) or `viewer` degrade (a directory without herdr-file-viewer installed) pages its output through `less -R`. Esc-to-quit and the three in-popup shell-escapes ship via a `lesskey` file: `o` escalates via less's single `visual` slot (`$VISUAL` -> `escalate.sh`); `e` and `d` cannot reuse that slot, so `e` is bound to less's `pshell` action (`escalate-editor.sh`) and `d` to its `shell` action (`dirty-diff.sh`), each with a `^P` extra-string prefix that suppresses the shell-escape's normal "done" prompt so the overlay resumes cleanly. See [DESIGN.md](DESIGN.md#the-lesskey-three-slot-map) for why there are only three slots to go around.

--- a/scripts/install-renderers.sh
+++ b/scripts/install-renderers.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# install-renderers.sh: brew-first installer for herdr-quicklook's v0.4
+# render-anything optional tools, grouped into P1/P2/P3 tiers so a user only
+# installs the tools they actually want. `--dry-run` (the default, a bare
+# invocation included) never touches the host: it previews the brew formula
+# per tier, skipping anything already on PATH, and exits 0. `--apply` is the
+# explicit opt-in that actually runs `brew install`. Never `curl | bash`;
+# when brew itself is absent this prints the manual (apt/pip/cargo) fallback
+# line as a comment and moves on -- it never executes a fallback command,
+# and never fails hard just because brew (or a formula) is missing.
+#
+# Tool -> formula map (ROADMAP.md's Type->tool->render table, this
+# sub-goal's design): p1 = glow, chafa, hexyl (Wave 2: markdown, images +
+# animated gif, the always-on file(1)+hexyl fallback). p2 = librsvg
+# (rsvg-convert), poppler (pdftoppm + pdftotext), qsv, jq (Wave 3's P2 pack:
+# svg/pdf/csv/json -- the archive type's unzip/tar are base-system, never
+# installed here). p3 = pandoc, ffmpeg (ffprobe + ffmpeg), sqlite (sqlite3)
+# (Wave 3's P3 pack: ipynb/office/media/sqlite+plist). unzip/tar/plutil/file
+# are base-system on macOS + Linux and never appear in the table below.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+usage() {
+  cat <<'EOF'
+usage: install-renderers.sh [--dry-run|--apply] [--p1] [--p2] [--p3]
+
+  --dry-run   preview only, touches nothing (DEFAULT; same as a bare invocation)
+  --apply     actually run `brew install` for anything missing
+  --p1        select the P1 tier (glow, chafa, hexyl)
+  --p2        select the P2 tier (librsvg, poppler, qsv, jq)
+  --p3        select the P3 tier (pandoc, ffmpeg, sqlite)
+              repeatable; default (no tier flag given) covers all three tiers
+  -h, --help  show this message
+EOF
+}
+
+die() {
+  printf 'install-renderers: %s\n' "$1" >&2
+  usage >&2
+  exit 1
+}
+
+# tier:formula:check-bins(comma-separated):manual fallback (documented only,
+# never executed). One line per tool; keep in the fixed p1/p2/p3 tier order
+# above so the preview output reads top-down by priority.
+tool_table() {
+  cat <<'EOF'
+p1:glow:glow:apt install glow (or see https://github.com/charmbracelet/glow#installation)
+p1:chafa:chafa:apt install chafa
+p1:hexyl:hexyl:apt install hexyl (or: cargo install hexyl)
+p2:librsvg:rsvg-convert:apt install librsvg2-bin
+p2:poppler:pdftoppm,pdftotext:apt install poppler-utils
+p2:qsv:qsv:cargo install qsv (no apt package)
+p2:jq:jq:apt install jq
+p3:pandoc:pandoc:apt install pandoc
+p3:ffmpeg:ffprobe,ffmpeg:apt install ffmpeg
+p3:sqlite:sqlite3:apt install sqlite3
+EOF
+}
+
+apply=0
+# tiers_selected: a space-separated word list, not a bash array. macOS
+# ships bash 3.2 as /bin/bash (what `#!/usr/bin/env bash` resolves to on a
+# host with no Homebrew bash yet -- exactly the host this script exists to
+# bootstrap), and 3.2 raises "unbound variable" under `set -u` when
+# expanding "${arr[@]}" on a still-empty array. A plain word-split string
+# sidesteps that entirely; tier names are simple tokens, never quoted or
+# space-containing, so word-splitting them back apart is safe.
+tiers_selected=""
+
+tier_selected() {
+  case " $tiers_selected " in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) apply=0 ;;
+    --apply) apply=1 ;;
+    --p1) tier_selected p1 || tiers_selected="$tiers_selected p1" ;;
+    --p2) tier_selected p2 || tiers_selected="$tiers_selected p2" ;;
+    --p3) tier_selected p3 || tiers_selected="$tiers_selected p3" ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) die "unknown flag: $1" ;;
+  esac
+  shift
+done
+
+[ -z "$tiers_selected" ] && tiers_selected="p1 p2 p3"
+
+brew_bin="$(command -v brew || true)"
+
+if [ "$apply" -eq 1 ]; then
+  echo "install-renderers: --apply (brew: ${brew_bin:-not found})"
+else
+  echo "install-renderers: --dry-run, previewing only -- nothing will be installed"
+fi
+
+while IFS=: read -r tier formula bins manual; do
+  [ -z "$tier" ] && continue
+  tier_selected "$tier" || continue
+
+  have=1
+  IFS=',' read -ra bin_list <<<"$bins"
+  for b in "${bin_list[@]}"; do
+    command -v "$b" >/dev/null 2>&1 || have=0
+  done
+  bins_display="${bins//,/ + }"
+
+  if [ "$have" -eq 1 ]; then
+    echo "  [$tier] already installed: $formula ($bins_display)"
+    continue
+  fi
+
+  if [ "$apply" -eq 0 ]; then
+    if [ -n "$brew_bin" ]; then
+      echo "  [$tier] would install: brew install $formula   (provides: $bins_display)"
+    else
+      echo "  [$tier] # no brew found -- install manually: $manual"
+    fi
+    continue
+  fi
+
+  # --apply from here down.
+  if [ -n "$brew_bin" ]; then
+    echo "  [$tier] installing: brew install $formula"
+    "$brew_bin" install "$formula" ||
+      echo "  [$tier] brew install $formula failed, skipping (not fatal)" >&2
+  else
+    echo "  [$tier] # no brew found -- install manually: $manual"
+  fi
+done < <(tool_table)
+
+echo "install-renderers: unzip, tar, plutil, file are base-system -- already present, never installed by this script"

--- a/tests/install-renderers.bats
+++ b/tests/install-renderers.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# Tests for scripts/install-renderers.sh: dry-run-default (never touches the
+# host), --apply's brew calls, tier selection (--p1/--p2/--p3), idempotence
+# (a tool already on PATH is skipped), and usage on an unknown flag.
+#
+# PATH-stub gotcha (see NOTES.md / recents.bats), sharpened for this suite:
+# the dev host ships jq AND sqlite3 as base binaries under /usr/bin (not
+# just via Homebrew), alongside dirname/grep/etc. So "exclude
+# /opt/homebrew/bin" alone is not enough here -- every installer run below
+# gets PATH="$STUB:/bin" ONLY (via a scoped assignment on the `run` line,
+# never a persistent `export`), where /bin has just enough coreutils (cat,
+# bash, chmod, mkdir...) for the script to execute, but no jq/sqlite3/dirname.
+# $STUB supplies a `dirname` shim (the script's one real external
+# dependency besides an optional `brew`) plus whatever brew/tool stubs a
+# given test needs. Because PATH is only ever scoped to the `run` line
+# itself, the test body's OWN grep/cat calls keep running under bats' normal
+# (unrestricted) PATH.
+
+setup() {
+  SCRIPT_SRC="$BATS_TEST_DIRNAME/../scripts/install-renderers.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/repo/scripts"
+  cp "$SCRIPT_SRC" "$FIX/repo/scripts/install-renderers.sh"
+  chmod +x "$FIX/repo/scripts/install-renderers.sh"
+
+  STUB="$(mktemp -d)"
+  # dirname shim: the only external binary install-renderers.sh calls
+  # besides an optional brew (it derives repo_root from dirname
+  # "${BASH_SOURCE[0]}"). Real dirname lives in /usr/bin alongside jq/
+  # sqlite3 on this host, so it can't be relied on once /usr/bin is
+  # excluded; this pure-bash shim covers the one shape the script needs
+  # (a plain absolute/relative file path, no trailing slash).
+  cat >"$STUB/dirname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  */*) printf '%s\n' "${1%/*}" ;;
+  *) printf '%s\n' "." ;;
+esac
+EOF
+  chmod +x "$STUB/dirname"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+# run_installer <args...>: runs the fixture script with PATH scoped to
+# "$STUB:/bin" for this one invocation only (never a persistent export), so
+# no real Homebrew-installed or base-system tool on this dev host can leak
+# through and no assertion later in the test loses grep/cat.
+run_installer() {
+  PATH="$STUB:/bin" run bash "$FIX/repo/scripts/install-renderers.sh" "$@"
+}
+
+# brew_stub_present: a fake `brew` in $STUB that logs every invocation's
+# argv to $FIX/brew.log and no-ops (exit 0). Never a real install.
+brew_stub_present() {
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/brew.log"\nexit 0\n' "$FIX" >"$STUB/brew"
+  chmod +x "$STUB/brew"
+}
+
+# stub_present_bin <name>: makes <name> resolve on PATH via $STUB, so the
+# installer reports it "already installed" without touching a real tool.
+stub_present_bin() {
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB/$1"
+  chmod +x "$STUB/$1"
+}
+
+@test "install-renderers.sh: bare invocation previews and exits 0, never calls brew to install" {
+  brew_stub_present
+  run_installer
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--dry-run"* ]]
+  [[ "$output" == *"would install: brew install glow"* ]]
+  # brew was never invoked at all (dry-run only detects it via command -v)
+  [ ! -e "$FIX/brew.log" ]
+}
+
+@test "install-renderers.sh: --dry-run explicitly behaves the same as bare" {
+  brew_stub_present
+  run_installer --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"would install: brew install chafa"* ]]
+  [ ! -e "$FIX/brew.log" ]
+}
+
+@test "install-renderers.sh: --apply calls the stubbed brew install with the right formulae" {
+  brew_stub_present
+  run_installer --apply
+  [ "$status" -eq 0 ]
+  for formula in glow chafa hexyl librsvg poppler qsv jq pandoc ffmpeg sqlite; do
+    grep -q "^install $formula\$" "$FIX/brew.log"
+  done
+}
+
+@test "install-renderers.sh: --p1 only touches the P1 set" {
+  brew_stub_present
+  run_installer --p1 --apply
+  [ "$status" -eq 0 ]
+  grep -q "^install glow\$" "$FIX/brew.log"
+  grep -q "^install chafa\$" "$FIX/brew.log"
+  grep -q "^install hexyl\$" "$FIX/brew.log"
+  # none of P2/P3's formulae were installed
+  ! grep -q "^install librsvg\$" "$FIX/brew.log"
+  ! grep -q "^install poppler\$" "$FIX/brew.log"
+  ! grep -q "^install qsv\$" "$FIX/brew.log"
+  ! grep -q "^install jq\$" "$FIX/brew.log"
+  ! grep -q "^install pandoc\$" "$FIX/brew.log"
+  ! grep -q "^install ffmpeg\$" "$FIX/brew.log"
+  ! grep -q "^install sqlite\$" "$FIX/brew.log"
+}
+
+@test "install-renderers.sh: a tool already on PATH is reported already-installed with no brew call for it" {
+  brew_stub_present
+  stub_present_bin jq
+  run_installer --p2 --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already installed: jq (jq)"* ]]
+  ! grep -q "^install jq\$" "$FIX/brew.log"
+  # its P2 siblings still get installed
+  grep -q "^install librsvg\$" "$FIX/brew.log"
+  grep -q "^install poppler\$" "$FIX/brew.log"
+  grep -q "^install qsv\$" "$FIX/brew.log"
+}
+
+@test "install-renderers.sh: a multi-binary tool (poppler) needs every binary present to skip" {
+  brew_stub_present
+  stub_present_bin pdftoppm
+  run_installer --p2 --apply
+  [ "$status" -eq 0 ]
+  # pdftotext is still missing, so poppler is NOT reported already-installed
+  grep -q "^install poppler\$" "$FIX/brew.log"
+}
+
+@test "install-renderers.sh: no brew on PATH prints the manual fallback as a comment, never fails" {
+  run_installer --p1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# no brew found -- install manually: apt install glow"* ]]
+}
+
+@test "install-renderers.sh: no brew on PATH with --apply still exits 0 and never installs" {
+  run_installer --p1 --apply
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# no brew found -- install manually"* ]]
+  [ ! -e "$FIX/brew.log" ]
+}
+
+@test "install-renderers.sh: an unknown flag exits nonzero with usage" {
+  brew_stub_present
+  run_installer --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"usage:"* ]]
+}


### PR DESCRIPTION
Adds `scripts/install-renderers.sh` (brew-first, `--dry-run` default + `--apply`, grouped P1/P2/P3, idempotent) so users install only the renderer tools they want, plus a README Prerequisites table documenting every external tool and exactly what degrades to what when it is absent. Pairs with the per-renderer graceful degrade (each type falls back to the `file(1)`+hexyl guard with an install hint). Run-table + dry-run transcript below.

## Run-table

| Command | Exit code | Result |
|---|---|---|
| `shellcheck -x scripts/*.sh scripts/handlers/*.sh` | 0 | clean, no warnings |
| `bats tests/ </dev/null` | 0 | 257 ok, 0 not ok (`1..257`, incl. the 9 new `install-renderers.bats` cases) |
| `./scripts/install-renderers.sh --dry-run` | 0 | preview only, transcript below |

## Dry-run transcript

<details>
<summary><code>./scripts/install-renderers.sh --dry-run</code></summary>

```
install-renderers: --dry-run, previewing only -- nothing will be installed
  [p1] already installed: glow (glow)
  [p1] already installed: chafa (chafa)
  [p1] would install: brew install hexyl   (provides: hexyl)
  [p2] already installed: librsvg (rsvg-convert)
  [p2] already installed: poppler (pdftoppm + pdftotext)
  [p2] already installed: qsv (qsv)
  [p2] already installed: jq (jq)
  [p3] already installed: pandoc (pandoc)
  [p3] already installed: ffmpeg (ffprobe + ffmpeg)
  [p3] already installed: sqlite (sqlite3)
install-renderers: unzip, tar, plutil, file are base-system -- already present, never installed by this script
```

</details>
