### PR TITLE
feat(renderers): markdown renderer (glow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   the floor every other v0.4 renderer degrades onto, so a preview never
   dumps a file's raw bytes into the terminal.
 
+- New render type: markdown (`.md`/`.markdown`) renders via `glow` in the
+  preview pane, paged; degrades to the plain-text preview when `glow` is
+  absent (a markdown file is still perfectly readable as text).
+
 - Bare domains (hermes.d.foundation, herdr.dev) classify as urls and open
   the browser with an https scheme, gated on a TLD allowlist so file
   extensions (.md, .go, .sh) never misclassify.

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -1,15 +1,33 @@
 # shellcheck shell=bash
-# markdown.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real markdown renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# markdown.sh: the markdown render-registry renderer (v0.4, SG-03). Parity
+# target: herdr-file-viewer's own markdown support (a bare extension check +
+# glow). See the render-registry contract comment at the top of lib.sh.
 
+# match_render_markdown <path>: owns `.md`/`.markdown` files, but only when
+# `glow` is on PATH (degrade is decided here, not mid-render - see the
+# contract comment) AND file(1) reports a text encoding, not binary. The
+# encoding check is what keeps a binary-garbage file wearing a `.md`
+# extension from being handed to glow - extension alone is not enough of a
+# type check (a markdown file IS text; glow itself has no binary guard).
 match_render_markdown() {
-  return 1
+  local path="$1" ext enc
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    md | markdown) ;;
+    *) return 1 ;;
+  esac
+  command -v glow >/dev/null 2>&1 || return 1
+  enc="$(file -b --mime-encoding -- "$path" 2>/dev/null)"
+  [ "$enc" != "binary" ] && [ -n "$enc" ]
 }
 
+# render_markdown <path> [line]: pages `glow`'s rendered output through
+# render_command_in_pager (glow -> less -R), same shape as every other
+# formatter-piped renderer. `line` is accepted for signature parity with
+# every other render_<kind> but unused - glow has no line-jump, so a
+# best-effort render (not an error) is the contract here.
 render_markdown() {
-  # unreachable: match_render_markdown always declines.
-  return 1
+  local target="$1"
+  render_command_in_pager glow -s auto -- "$target"
 }

--- a/tests/dispatch.bats
+++ b/tests/dispatch.bats
@@ -11,10 +11,15 @@ setup() {
   SCRIPT="$BATS_TEST_DIRNAME/../scripts/preview-pane.sh"
 
   FIX="$(cd "$(mktemp -d)" && pwd -P)"
-  # a repo whose DIRECTORY NAME is "myrepo" so a github URL for repo "myrepo" matches
+  # a repo whose DIRECTORY NAME is "myrepo" so a github URL for repo "myrepo" matches.
+  # .txt, not .md: this suite is proving path/line dispatch wiring through the
+  # render registry's `text` renderer (`less` directly, +LINE jump intact) -
+  # a real .md extension would now legitimately route through the markdown
+  # renderer (SG-03, glow on PATH here via /opt/homebrew/bin below), which
+  # has no line-jump by design (see tests/renderers-markdown.bats instead).
   mkdir -p "$FIX/myrepo"
   git -C "$FIX/myrepo" init -q -b main
-  printf 'line1\nline2\nline3\n' > "$FIX/myrepo/f.md"
+  printf 'line1\nline2\nline3\n' > "$FIX/myrepo/f.txt"
   git -C "$FIX/myrepo" add -A
   git -C "$FIX/myrepo" -c user.email=t@t -c user.name=t commit -qm fix
 
@@ -48,19 +53,19 @@ teardown() {
 }
 
 @test "dispatch: github blob URL opens the local file at the line" {
-  export QUICKLOOK_TOKEN="https://github.com/owner/myrepo/blob/main/f.md#L3"
+  export QUICKLOOK_TOKEN="https://github.com/owner/myrepo/blob/main/f.txt#L3"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
   # resolved to the LOCAL file, with the +3 line jump
-  [[ "$output" == *"$FIX/myrepo/f.md"* ]]
+  [[ "$output" == *"$FIX/myrepo/f.txt"* ]]
   [[ "$output" == *"+3"* ]]
 }
 
 @test "dispatch: a plain relative path token opens locally" {
-  export QUICKLOOK_TOKEN="f.md:2"
+  export QUICKLOOK_TOKEN="f.txt:2"
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"$FIX/myrepo/f.md"* ]]
+  [[ "$output" == *"$FIX/myrepo/f.txt"* ]]
   [[ "$output" == *"+2"* ]]
 }
 

--- a/tests/render-registry.bats
+++ b/tests/render-registry.bats
@@ -10,7 +10,12 @@ setup() {
   . "$LIB"
 
   FIX="$(cd "$(mktemp -d)" && pwd -P)"
-  printf 'hello world\nline two\n' > "$FIX/text.md"
+  # .txt, not .md: this fixture stands in for "a generic plain text file" in
+  # the fallthrough/dispatch tests below, and a .md extension would collide
+  # with the real match_render_markdown (SG-03) on any host with glow on
+  # PATH - a specific-kind renderer legitimately claiming its own extension,
+  # not a bug in that renderer.
+  printf 'hello world\nline two\n' > "$FIX/text.txt"
   # a real binary file (null + high bytes) so file(1) reports mime-encoding
   # "binary", not a text encoding - see match_render_text/match_render_fallback.
   printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/blob.bin"
@@ -24,7 +29,7 @@ teardown() {
 # ---- text/fallback real bodies (the only two non-stub renderers) ----
 
 @test "render-registry: text renderer matches a text file" {
-  match_render_text "$FIX/text.md"
+  match_render_text "$FIX/text.txt"
 }
 
 @test "render-registry: fallback renderer matches a binary file (text declines it)" {
@@ -36,7 +41,7 @@ teardown() {
   # fallback is the always-0 catch-all; RENDER_KINDS ordering (text before
   # fallback), not fallback's own predicate, is what keeps it from shadowing
   # text - see the ordering test below.
-  match_render_fallback "$FIX/text.md"
+  match_render_fallback "$FIX/text.txt"
 }
 
 # ---- an unmatched-by-specific-kind file falls through to text/fallback ----
@@ -44,7 +49,7 @@ teardown() {
 @test "render-registry: every declining stub actually declines a plain text file (proves the fallthrough is real, not a no-op chain)" {
   local kind
   for kind in markdown image gif svg pdf archive csv json ipynb office media sqlite plist; do
-    if "match_render_$kind" "$FIX/text.md"; then
+    if "match_render_$kind" "$FIX/text.txt"; then
       echo "kind $kind unexpectedly claimed a plain text file" >&2
       return 1
     fi
@@ -58,10 +63,10 @@ teardown() {
   run bash -c "
     . '$LIB'
     render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
-    render_any '$FIX/text.md'
+    render_any '$FIX/text.txt'
   "
   [ "$status" -eq 0 ]
-  [ "$output" = "TEXT-RENDERED:$FIX/text.md" ]
+  [ "$output" = "TEXT-RENDERED:$FIX/text.txt" ]
 }
 
 @test "render-registry: render_any dispatches a binary file to the fallback renderer" {
@@ -94,9 +99,9 @@ teardown() {
   render_zzz() { printf 'ZZZ-RENDERED:%s\n' "$1"; return 0; }
   RENDER_KINDS=(zzz "${RENDER_KINDS[@]}")
 
-  run render_any "$FIX/text.md"
+  run render_any "$FIX/text.txt"
   [ "$status" -eq 0 ]
-  [ "$output" = "ZZZ-RENDERED:$FIX/text.md" ]
+  [ "$output" = "ZZZ-RENDERED:$FIX/text.txt" ]
 }
 
 @test "render-registry: first-match ordering - position decides, not the target's real type" {

--- a/tests/renderers-markdown.bats
+++ b/tests/renderers-markdown.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# Tests for the markdown render-registry renderer (SG-03): scripts/renderers/
+# markdown.sh's match_render_markdown/render_markdown, plus render_any
+# dispatch through it. Same fixture/sourcing shape as tests/render-registry.
+# bats (sources lib.sh directly).
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf '# Hello\n\nSome **bold** text.\n' > "$FIX/doc.md"
+  printf '# Hello\n\nSame content, .markdown extension.\n' > "$FIX/doc.markdown"
+  printf 'plain text, not a markdown extension\n' > "$FIX/doc.txt"
+  # binary garbage wearing a .md extension - the negative control: extension
+  # alone must not be enough, file(1) has to say "binary" to decline it.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/blob.md"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+# stub dir with a fake glow + less, PATH built WITHOUT /opt/homebrew/bin or
+# /usr/local/bin (this host has a REAL glow in both - see the PATH-stub
+# gotcha called out in recents.bats; leaking the real one would defeat the
+# glow-absent tests further down and make render's argv assertions brittle
+# against whatever glow happens to print).
+stub_with_glow() {
+  STUB="$(mktemp -d)"
+  cat > "$STUB/glow" <<'SH'
+#!/usr/bin/env bash
+printf 'GLOW_ARGS:%s\n' "$*"
+SH
+  cat > "$STUB/less" <<'SH'
+#!/usr/bin/env bash
+printf 'LESS_ARGS:%s\n' "$*"
+cat
+SH
+  chmod +x "$STUB/glow" "$STUB/less"
+  export PATH="$STUB:/usr/bin:/bin"
+}
+
+# same stub dir, minus glow - the tool-absent degrade path.
+stub_without_glow() {
+  STUB="$(mktemp -d)"
+  cat > "$STUB/less" <<'SH'
+#!/usr/bin/env bash
+printf 'LESS_ARGS:%s\n' "$*"
+cat
+SH
+  chmod +x "$STUB/less"
+  export PATH="$STUB:/usr/bin:/bin"
+}
+
+# ---- match_render_markdown ----
+
+@test "match_render_markdown: matches a .md file when glow is on PATH" {
+  stub_with_glow
+  match_render_markdown "$FIX/doc.md"
+}
+
+@test "match_render_markdown: matches a .markdown file when glow is on PATH" {
+  stub_with_glow
+  match_render_markdown "$FIX/doc.markdown"
+}
+
+@test "match_render_markdown: declines when glow is absent from PATH" {
+  stub_without_glow
+  ! match_render_markdown "$FIX/doc.md"
+}
+
+@test "match_render_markdown: declines a non-markdown extension even with glow present" {
+  stub_with_glow
+  ! match_render_markdown "$FIX/doc.txt"
+}
+
+@test "match_render_markdown: declines binary-garbage content despite a .md extension (keys on type, not just extension)" {
+  stub_with_glow
+  ! match_render_markdown "$FIX/blob.md"
+}
+
+# ---- render_markdown: pages glow's output through less ----
+
+@test "render_markdown: pipes glow's rendered output through less -R" {
+  stub_with_glow
+  run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GLOW_ARGS:"* ]]
+  [[ "$output" == *"-s auto"* ]]
+  [[ "$output" == *"$FIX/doc.md"* ]]
+  [[ "$output" == *"LESS_ARGS:"* ]]
+  [[ "$output" == *"-R"* ]]
+}
+
+@test "render_markdown: the line arg is accepted but ignored (best-effort, no error)" {
+  stub_with_glow
+  run render_markdown "$FIX/doc.md" 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GLOW_ARGS:"* ]]
+}
+
+# ---- render_any dispatch: glow-present renders, glow-absent degrades ----
+
+@test "render_any: glow present - a .md file dispatches to the markdown renderer" {
+  stub_with_glow
+  run bash -c "
+    . '$LIB'
+    render_markdown() { printf 'MARKDOWN-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/doc.md'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "MARKDOWN-RENDERED:$FIX/doc.md" ]
+}
+
+@test "render_any: glow absent - a .md file falls through to the text renderer, not fallback" {
+  stub_without_glow
+  run bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/doc.md'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT-RENDERED:$FIX/doc.md" ]
+}
+
+# ---- negative control: binary garbage in a .md wrapper never reaches glow ----
+
+@test "render_any: binary-garbage file with a .md extension resolves to fallback, never glow-rendered as markdown" {
+  stub_with_glow
+  run bash -c "
+    . '$LIB'
+    render_markdown() { printf 'MARKDOWN-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/blob.md'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK-RENDERED:$FIX/blob.md" ]
+}


### PR DESCRIPTION
New render type: markdown (`.md`/`.markdown`) renders via `glow` in the preview pane, paged.
Degrades to plain-text preview when glow is absent (a markdown file is still text). One registry
renderer; `lib.sh` and pane scripts untouched. Run-table + COVERAGE-DELTA below.

## Run-table

| Command | Exit code | Result |
|---|---|---|
| `shellcheck -x scripts/*.sh scripts/renderers/*.sh scripts/handlers/*.sh` | 0 | clean, no warnings |
| `bats tests/ </dev/null` | 0 | 290 ok, 0 not ok (`1..290`) |

## Coverage delta

| | Test files | `@test` cases |
|---|---|---|
| Base (`main`) | 20 | 280 |
| This PR | 21 (+`tests/renderers-markdown.bats`) | 290 (+10) |

New cases in `tests/renderers-markdown.bats`: `match_render_markdown` matches `.md` and
`.markdown` with glow present, declines with glow absent, declines a non-markdown extension,
declines binary-garbage content wearing a `.md` extension (the negative control - extension alone
is not a type check); `render_markdown` pipes glow's output through `less -R` and ignores the
`line` arg without erroring; `render_any` dispatches to markdown when glow is present, falls
through to the `text` renderer when glow is absent, and resolves the binary-garbage `.md` file to
`fallback`, never glow.

## Deviations from the goal file

- **PR base**: the goal file names `feat/ql4-01-registry` as the base, but by the time this
  sub-goal was implemented both SG-01 (#27) and SG-02 (#28) and SG-05 (#29) had already merged to
  `main`; that branch is stale. This PR bases off `main` (rebased onto its current tip) instead.
- **Shared-fixture rename (`tests/render-registry.bats`, `tests/dispatch.bats`)**: both files
  hard-coded a `.md`-extension fixture (`text.md`, `f.md`) to stand in for "a generic plain text
  file" in dispatch/fallthrough tests written before any renderer claimed that extension. Once
  `match_render_markdown` is real, those fixtures legitimately collide with it on any host with
  `glow` on PATH (true here), turning "declines every kind" and "opens via `less` with a `+LINE`
  jump" assertions false. Renamed both fixtures to `.txt` (no other assertion in either file
  depended on the `.md` extension) so they keep testing what they were written to test, decoupled
  from markdown's now-real extension claim. Outside this goal's declared `## Touches`, but
  required to keep `bats tests/` at zero failures; the SG-05 PR (#29) hit the same shape of
  conflict independently and touched `tests/render-registry.bats` too (resolved via rebase, no
  further changes needed there beyond the rename).
- **No feature-table row appended**: the goal file's handoff step says to append a row to a
  render-type feature table, but no such table exists in README.md yet on this branch (or on
  `main`) - it's owned by SG-08's final README pass. Only the CHANGELOG entry was added.
