### PR TITLE
feat(fallback): hexyl/file always-on fallback renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Unknown/binary files now render through an always-on fallback guard: a
+  `file(1)` type line, a bounded first-KB hexdump (`hexyl`, degrading to
+  `xxd` then the base-system `od`), and an "install `<tool>`" hint when a
+  richer renderer exists for the extension but its tool isn't installed -
+  the floor every other v0.4 renderer degrades onto, so a preview never
+  dumps a file's raw bytes into the terminal.
+
 - Bare domains (hermes.d.foundation, herdr.dev) classify as urls and open
   the browser with an https scheme, gated on a TLD allowlist so file
   extensions (.md, .go, .sh) never misclassify.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ A few things that make it more than a pager:
 
 Resolution runs top-down: exact paths win before any fuzzy matching, and the first hit stops the chain. See [DESIGN.md](DESIGN.md) for how a token kind maps to its handler.
 
+## Renderers (v0.4)
+
+Once a token resolves to a local file, a second registry decides HOW to draw it: the closest-matching type gets a real renderer, and anything else lands on the always-on fallback below - the one guarantee that a preview never dumps a file's raw bytes into your terminal.
+
+| File type | What you get |
+|---|---|
+| unknown / binary (the catch-all fallback) | A `file(1)` one-line type description, a bounded first-~1KB hexdump ([`hexyl`](https://github.com/sharkdp/hexyl) when installed, degrading to `xxd` then the base-system `od` - never raw bytes), and an "install `<tool>`" hint when the extension maps to a known type whose renderer tool isn't on PATH yet |
+
 ## Install
 
 ```sh

--- a/scripts/renderers/fallback.sh
+++ b/scripts/renderers/fallback.sh
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
-# fallback.sh: the always-on catch-all render-registry renderer (v0.4, SG-01).
-# Real body now (a minimal one), not a stub: an unknown/binary file must
-# never dump raw bytes into the pane, even before any later Wave has a real
-# renderer for it. match_render_fallback always matches; RENDER_KINDS keeps
+# fallback.sh: the always-on catch-all render-registry renderer (v0.4).
+# This IS the floor of the whole registry - the guarantee that nothing ever
+# dumps raw bytes into the pane, even for a file no later Wave has a real
+# renderer for. match_render_fallback always matches; RENDER_KINDS keeps
 # `fallback` last (see the render-registry contract comment at the top of
 # lib.sh) so it only ever runs once every more-specific kind has declined.
 
@@ -10,22 +10,65 @@ match_render_fallback() {
   return 0
 }
 
-# render_fallback <path> [line]: a `file(1)` one-line type description plus
-# an optional RENDER_HINTS-derived "you might want X" hint by extension -
-# never the file's raw bytes. `line` is accepted (for signature parity with
-# every other render_<kind>) but unused: a byte-safe type description has no
-# concept of a line to jump to.
+# _fallback_hexdump <path> -> a safe dump of roughly the first 1KB of
+# <path> on stdout: hexyl (offset + hex + ASCII gutter) when it is on PATH,
+# else xxd, else the base-system `od -A x -t x1` (the GNU-only `x1z`
+# ASCII-gutter modifier is not available on macOS's BSD od, so this stays
+# hex-only rather than pick a non-portable format). `head -c 1024` bounds
+# the input BEFORE any dumper ever sees the bytes, so a multi-GB file never
+# gets fully piped through. Every one of these three tools' own output is
+# already a safe hex/ASCII-escaped text representation - not "the file's
+# bytes", a description of them - which is the actual guarantee here: a
+# control byte or an embedded terminal escape sequence in <path> can never
+# reach the pane un-hexed, no matter which of the three ran. file(1) + one
+# of xxd/od (never both missing on macOS/Linux) are the only hard deps;
+# hexyl is a nice-to-have, never a requirement to function.
+_fallback_hexdump() {
+  local path="$1"
+  if command -v hexyl >/dev/null 2>&1; then
+    head -c 1024 -- "$path" | hexyl
+  elif command -v xxd >/dev/null 2>&1; then
+    head -c 1024 -- "$path" | xxd
+  else
+    head -c 1024 -- "$path" | od -A x -t x1
+  fi
+}
+
+# _fallback_hint <path> -> "install <tool> for a richer preview of .<ext>
+# files" on stdout when <path>'s extension maps (RENDER_HINTS, via
+# render_hint_for_ext in lib.sh) to a real external tool that is NOT
+# already on PATH. rc 1 (no output) when: no extension, no mapping, the
+# mapping is `(builtin)` (zip/tar/plist already have no external-tool
+# story), or the mapped tool IS installed (a genuinely unknown binary
+# reaching fallback despite a known extension - nothing to recommend).
+_fallback_hint() {
+  local path="$1" ext tool
+  ext="${path##*.}"
+  [ "$ext" != "$path" ] || return 1
+  tool="$(render_hint_for_ext "$ext")" || return 1
+  [ "$tool" != '(builtin)' ] || return 1
+  command -v "$tool" >/dev/null 2>&1 && return 1
+  printf 'install %s for a richer preview of .%s files' "$tool" "$ext"
+}
+
+# render_fallback <path> [line]: the always-on guard - a `file(1)` one-line
+# type description, a bounded first-KB hexdump (_fallback_hexdump), and a
+# targeted install hint (_fallback_hint), paged through `less`. `less -R`
+# is a no-op passthrough when stdout is not a real terminal (e.g. under
+# bats), the same convention render_command_in_pager relies on in lib.sh.
+# `line` is accepted (signature parity with every other render_<kind>) but
+# unused: a byte-safe type description has no concept of a line to jump to.
 render_fallback() {
-  local path="$1" desc hint ext
+  local path="$1" desc hint
   desc="$(file -b -- "$path" 2>/dev/null)"
   [ -n "$desc" ] || desc="unknown file type"
-  printf 'quicklook: no specific renderer for this file yet\n'
-  printf '  path: %s\n' "$path"
-  printf '  type: %s\n' "$desc"
-  ext="${path##*.}"
-  if [ "$ext" != "$path" ] && hint="$(render_hint_for_ext "$ext")" && [ -n "$hint" ]; then
-    printf '  hint: consider %s\n' "$hint"
-  fi
-  read -r -n1 -p 'press any key to close' _ 2>/dev/null || sleep 2
+  hint="$(_fallback_hint "$path")" || hint=""
+  {
+    printf 'quicklook: no specific renderer for this file yet\n'
+    printf '  path: %s\n' "$path"
+    printf '  type: %s\n\n' "$desc"
+    _fallback_hexdump "$path"
+    [ -n "$hint" ] && printf '\n  hint: %s\n' "$hint"
+  } | less -R
   return 0
 }

--- a/tests/render-registry.bats
+++ b/tests/render-registry.bats
@@ -74,17 +74,17 @@ teardown() {
   [ "$output" = "FALLBACK-RENDERED:$FIX/blob.bin" ]
 }
 
-@test "render-registry: the real fallback renderer never dumps raw bytes, only a file(1) type line" {
+@test "render-registry: the real fallback renderer describes the file plus a safe hexdump, never the raw bytes" {
+  # blob.bin opens with a NUL/high-byte run (see setup) - the full
+  # hexyl/xxd/od-degrade guard and its "never un-hexed" guarantee are
+  # covered in depth by tests/renderers-fallback.bats; this is just the
+  # render-registry-level smoke check that fallback's real body still
+  # describes-then-dumps rather than `cat`ing the path.
+  export PATH="/usr/bin:/bin"
   run bash -c ". '$LIB'; render_fallback '$FIX/blob.bin' <<<'x'"
   [ "$status" -eq 0 ]
   [[ "$output" == *"no specific renderer"* ]]
   [[ "$output" == *"type:"* ]]
-  # blob.bin's raw bytes spell the ASCII substring "binary" on purpose (see
-  # setup); if render_fallback ever `cat`'d the file instead of describing
-  # it, that literal substring would leak into the output. A short,
-  # line-bounded summary (never a byte-for-byte dump) is the point.
-  [[ "$output" != *"binary"* ]]
-  [ "$(printf '%s\n' "$output" | wc -l)" -le 4 ]
 }
 
 # ---- a registered renderer wins / first-match ordering ----

--- a/tests/renderers-fallback.bats
+++ b/tests/renderers-fallback.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/fallback.sh, the always-on render-registry
+# guard (v0.4). This renderer IS every other renderer's negative control -
+# fallback.sh always matches (RENDER_KINDS keeps it last, see
+# tests/render-registry.bats for the ordering guarantees), so its own tests
+# are the reference for "an unknown/binary file never dumps raw bytes".
+#
+# PATH is rebuilt PER TEST (never inherited) so "tool absent" is a real,
+# deterministic absence, not an artifact of what happens to be installed on
+# the dev box - same convention as tests/handlers-dir.bats /
+# tests/recents.bats: deliberately excludes /opt/homebrew/bin and
+# /usr/local/bin so a brew/cargo-installed hexyl/chafa never leaks in.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # A real binary fixture carrying an actual terminal escape sequence
+  # (ESC [ 2 J - clear screen) plus NUL/high bytes - the concrete "this
+  # must never reach the pane un-hexed" payload the safety tests assert
+  # against.
+  printf '\x1b[2J\x00\x01\xffHELLO\x02world' > "$FIX/binary.bin"
+  printf 'hello world\nline two\n' > "$FIX/text.md"
+  printf '\x1b[2J\x00\x01\xffHELLO\x02world' > "$FIX/noext"
+  printf '\x1b[2J\x00PNGISH\x01' > "$FIX/pic.png"
+  printf '\x1b[2J\x00XYZISH\x01' > "$FIX/blob.xyz"
+
+  # STUB: fake tools for the "present" branches (hexyl, chafa). Front of
+  # PATH in tests that need them; omitted otherwise.
+  STUB="$(mktemp -d)"
+  cat > "$STUB/hexyl" <<'HEXYL'
+#!/usr/bin/env bash
+printf 'HEXYL-DUMP-MARKER\n'
+HEXYL
+  chmod +x "$STUB/hexyl"
+  cat > "$STUB/chafa" <<'CHAFA'
+#!/usr/bin/env bash
+exit 0
+CHAFA
+  chmod +x "$STUB/chafa"
+
+  # ONLYBASE: symlinks to ONLY file/head/od/less - no xxd, no hexyl. xxd
+  # ships in the SAME /usr/bin as file/head/od/less on macOS, so excluding
+  # a directory (the /opt/homebrew/bin convention used elsewhere) cannot
+  # hide it; only an allowlisted PATH does. This is the fixture that lets
+  # the od-only degrade tier (both hexyl AND xxd absent) be tested for
+  # real, not stubbed.
+  ONLYBASE="$(mktemp -d)"
+  ln -s "$(command -v file)" "$ONLYBASE/file"
+  ln -s "$(command -v head)" "$ONLYBASE/head"
+  ln -s "$(command -v od)" "$ONLYBASE/od"
+  ln -s "$(command -v less)" "$ONLYBASE/less"
+
+  # shellcheck disable=SC1090
+  . "$LIB"
+}
+
+teardown() {
+  cd /
+  # Absolute path, not a PATH lookup: several tests deliberately narrow
+  # PATH down to $ONLYBASE (no /bin) to prove the od-only degrade tier, and
+  # that narrowed PATH is still in effect here once the test body returns.
+  /bin/rm -rf "$FIX" "$STUB" "$ONLYBASE"
+  # Restore a normal PATH so bats-core's OWN post-teardown bookkeeping
+  # (which runs after this function, in the same process) can still find
+  # its usual coreutils - a narrowed-PATH test must not poison the runner.
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+# ---- match: fallback is a true always-0 catch-all ----
+
+@test "fallback: match_render_fallback accepts a plain text file" {
+  match_render_fallback "$FIX/text.md"
+}
+
+@test "fallback: match_render_fallback accepts a binary file" {
+  match_render_fallback "$FIX/binary.bin"
+}
+
+@test "fallback: match_render_fallback accepts a no-extension file" {
+  match_render_fallback "$FIX/noext"
+}
+
+# ---- render: hexyl present vs absent, both degrade tiers ----
+
+@test "fallback: hexyl present -> render_fallback uses hexyl" {
+  export PATH="$STUB:/usr/bin:/bin"
+  run render_fallback "$FIX/binary.bin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"type:"* ]]
+  [[ "$output" == *"HEXYL-DUMP-MARKER"* ]]
+}
+
+@test "fallback: hexyl absent, xxd present -> render_fallback degrades to xxd and never leaks the raw escape sequence" {
+  export PATH="/usr/bin:/bin"
+  ! command -v hexyl >/dev/null 2>&1
+  command -v xxd >/dev/null 2>&1
+  run render_fallback "$FIX/binary.bin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"type:"* ]]
+  local esc
+  esc=$'\x1b'
+  [[ "$output" != *"$esc"* ]]
+}
+
+@test "fallback: hexyl AND xxd absent -> render_fallback degrades to od and never leaks the raw escape sequence" {
+  export PATH="$ONLYBASE"
+  ! command -v hexyl >/dev/null 2>&1
+  ! command -v xxd >/dev/null 2>&1
+  command -v od >/dev/null 2>&1
+  run render_fallback "$FIX/binary.bin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"type:"* ]]
+  local esc
+  esc=$'\x1b'
+  [[ "$output" != *"$esc"* ]]
+  # a genuine dump happened (hex-looking bytes present), not an empty body
+  [[ "$output" == *"1b"* ]]
+}
+
+@test "fallback: works with zero optional tools (a no-extension binary still renders safely)" {
+  export PATH="$ONLYBASE"
+  run render_fallback "$FIX/noext"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no specific renderer"* ]]
+  [[ "$output" == *"type:"* ]]
+}
+
+# ---- hint: correct only when a mapped tool is genuinely absent ----
+
+@test "fallback: .png reaching fallback with chafa absent shows the install hint" {
+  export PATH="/usr/bin:/bin"
+  ! command -v chafa >/dev/null 2>&1
+  run render_fallback "$FIX/pic.png"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"install chafa"* ]]
+}
+
+@test "fallback: .png reaching fallback with chafa present shows no hint" {
+  export PATH="$STUB:/usr/bin:/bin"
+  command -v chafa >/dev/null 2>&1
+  run render_fallback "$FIX/pic.png"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"install chafa"* ]]
+  [[ "$output" != *hint* ]]
+}
+
+@test "fallback: an unmapped extension shows no hint regardless of installed tools" {
+  export PATH="$STUB:/usr/bin:/bin"
+  run render_fallback "$FIX/blob.xyz"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *hint* ]]
+}
+
+# ---- negative control: fallback is genuinely the terminal sink ----
+
+@test "fallback: a garbage file with a markdown/image extension only routes here because every specific matcher declined" {
+  export PATH="/usr/bin:/bin"
+  local kind
+  for kind in markdown image gif svg pdf archive csv json ipynb office media sqlite plist; do
+    if "match_render_$kind" "$FIX/pic.png"; then
+      echo "kind $kind unexpectedly claimed $FIX/pic.png" >&2
+      return 1
+    fi
+  done
+  match_render_fallback "$FIX/pic.png"
+  run render_any "$FIX/pic.png"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no specific renderer"* ]]
+}


### PR DESCRIPTION
## Summary

The always-on guard: an unknown or binary file now shows a `file(1)` one-line type plus a `hexyl` first-KB hexdump (degrading to `xxd`/`od` when hexyl is absent) plus a targeted "install `<tool>`" hint when a known type's renderer tool is missing - so the preview pane never dumps raw control bytes into the terminal. This is the floor every other renderer degrades onto. Fills the pre-registered `fallback` stub; `lib.sh`/pane scripts untouched.

## Run table

| Check | Command | Result |
|---|---|---|
| shellcheck | `shellcheck -x scripts/renderers/fallback.sh` | clean |
| full bats suite | `bats tests/ </dev/null` | 271/271 ok, 0 failures |
| new tests | `bats tests/renderers-fallback.bats` | 11/11 ok |

## Coverage delta

- `match_render_fallback` accepts text/binary/no-extension (always-0 catch-all), confirmed.
- `render_fallback`: hexyl present -> hexyl path (stubbed tool); hexyl absent + xxd present (real system tool) -> xxd path, no raw ESC byte in output; hexyl AND xxd absent (allowlisted PATH, real `od`) -> od path, no raw ESC byte in output, a genuine hexdump present.
- Zero-optional-tools case (file(1) + od only) still renders safely.
- Hint: `.png` w/ chafa absent -> "install chafa" hint; chafa present -> no hint; unmapped `.xyz` -> no hint regardless.
- Negative control: a garbage file with a markdown/image extension is declined by every specific `match_render_*` and only reaches fallback via `render_any`'s own ordering.
- Updated the one stale `render-registry.bats` assertion that encoded the OLD 4-line minimal-stub shape (no longer true now that the real hexdump body exists); the safety guarantee itself now lives in the new file's dedicated tests.

## Deviations from the goal file

- **ROADMAP**: not flipped here - the dispatching instructions for this run marked the mega-goal ROADMAP read-only for this worker; leaving that flip to the conductor/orchestrator.
- **HANDOFF.md / DECISIONS.md** (ops-toolkit megagoal folder): not touched - out of the explicit Touches list this run was scoped to (`scripts/renderers/fallback.sh`, `tests/renderers-fallback.bats`, plus the append-shared README/CHANGELOG rows the goal file calls for).
- **README/CHANGELOG rows**: added, since the goal file's own Handoff section calls for them and the dispatch instructions explicitly allow it. No `Renderers (v0.4)` feature-table section existed yet on this branch, so this PR introduces it (one row: unknown/binary fallback) rather than appending to something pre-existing - per SG-03/04/06/07's own goal files ("append-shared, conductor reconciles at merge"), a merge conflict here across sibling sub-goal branches is expected and left for the conductor.
- Replaced the old "press any key to close" prompt with piping the whole body through `less -R` (a no-op passthrough when stdout isn't a real terminal, e.g. under bats) so the hexdump is genuinely pageable, per the goal's "paged" requirement.