### PR TITLE
feat(renderers): still images + animated gif via chafa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   preview pane, paged; degrades to the plain-text preview when `glow` is
   absent (a markdown file is still perfectly readable as text).
 
+- The preview overlay renders still images (`png`/`jpg`/`jpeg`/`webp`/`bmp`) and animated gifs inline via `chafa`: ANSI symbols mode by default (works in any terminal), with a kitty-graphics passthrough enhancement when the terminal signals support. Gifs animate via `chafa --animate` (bounded duration, never hangs the pane), falling back to a first-frame still when animation is unavailable. Both degrade to the fallback guard above (never a raw-byte dump) when `chafa` is absent.
+
 - Bare domains (hermes.d.foundation, herdr.dev) classify as urls and open
   the browser with an https scheme, gated on a TLD allowlist so file
   extensions (.md, .go, .sh) never misclassify.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Once a token resolves to a local file, a second registry decides HOW to draw it:
 
 | File type | What you get |
 |---|---|
+| still images (`png`/`jpg`/`jpeg`/`webp`/`bmp`) | Inline ANSI art via [`chafa`](https://github.com/hpjansson/chafa) (kitty-graphics passthrough when the terminal signals support); falls back to the guard below when `chafa` is absent |
+| animated gifs (`.gif`) | Inline animation via `chafa --animate` (bounded duration - never hangs the pane); a first-frame still when `--animate` is unavailable, then the guard below when `chafa` is absent |
 | unknown / binary (the catch-all fallback) | A `file(1)` one-line type description, a bounded first-~1KB hexdump ([`hexyl`](https://github.com/sharkdp/hexyl) when installed, degrading to `xxd` then the base-system `od` - never raw bytes), and an "install `<tool>`" hint when the extension maps to a known type whose renderer tool isn't on PATH yet |
 
 ## Install

--- a/scripts/renderers/gif.sh
+++ b/scripts/renderers/gif.sh
@@ -1,15 +1,42 @@
 # shellcheck shell=bash
-# gif.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real gif renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# gif.sh: animated-gif render-registry renderer (v0.4 SG-04). Draws `.gif`
+# via `chafa --animate`; falls back to a first-frame STILL (the same ANSI
+# symbols base path image.sh uses) when `--animate` is unavailable or fails.
+# See the render-registry contract at the top of lib.sh.
 
+# match_render_gif <path>: extension gate (.gif) PLUS a real
+# `file --mime-type` check (declines a non-gif file renamed .gif - the
+# negative control this sub-goal's quality bar calls out) PLUS chafa on PATH
+# (absent -> decline -> fallback).
 match_render_gif() {
-  return 1
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  command -v chafa >/dev/null 2>&1 || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  [ "$ext" = "gif" ] || return 1
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  [ "$mime" = "image/gif" ]
 }
 
+# _GIF_ANIMATE_DURATION: chafa's own default duration for a single animated
+# file is INFINITE (it loops until interrupted) - unbounded, so it would hang
+# the pane forever. An explicit finite --duration bounds the animate path per
+# this sub-goal's quality bar ("must never hang the pane"), while chafa still
+# guarantees at least one full play-through of the frames. Overridable for a
+# faster interactive tune without editing the script.
+_GIF_ANIMATE_DURATION="${QUICKLOOK_GIF_ANIMATE_DURATION:-8}"
+
+# render_gif <path> [line]: tries the bounded animate path first; a nonzero
+# rc (chafa built without animate support, or it otherwise fails) falls back
+# to a first-frame STILL via the same ANSI symbols call image.sh uses. `line`
+# is accepted for signature parity (unused - no line to jump to on an
+# image/gif). Pauses after drawing, matching the pane's pause-close idiom.
+# No `o`/`d`/`e` overlay keys - same documented scope edge as image.sh.
 render_gif() {
-  # unreachable: match_render_gif always declines.
-  return 1
+  local path="$1"
+  if ! chafa --animate -d "$_GIF_ANIMATE_DURATION" -- "$path" 2>/dev/null; then
+    chafa --format symbols -- "$path" 2>/dev/null
+  fi
+  read -r -n1 -p 'press any key to close' _ 2>/dev/null || sleep 2
+  return 0
 }

--- a/scripts/renderers/image.sh
+++ b/scripts/renderers/image.sh
@@ -1,15 +1,61 @@
 # shellcheck shell=bash
-# image.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real image renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# image.sh: still-image render-registry renderer (v0.4 SG-04). Draws PNG/JPG/
+# JPEG/WEBP/BMP inline via chafa in ANSI symbols mode - the guaranteed BASE
+# PATH that works in any pane/terminal (see the render-registry contract at
+# the top of lib.sh). kitty-graphics passthrough is an ENHANCEMENT only: when
+# the terminal signals kitty-protocol support, chafa is invoked WITHOUT an
+# explicit --format so it auto-detects and upgrades the render; chafa's own
+# auto mode still falls back to a text format on a bad guess, so a false
+# positive here only costs a slightly worse render, never a crash - safe and
+# reversible, which is the bar this sub-goal's feasibility gate set.
 
+# match_render_image <path>: extension gate (png/jpg/jpeg/webp/bmp) PLUS a
+# real `file --mime-type` check (the extension alone would let a renamed
+# garbage/text file through - the negative control this sub-goal's quality
+# bar calls out) PLUS chafa on PATH (absent -> decline -> fallback, an image
+# is never worth a raw-byte dump).
 match_render_image() {
-  return 1
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  command -v chafa >/dev/null 2>&1 || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    png | jpg | jpeg | webp | bmp) ;;
+    *) return 1 ;;
+  esac
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  case "$mime" in
+    image/*) ;;
+    *) return 1 ;;
+  esac
 }
 
+# _image_terminal_supports_kitty: the only signals trusted for the kitty-
+# passthrough enhancement - kitty itself ($KITTY_WINDOW_ID) and $TERM ==
+# xterm-kitty (kitty's own default TERM value). Anything else stays on the
+# ANSI symbols base path; a missed positive here costs a worse render, never
+# a crash, which is what makes the enhancement safe to feasibility-test.
+_image_terminal_supports_kitty() {
+  [ -n "${KITTY_WINDOW_ID:-}" ] && return 0
+  [ "${TERM:-}" = "xterm-kitty" ]
+}
+
+# render_image <path> [line]: base path is an explicit `chafa --format
+# symbols` (works in ANY terminal); the kitty-capable branch omits --format
+# so chafa's own probe/auto-detect can pick kitty-graphics passthrough.
+# `line` is accepted for render_<kind> signature parity (render_any always
+# passes it) but unused - an inline image render has no line to jump to.
+# Pauses after drawing (read/keypress) so the overlay does not instantly
+# close, matching the pane's existing pause-close idiom (see fallback.sh).
+# No `o`/`d`/`e` overlay keys here - there is no less session to bind them
+# to; documented as a scope edge in the goal file, not a bug.
 render_image() {
-  # unreachable: match_render_image always declines.
-  return 1
+  local path="$1"
+  if _image_terminal_supports_kitty; then
+    chafa -- "$path" 2>/dev/null
+  else
+    chafa --format symbols -- "$path" 2>/dev/null
+  fi
+  read -r -n1 -p 'press any key to close' _ 2>/dev/null || sleep 2
+  return 0
 }

--- a/tests/renderers-gif.bats
+++ b/tests/renderers-gif.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/gif.sh (animated gifs via chafa, v0.4 SG-04).
+# Sources lib.sh directly, same fixture shape as tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # Minimal, REAL 1x1 GIF bytes (verified via `file --mime-type` = image/gif).
+  printf '\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\xff\xff\xff\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x01\x4c\x00\x3b' > "$FIX/t.gif"
+  # binary garbage wearing a .gif extension (same shape as
+  # render-registry.bats's own blob.bin) - the negative control. Must be
+  # genuinely BINARY, not text, for the same reason as renderers-image.bats.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.gif"
+
+  STUB="$(mktemp -d)"
+  export CHAFA_ARGV_FILE="$FIX/chafa.argv"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+_stub_chafa_animate_ok() {
+  cat > "$STUB/chafa" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CHAFA_ARGV_FILE"
+exit 0
+SH
+  chmod +x "$STUB/chafa"
+}
+
+# --animate is stubbed unavailable (nonzero rc) whenever it's on the argv;
+# a plain still call (no --animate) still succeeds and records its argv.
+_stub_chafa_animate_unavailable() {
+  cat > "$STUB/chafa" <<'SH'
+#!/usr/bin/env bash
+for a in "$@"; do
+  [ "$a" = "--animate" ] && exit 1
+done
+printf '%s\n' "$@" > "$CHAFA_ARGV_FILE"
+exit 0
+SH
+  chmod +x "$STUB/chafa"
+}
+
+# ---- match: chafa present ----
+
+@test "match_render_gif: matches a real .gif when chafa is present" {
+  _stub_chafa_animate_ok
+  export PATH="$STUB:$PATH"
+  match_render_gif "$FIX/t.gif"
+}
+
+@test "match_render_gif: declines a non-gif extension" {
+  _stub_chafa_animate_ok
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_gif "$FIX/t.md"
+}
+
+# ---- degrade: chafa absent ----
+
+@test "match_render_gif: declines when chafa is absent (PATH excludes /opt/homebrew/bin and /usr/local/bin)" {
+  export PATH="/usr/bin:/bin"
+  ! match_render_gif "$FIX/t.gif"
+}
+
+@test "render-registry: chafa absent routes a real gif to fallback via render_any" {
+  export PATH="/usr/bin:/bin"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.gif'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.gif" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_gif: declines binary garbage renamed .gif (keys on type, not extension)" {
+  _stub_chafa_animate_ok
+  export PATH="$STUB:$PATH"
+  ! match_render_gif "$FIX/fake.gif"
+}
+
+@test "render-registry: binary garbage renamed .gif routes to fallback, never chafa" {
+  _stub_chafa_animate_ok
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.gif'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.gif" ]
+  [ ! -e "$CHAFA_ARGV_FILE" ]
+}
+
+# ---- render: --animate argv, bounded duration ----
+
+@test "render_gif: calls chafa with --animate, a duration bound, and the file" {
+  _stub_chafa_animate_ok
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_gif '$FIX/t.gif' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$FIX/chafa.argv" ]
+  grep -qx -- '--animate' "$FIX/chafa.argv"
+  grep -qx -- '-d' "$FIX/chafa.argv"
+  grep -qx -- "$FIX/t.gif" "$FIX/chafa.argv"
+}
+
+# ---- render: first-frame-still fallback when --animate is unavailable ----
+
+@test "render_gif: falls back to a first-frame still (explicit symbols format) when --animate is unavailable" {
+  _stub_chafa_animate_unavailable
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_gif '$FIX/t.gif' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$FIX/chafa.argv" ]
+  grep -qx -- '--format' "$FIX/chafa.argv"
+  grep -qx -- 'symbols' "$FIX/chafa.argv"
+  ! grep -qx -- '--animate' "$FIX/chafa.argv"
+}

--- a/tests/renderers-image.bats
+++ b/tests/renderers-image.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/image.sh (still images via chafa, v0.4 SG-04).
+# Sources lib.sh directly, same fixture shape as tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # Minimal, REAL 1x1 PNG bytes (verified via `file --mime-type` = image/png).
+  printf '\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52\x00\x00\x00\x01\x00\x00\x00\x01\x08\x04\x00\x00\x00\xb5\x1c\x0c\x02\x00\x00\x00\x0b\x49\x44\x41\x54\x78\xda\x63\x64\xf8\x0f\x00\x01\x05\x01\x01\x27\x18\xe3\x66\x00\x00\x00\x00\x49\x45\x4e\x44\xae\x42\x60\x82' > "$FIX/t.png"
+  cp "$FIX/t.png" "$FIX/t.jpg"
+  cp "$FIX/t.png" "$FIX/t.jpeg"
+  cp "$FIX/t.png" "$FIX/t.webp"
+  cp "$FIX/t.png" "$FIX/t.bmp"
+  # binary garbage wearing an image extension (null + high bytes, same shape
+  # as render-registry.bats's own blob.bin) - the negative control. Must be
+  # genuinely BINARY, not text: a text file here would legitimately match
+  # the `text` renderer (which keys on mime-ENCODING, not extension) and
+  # this test would be asserting the wrong thing.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.png"
+
+  # a stub chafa that records its argv (order preserved) so render tests can
+  # assert the invocation shape without needing a real terminal.
+  STUB="$(mktemp -d)"
+  cat > "$STUB/chafa" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CHAFA_ARGV_FILE"
+exit 0
+SH
+  chmod +x "$STUB/chafa"
+  export CHAFA_ARGV_FILE="$FIX/chafa.argv"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+# ---- match: chafa present ----
+
+@test "match_render_image: matches every still extension when chafa is present" {
+  export PATH="$STUB:$PATH"
+  match_render_image "$FIX/t.png"
+  match_render_image "$FIX/t.jpg"
+  match_render_image "$FIX/t.jpeg"
+  match_render_image "$FIX/t.webp"
+  match_render_image "$FIX/t.bmp"
+}
+
+@test "match_render_image: declines a non-image extension" {
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_image "$FIX/t.md"
+}
+
+# ---- degrade: chafa absent ----
+
+@test "match_render_image: declines when chafa is absent (PATH excludes /opt/homebrew/bin and /usr/local/bin)" {
+  export PATH="/usr/bin:/bin"
+  ! match_render_image "$FIX/t.png"
+}
+
+@test "render-registry: chafa absent routes a real image to fallback via render_any" {
+  export PATH="/usr/bin:/bin"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.png'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.png" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_image: declines binary garbage renamed .png (keys on type, not extension)" {
+  export PATH="$STUB:$PATH"
+  ! match_render_image "$FIX/fake.png"
+}
+
+@test "render-registry: binary garbage renamed .png routes to fallback, never chafa" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.png'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.png" ]
+  [ ! -e "$CHAFA_ARGV_FILE" ]
+}
+
+# ---- render: ANSI base path argv + pause ----
+
+@test "render_image: base path calls chafa with the file and an explicit symbols/format flag, then pauses" {
+  export PATH="$STUB:$PATH"
+  unset KITTY_WINDOW_ID
+  export TERM=xterm
+  run bash -c ". '$LIB'; render_image '$FIX/t.png' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$FIX/chafa.argv" ]
+  grep -qx -- '--format' "$FIX/chafa.argv"
+  grep -qx -- 'symbols' "$FIX/chafa.argv"
+  grep -qx -- "$FIX/t.png" "$FIX/chafa.argv"
+}
+
+@test "render_image: a kitty-capable env still produces a valid render (enhancement path does not break)" {
+  export PATH="$STUB:$PATH"
+  export KITTY_WINDOW_ID=1
+  run bash -c ". '$LIB'; render_image '$FIX/t.png' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$FIX/chafa.argv" ]
+  grep -qx -- "$FIX/t.png" "$FIX/chafa.argv"
+  # the enhancement branch omits --format, letting chafa auto-detect.
+  ! grep -qx -- '--format' "$FIX/chafa.argv"
+}


### PR DESCRIPTION
New render types: still images (png/jpg/jpeg/webp/bmp) draw inline via `chafa` ANSI symbols mode (works in any terminal; kitty-graphics passthrough as a safe/reversible enhancement), and animated gifs via `chafa --animate` (bounded duration) with a first-frame still fallback. Both key on `file(1)` mime type (not just extension) and degrade to the fallback guard when `chafa` is absent. `lib.sh`/`RENDER_KINDS`/pane scripts untouched; two registry renderers + their tests only. Appends two rows to the `## Renderers (v0.4)` table SG-05 (`#29`) started.

## Run-table

| Command | Result |
|---|---|
| `shellcheck -x scripts/renderers/image.sh scripts/renderers/gif.sh` | clean (rc=0) |
| `bats tests/renderers-image.bats tests/renderers-gif.bats` | 16/16 passing |
| `bats tests/` (full suite, rebased onto `main` after #27/#28/#29/#31) | 306/306 passing, 0 failures |

## COVERAGE-DELTA

- Base at last rebase (`main` after SG-01 `#27`, SG-02 `#28`, SG-05 `#29`, SG-03 `#31`): 290 bats cases.
- After this PR: 306 (+16): 8 in `tests/renderers-image.bats`, 8 in `tests/renderers-gif.bats` - match (chafa present, every still extension), match decline (non-image extension), degrade (chafa absent, PATH excludes `/opt/homebrew/bin` + `/usr/local/bin`), render-registry fallthrough-to-fallback on chafa-absent, negative control (binary garbage renamed `.png`/`.gif`, both the matcher-declines and the render_any-routes-to-fallback angles), render argv assertion (ANSI base path + pause), kitty-capable-env render (enhancement path), `--animate` argv + bounded `-d`, and the first-frame-still fallback when `--animate` is stubbed unavailable.

## Kitty-passthrough feasibility verdict

Feasibility-tested and landed as a narrow, reversible enhancement: `render_image`/`render_gif` only omit chafa's explicit `--format symbols` when `$KITTY_WINDOW_ID` is set or `$TERM=xterm-kitty` (kitty's own self-reported signals), letting chafa's own probe/auto-detect upgrade to kitty graphics. A false positive here only costs a worse render (chafa's own auto mode still degrades sanely) - never a crash - so this stays a safe default-on enhancement, never the base guarantee. The ANSI `--format symbols` path is unconditional otherwise.

## Deviations from the goal file

- **PR base is `main`, not `feat/ql4-01-registry`.** That branch was a pre-merge copy of SG-01, superseded when SG-01 merged into `main` via #27 (different SHA, same content). This branch is rebased onto current `main`, which also picked up SG-02 (#28), SG-05 (#29) and SG-03 (#31) as they landed mid-session (several sub-goals were merging in parallel); each rebase resolved one append-only conflict in `CHANGELOG.md` (kept both entries, ordered by merge time).
- **RENDER_KINDS order**: the goal file's assumption section states "gif is registered BEFORE image in `RENDER_KINDS`"; the actual SG-01-merged order has `image` before `gif`. Harmless in practice - `match_render_image`'s extension set (`png`/`jpg`/`jpeg`/`webp`/`bmp`) excludes `.gif`, so dispatch is correct regardless of order. `RENDER_KINDS` is out of scope for this sub-goal (untouched), so this is noted, not fixed here.
- **README feature-table rows**: SG-05 (`#29`) landed first and introduced a new `## Renderers (v0.4)` table (superseding this PR's originally-planned standalone section); this PR appends its two rows there instead of creating a duplicate table.
