### PR TITLE
feat(renderers): P2 pack - svg, pdf, archive, csv, json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Five new render types (P2 pack): svg (`.svg`, `rsvg-convert` -> a temp png
+  -> the same inline chafa render as still images), pdf (`.pdf`, a page-1
+  poster via `pdftoppm`+chafa plus extracted text via `pdftotext`, paged
+  together), archives (`zip`/`tar`/`tgz`/`jar`, a content listing via
+  `unzip -l`/`tar -tf`), csv/tsv (`.csv`/`.tsv`, an aligned table via
+  `qsv table`), and json (`.json`, pretty-printed via `jq .`). Each degrades
+  cleanly without its tool: svg/csv/json (all textual content) fall to the
+  plain-text preview, pdf degrades to text-only when only `pdftotext` is
+  present, archives fall to the fallback guard below in the rare case
+  `unzip`/`tar` are somehow absent (they are base-system).
+
 - Unknown/binary files now render through an always-on fallback guard: a
   `file(1)` type line, a bounded first-KB hexdump (`hexyl`, degrading to
   `xxd` then the base-system `od`), and an "install `<tool>`" hint when a

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Once a token resolves to a local file, a second registry decides HOW to draw it:
 |---|---|
 | still images (`png`/`jpg`/`jpeg`/`webp`/`bmp`) | Inline ANSI art via [`chafa`](https://github.com/hpjansson/chafa) (kitty-graphics passthrough when the terminal signals support); falls back to the guard below when `chafa` is absent |
 | animated gifs (`.gif`) | Inline animation via `chafa --animate` (bounded duration - never hangs the pane); a first-frame still when `--animate` is unavailable, then the guard below when `chafa` is absent |
+| svg (`.svg`) | `rsvg-convert` to a temp PNG, then the SAME inline chafa render as still images; falls back to the guard below (or, tool-absent, the plain-text preview - an svg is XML) |
+| pdf (`.pdf`) | A page-1 poster (`pdftoppm` -> chafa) plus the extracted text (`pdftotext`), paged together; degrades to text-only when `pdftoppm`/`chafa` are missing, or the guard below when poppler is entirely absent |
+| archives (`zip`/`tar`/`tgz`/`jar`) | A content listing (`unzip -l` / `tar -tf`), paged - `unzip`/`tar` are base-system, so this rarely degrades |
+| csv/tsv (`.csv`/`.tsv`) | An aligned table via [`qsv table`](https://github.com/dathere/qsv); degrades to the plain-text preview when `qsv` is absent |
+| json (`.json`) | Pretty-printed via `jq .` (fixes minified/single-line json); degrades to the plain-text preview when `jq` is absent |
 | unknown / binary (the catch-all fallback) | A `file(1)` one-line type description, a bounded first-~1KB hexdump ([`hexyl`](https://github.com/sharkdp/hexyl) when installed, degrading to `xxd` then the base-system `od` - never raw bytes), and an "install `<tool>`" hint when the extension maps to a known type whose renderer tool isn't on PATH yet |
 
 ## Install

--- a/scripts/renderers/archive.sh
+++ b/scripts/renderers/archive.sh
@@ -1,15 +1,62 @@
 # shellcheck shell=bash
-# archive.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real archive renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# archive.sh: archive render-registry renderer (v0.4 SG-06/P2). A CONTENT
+# LISTING, not extraction - `unzip -l` for zip/jar, `tar -tf` for tar/tgz -
+# paged through render_command_in_pager. unzip/tar are base-system on
+# macOS + Linux, so this kind rarely degrades (per the ROADMAP type->tool
+# map); the always-on `fallback` renderer is still the floor if a listing
+# tool is somehow absent. See the render-registry contract at the top of
+# lib.sh.
 
-match_render_archive() {
-  return 1
+# _archive_kind <path> -> the four supported extensions, lowercased,
+# normalized so match/render do the extension work once each.
+_archive_kind() {
+  printf '%s' "${1##*.}" | tr '[:upper:]' '[:lower:]'
 }
 
+# match_render_archive <path>: owns zip/tar/tgz/jar files, gated on BOTH the
+# listing tool being on PATH (unzip for zip/jar, tar for tar/tgz - absent
+# -> decline -> fallback, the rare base-system-missing degrade) AND file(1)
+# confirming the archive's real mime type - the negative control this
+# sub-goal's quality bar calls out (a renamed non-archive file declines
+# rather than being handed to unzip/tar).
+match_render_archive() {
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  ext="$(_archive_kind "$path")"
+  case "$ext" in
+    zip | jar)
+      command -v unzip >/dev/null 2>&1 || return 1
+      mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+      [ "$mime" = "application/zip" ]
+      ;;
+    tar)
+      command -v tar >/dev/null 2>&1 || return 1
+      mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+      [ "$mime" = "application/x-tar" ]
+      ;;
+    tgz)
+      command -v tar >/dev/null 2>&1 || return 1
+      mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+      [ "$mime" = "application/gzip" ]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# render_archive <path> [line]: pages the listing. `line` is accepted for
+# render_<kind> signature parity but unused - a listing has no line to jump
+# to. tar's invocation deliberately omits the `--` end-of-options marker
+# every other renderer in this pack uses: macOS's bundled bsdtar mis-parses
+# `tar -tf -- <path>` (`tar: --: m: No such file or directory`, verified
+# interactively) even though `unzip -l -- <path>` handles it fine.
+# `resolve()` in lib.sh only ever hands renderers an ABSOLUTE path, so a
+# bare `tar -tf <path>` is never at risk of the path being misread as a
+# flag.
 render_archive() {
-  # unreachable: match_render_archive always declines.
-  return 1
+  local path="$1" ext
+  ext="$(_archive_kind "$path")"
+  case "$ext" in
+    zip | jar) render_command_in_pager unzip -l -- "$path" ;;
+    tar | tgz) render_command_in_pager tar -tf "$path" ;;
+  esac
 }

--- a/scripts/renderers/csv.sh
+++ b/scripts/renderers/csv.sh
@@ -1,15 +1,40 @@
 # shellcheck shell=bash
-# csv.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real csv renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# csv.sh: csv/tsv render-registry renderer (v0.4 SG-06/P2). Draws an
+# aligned table via `qsv table`, paged through render_command_in_pager.
+# Absent `qsv` declines to the TEXT renderer (a csv/tsv is still perfectly
+# readable as plain text) rather than the fallback guard - same precedent
+# as markdown.sh's glow-absent degrade. See the render-registry contract at
+# the top of lib.sh.
 
+# match_render_csv <path>: owns `.csv`/`.tsv` files, but only when `qsv` is
+# on PATH (absent -> decline -> falls through the registry to `text`, since
+# csv/tsv content is textual) AND file(1) reports a text encoding, not
+# binary - the negative control this sub-goal's quality bar calls out (a
+# binary-garbage file wearing a `.csv`/`.tsv` extension declines rather
+# than being handed to qsv).
 match_render_csv() {
-  return 1
+  local path="$1" ext enc
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    csv | tsv) ;;
+    *) return 1 ;;
+  esac
+  command -v qsv >/dev/null 2>&1 || return 1
+  enc="$(file -b --mime-encoding -- "$path" 2>/dev/null)"
+  [ "$enc" != "binary" ] && [ -n "$enc" ]
 }
 
+# render_csv <path> [line]: `.tsv` gets an explicit tab delimiter (qsv's
+# own default is comma); `.csv` uses qsv's default. `line` is accepted for
+# render_<kind> signature parity but unused - an aligned table has no line
+# to jump to.
 render_csv() {
-  # unreachable: match_render_csv always declines.
-  return 1
+  local path="$1" ext
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  if [ "$ext" = "tsv" ]; then
+    render_command_in_pager qsv table -d "$(printf '\t')" -- "$path"
+  else
+    render_command_in_pager qsv table -- "$path"
+  fi
 }

--- a/scripts/renderers/json.sh
+++ b/scripts/renderers/json.sh
@@ -1,15 +1,33 @@
 # shellcheck shell=bash
-# json.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real json renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# json.sh: json render-registry renderer (v0.4 SG-06/P2). Pretty-prints via
+# `jq .` (fixes minified/single-line json), paged through
+# render_command_in_pager. Absent `jq` declines to the TEXT renderer (json
+# is still perfectly readable, if less pretty, as plain text) rather than
+# the fallback guard - same precedent as markdown.sh's glow-absent degrade
+# and csv.sh's qsv-absent degrade. See the render-registry contract at the
+# top of lib.sh.
 
+# match_render_json <path>: owns `.json` files, but only when `jq` is on
+# PATH (absent -> decline -> falls through the registry to `text`) AND
+# file(1) reports a text encoding, not binary - the negative control this
+# sub-goal's quality bar calls out (a binary-garbage file wearing a
+# `.json` extension declines rather than being handed to jq).
 match_render_json() {
-  return 1
+  local path="$1" ext enc
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  [ "$ext" = "json" ] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  enc="$(file -b --mime-encoding -- "$path" 2>/dev/null)"
+  [ "$enc" != "binary" ] && [ -n "$enc" ]
 }
 
+# render_json <path> [line]: `line` is accepted for render_<kind> signature
+# parity but unused - a pretty-printed document has no line to jump to. A
+# malformed-json file that still passed the mime-encoding check (it is
+# still text) makes `jq .` print its own parse error to the pager instead
+# of a render - an honest degrade, not a crash.
 render_json() {
-  # unreachable: match_render_json always declines.
-  return 1
+  local path="$1"
+  render_command_in_pager jq . -- "$path"
 }

--- a/scripts/renderers/pdf.sh
+++ b/scripts/renderers/pdf.sh
@@ -1,15 +1,60 @@
 # shellcheck shell=bash
-# pdf.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real pdf renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# pdf.sh: pdf render-registry renderer (v0.4 SG-06/P2). Two independent
+# poppler-backed modes, run together when both are available: a page-1
+# POSTER (`pdftoppm` -> a temp PNG -> image.sh's render_image, the SAME
+# chafa invocation image.sh already uses, never re-implemented) and a TEXT
+# extraction (`pdftotext ... -` paged through render_command_in_pager).
+# Either mode alone is still a useful render, so this renderer degrades in
+# three tiers per the ROADMAP type->tool map: poster+text -> text-only (no
+# pdftoppm/chafa) -> decline (no poppler at all - a real-world pdf's binary
+# stream content then falls through the registry to `fallback`). See the
+# render-registry contract at the top of lib.sh.
 
-match_render_pdf() {
-  return 1
+_pdf_have_poster() {
+  command -v pdftoppm >/dev/null 2>&1 && command -v chafa >/dev/null 2>&1
 }
 
+_pdf_have_text() {
+  command -v pdftotext >/dev/null 2>&1
+}
+
+# match_render_pdf <path>: owns `.pdf` files reported as application/pdf by
+# file(1) (extension alone would let a renamed non-pdf file through), but
+# only when at least ONE poppler mode is usable - poster (pdftoppm+chafa)
+# or text (pdftotext). Neither present -> decline.
+match_render_pdf() {
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  [ "$ext" = "pdf" ] || return 1
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  [ "$mime" = "application/pdf" ] || return 1
+  _pdf_have_poster || _pdf_have_text
+}
+
+# render_pdf <path> [line]: draws the page-1 poster first (when available),
+# then pages the extracted text (when available). `line` is accepted for
+# render_<kind> signature parity but unused - neither poppler mode has a
+# line-jump concept. A poster conversion failure (a corrupt pdf that still
+# passed the mime check) is swallowed - text mode (or nothing, if that is
+# also unavailable) still runs; match_render_pdf already guaranteed at
+# least one mode is usable. The temp PNG is always removed.
 render_pdf() {
-  # unreachable: match_render_pdf always declines.
-  return 1
+  local path="$1" tmp_prefix tmp_png
+  if _pdf_have_poster; then
+    tmp_prefix="$(mktemp "${TMPDIR:-/tmp}/herdr-quicklook-pdf-XXXXXX" 2>/dev/null)" || tmp_prefix=""
+    if [ -n "$tmp_prefix" ]; then
+      rm -f -- "$tmp_prefix"
+      if pdftoppm -png -f 1 -l 1 -singlefile -- "$path" "$tmp_prefix" 2>/dev/null; then
+        tmp_png="$tmp_prefix.png"
+        [ -f "$tmp_png" ] && render_image "$tmp_png"
+        rm -f -- "$tmp_png"
+      fi
+    fi
+  fi
+  if _pdf_have_text; then
+    render_command_in_pager pdftotext -- "$path" -
+    return $?
+  fi
+  return 0
 }

--- a/scripts/renderers/svg.sh
+++ b/scripts/renderers/svg.sh
@@ -1,15 +1,49 @@
 # shellcheck shell=bash
-# svg.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real svg renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# svg.sh: svg render-registry renderer (v0.4 SG-06/P2). Converts to a PNG
+# via `rsvg-convert`, then draws it through image.sh's render_image (SG-04)
+# - reusing the SAME chafa invocation image.sh already uses rather than a
+# second copy, per this sub-goal's scope edge. See the render-registry
+# contract at the top of lib.sh.
 
+# match_render_svg <path>: owns `.svg` files, but only when BOTH
+# `rsvg-convert` and `chafa` are on PATH (degrade is decided here, not
+# mid-render - see the contract comment) AND file(1) actually reports the
+# svg mime type, not just a matching extension - the negative control this
+# sub-goal's quality bar calls out (a binary-garbage/renamed file never
+# reaches rsvg-convert). Note: an svg is XML TEXT, so when this renderer
+# declines on a genuinely absent tool, the registry cascade (RENDER_KINDS
+# in lib.sh) lands the file on the `text` renderer, not `fallback` - the
+# same precedent markdown.sh's glow-absent degrade already established for
+# textual content (see its own bats file); only a non-text kind's
+# tool-absent decline naturally reaches `fallback` (pdf.sh, archive.sh).
 match_render_svg() {
-  return 1
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  [ "$ext" = "svg" ] || return 1
+  command -v rsvg-convert >/dev/null 2>&1 || return 1
+  command -v chafa >/dev/null 2>&1 || return 1
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  [ "$mime" = "image/svg+xml" ]
 }
 
+# render_svg <path> [line]: rsvg-convert -> a temp PNG -> render_image (the
+# SAME chafa invocation image.sh already uses, never re-implemented here).
+# A conversion failure (a corrupt svg that still passed the mime check)
+# degrades to render_fallback rather than crashing or drawing a blank
+# frame. `line` is accepted for render_<kind> signature parity but unused -
+# no line to jump to on an inline image. The temp PNG is always removed,
+# on every exit path.
 render_svg() {
-  # unreachable: match_render_svg always declines.
-  return 1
+  local path="$1" tmp_png rc
+  tmp_png="$(mktemp "${TMPDIR:-/tmp}/herdr-quicklook-svg-XXXXXX.png" 2>/dev/null)" || tmp_png=""
+  if [ -z "$tmp_png" ] || ! rsvg-convert -o "$tmp_png" -- "$path" 2>/dev/null; then
+    [ -n "$tmp_png" ] && rm -f -- "$tmp_png"
+    render_fallback "$path"
+    return $?
+  fi
+  render_image "$tmp_png"
+  rc=$?
+  rm -f -- "$tmp_png"
+  return "$rc"
 }

--- a/tests/renderers-archive.bats
+++ b/tests/renderers-archive.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/archive.sh (zip/tar/tgz/jar content listings
+# via unzip -l / tar -tf, v0.4 SG-06/P2). Same fixture/sourcing shape as
+# tests/render-registry.bats.
+#
+# unzip/tar are base-system on macOS + Linux (never absent in practice, per
+# the ROADMAP type->tool map), so a plain PATH narrowed to /usr/bin:/bin
+# still finds them - unlike every other kind in this pack. The tool-absent
+# degrade test below needs a SYMLINK-ONLY allowlist (mirroring
+# tests/renderers-fallback.bats's ONLYBASE idiom) to simulate the genuinely
+# rare case.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  echo hi > "$FIX/a.txt"
+  (cd "$FIX" && zip -q t.zip a.txt && tar -cf t.tar a.txt && gzip -c t.tar > t.tgz && cp t.zip t.jar)
+  # binary garbage wearing each archive extension - the negative control,
+  # same shape as render-registry.bats's own blob.bin.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.zip"
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.tar"
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.tgz"
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.jar"
+
+  # NOARCH: symlinks to ONLY file/tr/less/head/od/dirname (dirname is what
+  # lib.sh itself needs at source time for LIB_DIR - see its top) - no
+  # unzip, no tar. A narrowed /usr/bin:/bin PATH cannot hide these two
+  # (they ARE base-system on macOS/Linux), so only an allowlisted PATH lets
+  # the "tool somehow absent" degrade be tested for real, per the ROADMAP
+  # note above.
+  NOARCH="$(mktemp -d)"
+  for b in file tr less head od dirname; do
+    ln -s "$(command -v "$b")" "$NOARCH/$b"
+  done
+
+  STUB="$(mktemp -d)"
+  export UNZIP_ARGV_FILE="$FIX/unzip.argv"
+  export TAR_ARGV_FILE="$FIX/tar.argv"
+}
+
+teardown() {
+  cd /
+  # Absolute path, not a PATH lookup: the tool-absent test above narrows
+  # PATH down to $NOARCH (no /bin) for the rest of this test invocation -
+  # same convention as tests/renderers-fallback.bats's ONLYBASE teardown.
+  /bin/rm -rf "$FIX" "$STUB" "$NOARCH"
+  # Restore a normal PATH so bats-core's OWN post-teardown bookkeeping
+  # (which runs after this function, in the same process) can still find
+  # its usual coreutils.
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+_stub_unzip() {
+  cat > "$STUB/unzip" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$UNZIP_ARGV_FILE"
+printf 'UNZIP_LISTING\n'
+exit 0
+SH
+  chmod +x "$STUB/unzip"
+}
+
+_stub_tar() {
+  cat > "$STUB/tar" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$TAR_ARGV_FILE"
+printf 'TAR_LISTING\n'
+exit 0
+SH
+  chmod +x "$STUB/tar"
+}
+
+# ---- match: unzip/tar present (the normal case, base-system) ----
+
+@test "match_render_archive: matches a real .zip" {
+  _stub_unzip
+  export PATH="$STUB:$PATH"
+  match_render_archive "$FIX/t.zip"
+}
+
+@test "match_render_archive: matches a real .jar (zip format)" {
+  _stub_unzip
+  export PATH="$STUB:$PATH"
+  match_render_archive "$FIX/t.jar"
+}
+
+@test "match_render_archive: matches a real .tar" {
+  _stub_tar
+  export PATH="$STUB:$PATH"
+  match_render_archive "$FIX/t.tar"
+}
+
+@test "match_render_archive: matches a real .tgz" {
+  _stub_tar
+  export PATH="$STUB:$PATH"
+  match_render_archive "$FIX/t.tgz"
+}
+
+@test "match_render_archive: declines a non-archive extension" {
+  _stub_unzip
+  _stub_tar
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_archive "$FIX/t.md"
+}
+
+# ---- degrade: unzip/tar somehow absent (symlink-only allowlist) ----
+
+@test "match_render_archive: declines when unzip/tar are absent (symlink-only allowlist, no /usr/bin or /usr/local/bin)" {
+  export PATH="$NOARCH"
+  ! command -v unzip >/dev/null 2>&1
+  ! command -v tar >/dev/null 2>&1
+  ! match_render_archive "$FIX/t.zip"
+  ! match_render_archive "$FIX/t.tar"
+}
+
+@test "render-registry: unzip/tar absent - a real zip routes to fallback via render_any" {
+  export PATH="$NOARCH"
+  # Absolute /bin/bash, not a PATH lookup: $NOARCH does not carry bash
+  # itself (only the archive-tool allowlist), same reasoning as the
+  # teardown fix above.
+  run /bin/bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.zip'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.zip" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_archive: declines binary garbage renamed for each extension (keys on type, not extension)" {
+  _stub_unzip
+  _stub_tar
+  export PATH="$STUB:$PATH"
+  ! match_render_archive "$FIX/fake.zip"
+  ! match_render_archive "$FIX/fake.jar"
+  ! match_render_archive "$FIX/fake.tar"
+  ! match_render_archive "$FIX/fake.tgz"
+}
+
+@test "render-registry: binary garbage renamed .zip routes to fallback, never unzip" {
+  _stub_unzip
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.zip'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.zip" ]
+  [ ! -e "$UNZIP_ARGV_FILE" ]
+}
+
+# ---- render: content listing, paged ----
+
+@test "render_archive: zip/jar page an unzip -l listing" {
+  _stub_unzip
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_archive '$FIX/t.zip'"
+  [ "$status" -eq 0 ]
+  [ -f "$UNZIP_ARGV_FILE" ]
+  grep -qx -- '-l' "$UNZIP_ARGV_FILE"
+  grep -qx -- "$FIX/t.zip" "$UNZIP_ARGV_FILE"
+  [[ "$output" == *"UNZIP_LISTING"* ]]
+}
+
+@test "render_archive: tar/tgz page a tar -tf listing" {
+  _stub_tar
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_archive '$FIX/t.tgz'"
+  [ "$status" -eq 0 ]
+  [ -f "$TAR_ARGV_FILE" ]
+  grep -qx -- '-tf' "$TAR_ARGV_FILE"
+  grep -qx -- "$FIX/t.tgz" "$TAR_ARGV_FILE"
+  [[ "$output" == *"TAR_LISTING"* ]]
+}
+
+# ---- real tools end-to-end (no stubs): a genuine listing, not a stub echo ----
+
+@test "render_archive: a real .zip lists its member file via the actual unzip binary" {
+  run bash -c ". '$LIB'; render_archive '$FIX/t.zip'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"a.txt"* ]]
+}
+
+@test "render_archive: a real .tgz lists its member file via the actual tar binary" {
+  run bash -c ". '$LIB'; render_archive '$FIX/t.tgz'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"a.txt"* ]]
+}

--- a/tests/renderers-csv.bats
+++ b/tests/renderers-csv.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/csv.sh (csv/tsv via `qsv table`, v0.4
+# SG-06/P2). Same fixture/sourcing shape as tests/render-registry.bats.
+# `qsv` is not a base-system tool, so a plain /usr/bin:/bin PATH is a real
+# absence (verified - no /opt/homebrew/bin or /usr/local/bin gotcha here).
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf 'a,b,c\n1,2,3\n' > "$FIX/t.csv"
+  printf 'a\tb\tc\n1\t2\t3\n' > "$FIX/t.tsv"
+  # binary garbage wearing a .csv/.tsv extension - the negative control,
+  # same shape as render-registry.bats's own blob.bin.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.csv"
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.tsv"
+
+  STUB="$(mktemp -d)"
+  export QSV_ARGV_FILE="$FIX/qsv.argv"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+_stub_qsv() {
+  cat > "$STUB/qsv" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$QSV_ARGV_FILE"
+printf 'QSV_TABLE\n'
+exit 0
+SH
+  chmod +x "$STUB/qsv"
+}
+
+# ---- match: qsv present ----
+
+@test "match_render_csv: matches a real .csv when qsv is present" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  match_render_csv "$FIX/t.csv"
+}
+
+@test "match_render_csv: matches a real .tsv when qsv is present" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  match_render_csv "$FIX/t.tsv"
+}
+
+@test "match_render_csv: declines a non-csv/tsv extension" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_csv "$FIX/t.md"
+}
+
+# ---- degrade: qsv absent ----
+
+@test "match_render_csv: declines when qsv is absent (PATH excludes /opt/homebrew/bin and /usr/local/bin)" {
+  export PATH="/usr/bin:/bin"
+  ! command -v qsv >/dev/null 2>&1
+  ! match_render_csv "$FIX/t.csv"
+}
+
+@test "render-registry: qsv absent - a real csv falls through to the text renderer, not fallback (a csv is still readable as text)" {
+  export PATH="/usr/bin:/bin"
+  run bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.csv'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT-RENDERED:$FIX/t.csv" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_csv: declines binary garbage renamed .csv/.tsv (keys on type, not extension)" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  ! match_render_csv "$FIX/fake.csv"
+  ! match_render_csv "$FIX/fake.tsv"
+}
+
+@test "render-registry: binary garbage renamed .csv routes to fallback, never qsv" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.csv'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.csv" ]
+  [ ! -e "$QSV_ARGV_FILE" ]
+}
+
+# ---- render: aligned table argv, csv default vs tsv explicit delimiter ----
+
+@test "render_csv: a .csv calls qsv table with no explicit delimiter" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_csv '$FIX/t.csv'"
+  [ "$status" -eq 0 ]
+  [ -f "$QSV_ARGV_FILE" ]
+  grep -qx -- "$FIX/t.csv" "$QSV_ARGV_FILE"
+  ! grep -qx -- '-d' "$QSV_ARGV_FILE"
+  [[ "$output" == *"QSV_TABLE"* ]]
+}
+
+@test "render_csv: a .tsv calls qsv table with an explicit tab delimiter" {
+  _stub_qsv
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_csv '$FIX/t.tsv'"
+  [ "$status" -eq 0 ]
+  [ -f "$QSV_ARGV_FILE" ]
+  grep -qx -- '-d' "$QSV_ARGV_FILE"
+  printf '\t' > "$FIX/tab.expected"
+  grep -qxFf "$FIX/tab.expected" "$QSV_ARGV_FILE"
+  grep -qx -- "$FIX/t.tsv" "$QSV_ARGV_FILE"
+}
+
+# ---- real qsv end-to-end (no stub): a genuine aligned table, not a stub echo ----
+
+@test "render_csv: a real .csv renders an aligned table via the actual qsv binary" {
+  run bash -c ". '$LIB'; render_csv '$FIX/t.csv'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"a"*"b"*"c"* ]]
+  [[ "$output" == *"1"*"2"*"3"* ]]
+}

--- a/tests/renderers-json.bats
+++ b/tests/renderers-json.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/json.sh (json via `jq .`, v0.4 SG-06/P2). Same
+# fixture/sourcing shape as tests/render-registry.bats.
+#
+# GOTCHA: unlike every other tool in this pack, `jq` is ALSO installed as a
+# base-system binary at /usr/bin/jq on some hosts (verified on this one) -
+# a plain PATH="/usr/bin:/bin" is NOT a real absence here. The tool-absent
+# tests below use a symlink-only allowlist (mirroring
+# tests/renderers-fallback.bats's ONLYBASE idiom) instead.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf '{"a":1,"b":[1,2,3]}' > "$FIX/t.json"
+  # binary garbage wearing a .json extension - the negative control, same
+  # shape as render-registry.bats's own blob.bin.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.json"
+
+  # NOJQ: symlinks to ONLY file/tr/less/head/od/dirname (dirname is what
+  # lib.sh itself needs at source time for LIB_DIR - see its top) - no jq.
+  # See the GOTCHA note above: excluding /opt/homebrew/bin and
+  # /usr/local/bin is not enough on a host where jq also lives in /usr/bin.
+  NOJQ="$(mktemp -d)"
+  for b in file tr less head od dirname; do
+    ln -s "$(command -v "$b")" "$NOJQ/$b"
+  done
+
+  STUB="$(mktemp -d)"
+  export JQ_ARGV_FILE="$FIX/jq.argv"
+}
+
+teardown() {
+  cd /
+  # Absolute path, not a PATH lookup: the tool-absent test above narrows
+  # PATH down to $NOJQ (no /bin) for the rest of this test invocation -
+  # same convention as tests/renderers-fallback.bats's ONLYBASE teardown.
+  /bin/rm -rf "$FIX" "$STUB" "$NOJQ"
+  # Restore a normal PATH so bats-core's OWN post-teardown bookkeeping
+  # (which runs after this function, in the same process) can still find
+  # its usual coreutils.
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+_stub_jq() {
+  cat > "$STUB/jq" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$JQ_ARGV_FILE"
+printf 'JQ_PRETTY\n'
+exit 0
+SH
+  chmod +x "$STUB/jq"
+}
+
+# ---- match: jq present ----
+
+@test "match_render_json: matches a real .json when jq is present" {
+  _stub_jq
+  export PATH="$STUB:$PATH"
+  match_render_json "$FIX/t.json"
+}
+
+@test "match_render_json: declines a non-json extension" {
+  _stub_jq
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_json "$FIX/t.md"
+}
+
+# ---- degrade: jq absent (symlink-only allowlist, see the GOTCHA note) ----
+
+@test "match_render_json: declines when jq is absent (symlink-only allowlist, no /usr/bin or /usr/local/bin)" {
+  export PATH="$NOJQ"
+  ! command -v jq >/dev/null 2>&1
+  ! match_render_json "$FIX/t.json"
+}
+
+@test "render-registry: jq absent - a real json falls through to the text renderer, not fallback (json is still readable as text)" {
+  export PATH="$NOJQ"
+  # Absolute /bin/bash, not a PATH lookup: $NOJQ does not carry bash itself
+  # (only the jq-exclusion allowlist), same reasoning as the teardown fix
+  # above.
+  run /bin/bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.json'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT-RENDERED:$FIX/t.json" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_json: declines binary garbage renamed .json (keys on type, not extension)" {
+  _stub_jq
+  export PATH="$STUB:$PATH"
+  ! match_render_json "$FIX/fake.json"
+}
+
+@test "render-registry: binary garbage renamed .json routes to fallback, never jq" {
+  _stub_jq
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.json'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.json" ]
+  [ ! -e "$JQ_ARGV_FILE" ]
+}
+
+# ---- render: pretty-print argv, paged ----
+
+@test "render_json: calls jq . on the file and pages the output" {
+  _stub_jq
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_json '$FIX/t.json'"
+  [ "$status" -eq 0 ]
+  [ -f "$JQ_ARGV_FILE" ]
+  grep -qx -- '.' "$JQ_ARGV_FILE"
+  grep -qx -- "$FIX/t.json" "$JQ_ARGV_FILE"
+  [[ "$output" == *"JQ_PRETTY"* ]]
+}
+
+# ---- real jq end-to-end (no stub): a genuine pretty-print, not a stub echo ----
+
+@test "render_json: a real minified json pretty-prints via the actual jq binary" {
+  printf '{"a":1}' > "$FIX/mini.json"
+  run bash -c ". '$LIB'; render_json '$FIX/mini.json'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"a": 1'* ]]
+}

--- a/tests/renderers-pdf.bats
+++ b/tests/renderers-pdf.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/pdf.sh (pdf via pdftoppm+chafa poster and
+# pdftotext text mode, v0.4 SG-06/P2). Same fixture/sourcing shape as
+# tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # A minimal, REAL pdf (verified via `file --mime-type` = application/pdf).
+  {
+    printf '%%PDF-1.4\n'
+    printf '1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n'
+    printf '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n'
+    printf '3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 100]>>endobj\n'
+    printf 'trailer<</Size 4/Root 1 0 R>>\n%%%%EOF\n'
+  } >"$FIX/t.pdf"
+  # A real pdf whose stream carries actual binary bytes (a NUL byte) -
+  # representative of a genuine PDF (compressed/binary stream content),
+  # unlike the plain-ASCII fixture above. file(1) still reports
+  # application/pdf but mime-ENCODING is "binary" - this is the fixture the
+  # "poppler entirely absent" degrade test needs, since an all-ASCII pdf
+  # would (like an svg) instead fall through to the text renderer.
+  {
+    printf '%%PDF-1.4\n'
+    printf '1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n'
+    printf '4 0 obj<</Length 8>>\nstream\n'
+    printf '\x00\x01\x02\x03\x04\x05\x06\x07'
+    printf '\nendstream\nendobj\n'
+    printf 'trailer<</Size 5/Root 1 0 R>>\n%%%%EOF\n'
+  } >"$FIX/bin.pdf"
+  # binary garbage wearing a .pdf extension - the negative control.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' >"$FIX/fake.pdf"
+
+  STUB="$(mktemp -d)"
+  export PDFTOPPM_ARGV_FILE="$FIX/pdftoppm.argv"
+  export PDFTOTEXT_ARGV_FILE="$FIX/pdftotext.argv"
+  export CHAFA_ARGV_FILE="$FIX/chafa.argv"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+_stub_pdftoppm_ok() {
+  cat > "$STUB/pdftoppm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$PDFTOPPM_ARGV_FILE"
+last="${@: -1}"
+: > "${last}.png"
+exit 0
+SH
+  chmod +x "$STUB/pdftoppm"
+}
+
+_stub_pdftotext_ok() {
+  cat > "$STUB/pdftotext" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$PDFTOTEXT_ARGV_FILE"
+printf 'PDFTOTEXT_OUTPUT\n'
+exit 0
+SH
+  chmod +x "$STUB/pdftotext"
+}
+
+_stub_chafa() {
+  cat > "$STUB/chafa" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CHAFA_ARGV_FILE"
+exit 0
+SH
+  chmod +x "$STUB/chafa"
+}
+
+# ---- match: both modes present ----
+
+@test "match_render_pdf: matches a real .pdf when pdftoppm+chafa AND pdftotext are all present" {
+  _stub_pdftoppm_ok
+  _stub_pdftotext_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  match_render_pdf "$FIX/t.pdf"
+}
+
+@test "match_render_pdf: matches poster-only (pdftotext absent, pdftoppm+chafa present)" {
+  _stub_pdftoppm_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  match_render_pdf "$FIX/t.pdf"
+}
+
+@test "match_render_pdf: matches text-only (pdftoppm absent, pdftotext present)" {
+  _stub_pdftotext_ok
+  export PATH="$STUB:/usr/bin:/bin"
+  match_render_pdf "$FIX/t.pdf"
+}
+
+@test "match_render_pdf: declines a non-pdf extension" {
+  _stub_pdftoppm_ok
+  _stub_pdftotext_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_pdf "$FIX/t.md"
+}
+
+# ---- degrade: poppler entirely absent ----
+
+@test "match_render_pdf: declines when all of pdftoppm/pdftotext are absent (PATH excludes /opt/homebrew/bin and /usr/local/bin)" {
+  export PATH="/usr/bin:/bin"
+  ! match_render_pdf "$FIX/t.pdf"
+}
+
+@test "render-registry: poppler absent - a real (binary-stream) pdf routes to fallback via render_any, never text" {
+  export PATH="/usr/bin:/bin"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_text() { printf 'TEXT:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/bin.pdf'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/bin.pdf" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_pdf: declines binary garbage renamed .pdf (keys on type, not extension)" {
+  _stub_pdftoppm_ok
+  _stub_pdftotext_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  ! match_render_pdf "$FIX/fake.pdf"
+}
+
+@test "render-registry: binary garbage renamed .pdf routes to fallback, never pdftoppm/pdftotext" {
+  _stub_pdftoppm_ok
+  _stub_pdftotext_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.pdf'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.pdf" ]
+  [ ! -e "$PDFTOPPM_ARGV_FILE" ]
+  [ ! -e "$PDFTOTEXT_ARGV_FILE" ]
+}
+
+# ---- render: poster + text together ----
+
+@test "render_pdf: full mode draws the page-1 poster via render_image (chafa) then pages pdftotext's output" {
+  _stub_pdftoppm_ok
+  _stub_pdftotext_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_pdf '$FIX/t.pdf' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$PDFTOPPM_ARGV_FILE" ]
+  grep -qx -- '-singlefile' "$PDFTOPPM_ARGV_FILE"
+  grep -qx -- "$FIX/t.pdf" "$PDFTOPPM_ARGV_FILE"
+  tmp_prefix="$(tail -1 "$PDFTOPPM_ARGV_FILE")"
+  [ -f "$CHAFA_ARGV_FILE" ]
+  grep -qx -- "${tmp_prefix}.png" "$CHAFA_ARGV_FILE"
+  # the poster temp png is cleaned up after the render.
+  [ ! -e "${tmp_prefix}.png" ]
+  [ -f "$PDFTOTEXT_ARGV_FILE" ]
+  grep -qx -- "$FIX/t.pdf" "$PDFTOTEXT_ARGV_FILE"
+  [[ "$output" == *"PDFTOTEXT_OUTPUT"* ]]
+}
+
+# ---- render: poster-only (pdftotext absent) ----
+
+@test "render_pdf: poster-only mode draws via chafa and never calls pdftotext" {
+  _stub_pdftoppm_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_pdf '$FIX/t.pdf' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$CHAFA_ARGV_FILE" ]
+  [ ! -e "$PDFTOTEXT_ARGV_FILE" ]
+}
+
+# ---- render: text-only (poster tools absent) ----
+
+@test "render_pdf: text-only mode pages pdftotext's output and never calls pdftoppm/chafa" {
+  _stub_pdftotext_ok
+  export PATH="$STUB:/usr/bin:/bin"
+  run bash -c ". '$LIB'; render_pdf '$FIX/t.pdf'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PDFTOTEXT_OUTPUT"* ]]
+  [ ! -e "$PDFTOPPM_ARGV_FILE" ]
+  [ ! -e "$CHAFA_ARGV_FILE" ]
+}

--- a/tests/renderers-svg.bats
+++ b/tests/renderers-svg.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/svg.sh (svg via rsvg-convert -> chafa, v0.4
+# SG-06/P2). Same fixture/sourcing shape as tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>\n' > "$FIX/t.svg"
+  # binary garbage wearing a .svg extension - the negative control, same
+  # shape as render-registry.bats's own blob.bin.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.svg"
+
+  STUB="$(mktemp -d)"
+  export RSVG_ARGV_FILE="$FIX/rsvg.argv"
+  export CHAFA_ARGV_FILE="$FIX/chafa.argv"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+_stub_rsvg_ok() {
+  cat > "$STUB/rsvg-convert" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$RSVG_ARGV_FILE"
+exit 0
+SH
+  chmod +x "$STUB/rsvg-convert"
+}
+
+_stub_rsvg_fails() {
+  cat > "$STUB/rsvg-convert" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$STUB/rsvg-convert"
+}
+
+_stub_chafa() {
+  cat > "$STUB/chafa" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CHAFA_ARGV_FILE"
+exit 0
+SH
+  chmod +x "$STUB/chafa"
+}
+
+# ---- match: both tools present ----
+
+@test "match_render_svg: matches a real .svg when rsvg-convert and chafa are present" {
+  _stub_rsvg_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  match_render_svg "$FIX/t.svg"
+}
+
+@test "match_render_svg: declines a non-svg extension" {
+  _stub_rsvg_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  printf 'hello\n' > "$FIX/t.md"
+  ! match_render_svg "$FIX/t.md"
+}
+
+# ---- degrade: either tool absent ----
+
+@test "match_render_svg: declines when rsvg-convert is absent (PATH excludes /opt/homebrew/bin and /usr/local/bin)" {
+  _stub_chafa
+  export PATH="$STUB:/usr/bin:/bin"
+  ! match_render_svg "$FIX/t.svg"
+}
+
+@test "match_render_svg: declines when chafa is absent (PATH excludes /opt/homebrew/bin and /usr/local/bin)" {
+  _stub_rsvg_ok
+  export PATH="$STUB:/usr/bin:/bin"
+  ! match_render_svg "$FIX/t.svg"
+}
+
+@test "render-registry: tools absent - a real svg falls through to the text renderer (svg is XML text, same precedent as markdown.sh's glow-absent degrade), never fallback" {
+  export PATH="/usr/bin:/bin"
+  run bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK-RENDERED:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.svg'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT-RENDERED:$FIX/t.svg" ]
+}
+
+# ---- negative control: type mismatch, not just extension ----
+
+@test "match_render_svg: declines binary garbage renamed .svg (keys on type, not extension)" {
+  _stub_rsvg_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  ! match_render_svg "$FIX/fake.svg"
+}
+
+@test "render-registry: binary garbage renamed .svg routes to fallback, never rsvg-convert" {
+  _stub_rsvg_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.svg'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.svg" ]
+  [ ! -e "$RSVG_ARGV_FILE" ]
+}
+
+# ---- render: rsvg-convert -> temp png -> render_image (reused, not duplicated) ----
+
+@test "render_svg: converts via rsvg-convert to a temp png, then draws the SAME file via image.sh's render_image (chafa)" {
+  _stub_rsvg_ok
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_svg '$FIX/t.svg' <<<'x'"
+  [ "$status" -eq 0 ]
+  [ -f "$RSVG_ARGV_FILE" ]
+  grep -qx -- '-o' "$RSVG_ARGV_FILE"
+  grep -qx -- "$FIX/t.svg" "$RSVG_ARGV_FILE"
+  tmp_png="$(grep -A1 -x -- '-o' "$RSVG_ARGV_FILE" | tail -1)"
+  [[ "$tmp_png" == *.png ]]
+  [ -f "$CHAFA_ARGV_FILE" ]
+  grep -qx -- "$tmp_png" "$CHAFA_ARGV_FILE"
+  # the temp png is cleaned up after the render, never left behind.
+  [ ! -e "$tmp_png" ]
+}
+
+@test "render_svg: a conversion failure degrades to render_fallback, never a blank/crashed frame" {
+  _stub_rsvg_fails
+  _stub_chafa
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_svg '$FIX/t.svg'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.svg" ]
+  [ ! -e "$CHAFA_ARGV_FILE" ]
+}


### PR DESCRIPTION
New render types (P2): svg (rsvg-convert -> chafa), pdf (pdftoppm page-1 poster via
chafa + pdftotext text mode), archives zip/tar/tgz/jar (content listing), csv/tsv
(`qsv table`), minified json (`jq .`). Each degrades cleanly: chafa/poppler-backed
kinds (svg, pdf-poster) and binary kinds (archives) fall to the `file(1)`+hexyl
fallback guard; text-like kinds (csv, json, and svg specifically since svg is XML
text) fall to the plain-text preview instead. `lib.sh`, `RENDER_KINDS`,
`preview-pane.sh` are untouched - each kind is a single new-file edit to its own
`scripts/renderers/<kind>.sh`.

## Run-table

| Kind | Tool | Match (present) | Render | Degrade (tool absent) | Negative control (binary garbage) |
|---|---|---|---|---|---|
| svg | `rsvg-convert` + `chafa` | ext `.svg` + mime `image/svg+xml` | rsvg-convert -> temp png -> image.sh's `render_image` (chafa, reused) | falls through to `text` (svg is XML text - same precedent as markdown.sh's glow-absent degrade) | declines, routes to `fallback` |
| pdf | `pdftoppm`+`chafa` and/or `pdftotext` | ext `.pdf` + mime `application/pdf` | page-1 poster (pdftoppm -> `render_image`) + `pdftotext` piped through `less -R` | poster-only or text-only tiers; poppler entirely absent -> `fallback` (pdf is binary) | declines, routes to `fallback` |
| archive | `unzip` (zip/jar) / `tar` (tar/tgz) | ext + mime (`application/zip`, `application/x-tar`, `application/gzip`) | `unzip -l` / `tar -tf`, paged via `render_command_in_pager` | falls to `fallback` (rare - unzip/tar are base-system) | declines, routes to `fallback` |
| csv/tsv | `qsv` | ext `.csv`/`.tsv` + non-binary mime-encoding | `qsv table` (explicit `-d` tab for tsv), paged | falls through to `text` (csv/tsv is textual) | declines, routes to `fallback` (garbage's own mime-encoding is binary) |
| json | `jq` | ext `.json` + non-binary mime-encoding | `jq .`, paged | falls through to `text` (json is textual) | declines, routes to `fallback` |

## COVERAGE-DELTA

- `scripts/renderers/{svg,pdf,archive,csv,json}.sh`: filled from the SG-01 declining
  stubs to real renderers. `shellcheck -x` clean on all five.
- `tests/renderers-{svg,pdf,archive,csv,json}.bats`: 51 new tests (9 svg, 11 pdf, 13
  archive, 10 csv, 8 json) covering match-present, match-declines-tool-absent,
  render argv/output shape, the render-registry degrade cascade, and a
  binary-garbage negative control per kind. Full suite: 357 passed, 0 failed
  (`bats tests/`).
- `README.md`: 5 new rows in the `## Renderers (v0.4)` table.
- `CHANGELOG.md`: 1 new Unreleased bullet covering all five kinds.

## Deviations from the goal file

- **PR base is `main`, not `feat/ql4-01-registry`.** Per the dispatch brief, this
  branch was cut from current `main` with waves 1-2 (registry, install script,
  markdown, image/gif, fallback) already merged in; `feat/ql4-01-registry` is the
  pre-merge branch name from before wave ordering settled.
- **svg's tool-absent degrade lands on the `text` renderer, not `fallback`.** The
  goal file's Outcome section says "absent rsvg-convert OR chafa -> decline ->
  fallback + hint", mirroring the ROADMAP type-table's "Degrades to: fallback +
  hint" cell. In the actual shipped registry, RENDER_KINDS cascades a declined
  kind through every remaining kind before `fallback`, and `text`'s own match
  (`file -b --mime-encoding` != binary) claims ANY textual content - which an svg
  file is (it's XML). This is the exact same situation markdown.sh already hit and
  resolved: its own ROADMAP row also says "fallback + hint", but its shipped
  degrade (and its own bats test, `renderers-markdown.bats`) is "falls through to
  the text renderer, not fallback" - the ROADMAP table's degrade column is written
  at the tool-tier level, not the final-registry-hop level. I followed the
  markdown precedent rather than fight `lib.sh`/`RENDER_KINDS` (both out of scope
  for this sub-goal) to force a different outcome. pdf and archive are genuinely
  binary formats, so their tool-absent degrade lands on `fallback` exactly as
  written, no deviation there.
- **Two host-specific PATH gotchas found and worked around in tests** (documented
  inline): `jq` is ALSO a base-system binary at `/usr/bin/jq` on this host, so the
  json tool-absent tests use a symlink-only allowlist PATH (mirroring
  `renderers-fallback.bats`'s `ONLYBASE` idiom) rather than the usual
  `/usr/bin:/bin` narrowing. Conversely `unzip`/`tar` are GENUINELY base-system
  (by design, per the ROADMAP), so the archive tool-absent test also needed the
  same symlink-only allowlist technique to simulate the rare "somehow absent" case
  at all.
- **tar's argv omits the `--` end-of-options marker** every other renderer in this
  pack uses: macOS's bundled bsdtar mis-parses `tar -tf -- <path>` (`tar: --: m:
  No such file or directory`, verified interactively), while `unzip -l -- <path>`
  handles it fine. `resolve()` in `lib.sh` only ever hands renderers an ABSOLUTE
  path, so a bare `tar -tf <path>` is never at risk of the path being misread as a
  flag. Documented inline in `archive.sh`.
