### PR TITLE
feat(renderers): P3 pack - ipynb, office, media, sqlite, plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@
   present, archives fall to the fallback guard below in the rare case
   `unzip`/`tar` are somehow absent (they are base-system).
 
+- The preview overlay renders the P3 file types: Jupyter notebooks (`.ipynb`,
+  via `pandoc`'s ipynb reader -> markdown -> `glow`), office documents
+  (`docx`/`xlsx`, via `pandoc` -> markdown -> `glow`, `xlsx` shows its first
+  sheet only), media (`mp4`/`mov`/`mp3`, `ffprobe` metadata plus a bounded
+  `ffmpeg` first-frame poster for video - **never playback**), sqlite
+  databases (`.sqlite`/`.db`, table list + schema via `sqlite3 -readonly` -
+  never a row dump), and plists (`.plist`, `plutil -p`). Every kind degrades
+  to plain text (for the text-shaped `.ipynb`) or the fallback guard below
+  (for the binary-shaped kinds) when its tool is absent, never a crash or a
+  raw-byte dump.
+
 - Unknown/binary files now render through an always-on fallback guard: a
   `file(1)` type line, a bounded first-KB hexdump (`hexyl`, degrading to
   `xxd` then the base-system `od`), and an "install `<tool>`" hint when a

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Once a token resolves to a local file, a second registry decides HOW to draw it:
 | archives (`zip`/`tar`/`tgz`/`jar`) | A content listing (`unzip -l` / `tar -tf`), paged - `unzip`/`tar` are base-system, so this rarely degrades |
 | csv/tsv (`.csv`/`.tsv`) | An aligned table via [`qsv table`](https://github.com/dathere/qsv); degrades to the plain-text preview when `qsv` is absent |
 | json (`.json`) | Pretty-printed via `jq .` (fixes minified/single-line json); degrades to the plain-text preview when `jq` is absent |
+| Jupyter notebooks (`.ipynb`) | `pandoc`'s ipynb reader converts cells to markdown (its `::: {.cell ...}` fences stripped), rendered via the same `glow` path as plain markdown; degrades to the plain-text preview (a notebook is JSON, still readable) when `pandoc` or `glow` is absent |
+| office documents (`docx`/`xlsx`) | `pandoc` converts to markdown and renders via the same `glow` path (`xlsx` shows the FIRST sheet only); falls back to the guard below when `pandoc` or `glow` is absent (an office file is binary, not readable as plain text) |
+| media (`mp4`/`mov`/`mp3`) | `ffprobe` metadata (duration/codec/dimensions/bitrate) always, plus an `ffmpeg` first-frame poster drawn inline via `chafa` for video - **never playback**, every probe/extraction is bounded so a bad or huge file can't hang the pane; audio degrades to metadata-only (no poster to extract); falls back to the guard below when `ffprobe` (or, for video, `ffmpeg`) is absent |
+| sqlite databases (`.sqlite`/`.db`) | Table list + schema via `sqlite3 -readonly` - never a row dump; falls back to the guard below when `sqlite3` is absent |
+| plists (`.plist`) | A structured dump via `plutil -p` (base-system on macOS, works for both XML and binary plists); falls back to the guard below on Linux, where `plutil` doesn't exist |
 | unknown / binary (the catch-all fallback) | A `file(1)` one-line type description, a bounded first-~1KB hexdump ([`hexyl`](https://github.com/sharkdp/hexyl) when installed, degrading to `xxd` then the base-system `od` - never raw bytes), and an "install `<tool>`" hint when the extension maps to a known type whose renderer tool isn't on PATH yet |
 
 ## Install

--- a/scripts/renderers/ipynb.sh
+++ b/scripts/renderers/ipynb.sh
@@ -1,15 +1,66 @@
 # shellcheck shell=bash
-# ipynb.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real ipynb renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# ipynb.sh: Jupyter-notebook render-registry renderer (v0.4 SG-07, P3 pack).
+# Converts the notebook to markdown via `pandoc -f ipynb` (pandoc's own ipynb
+# reader - the tool README.md's Prerequisites table already commits `.ipynb`
+# to, alongside `glow` for the P1 markdown row: no new undeclared dependency),
+# strips pandoc's `::: {.cell ...}` / `:::` div-fence wrapper lines (goldmark,
+# what `glow` renders with, does not understand pandoc-native fenced divs -
+# left in, they would show up as literal `:::` noise around every cell), then
+# feeds the result to `render_markdown` (SG-03) - reuse BY CALLING, never a
+# duplicated glow/pager invocation. See the render-registry contract at the
+# top of lib.sh.
 
+# match_render_ipynb <path>: extension gate (.ipynb) PLUS pandoc AND glow on
+# PATH (both required - render_ipynb always ends in a call to render_markdown,
+# so glow's presence must be decided HERE, not mid-render, same as
+# match_render_markdown's own gate) PLUS a text-encoding check (a .ipynb is
+# JSON, i.e. text - `file --mime-encoding` reporting "binary" is the
+# negative-control signal that this is garbage wearing a .ipynb extension, not
+# a real notebook; declining here lets it fall through to `text`, which
+# declines the same binary file for the same reason, landing it on
+# `fallback` - exactly the "binary-garbage -> fallback" quality bar). A
+# syntactically-broken-but-textual .ipynb (invalid JSON, valid UTF-8) still
+# matches; pandoc's own parse failure is handled as a graceful in-pane message
+# by render_ipynb below, never a crash.
 match_render_ipynb() {
-  return 1
+  local path="$1" ext enc
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  [ "$ext" = "ipynb" ] || return 1
+  command -v pandoc >/dev/null 2>&1 || return 1
+  command -v glow >/dev/null 2>&1 || return 1
+  enc="$(file -b --mime-encoding -- "$path" 2>/dev/null)"
+  [ "$enc" != "binary" ] && [ -n "$enc" ]
 }
 
+# render_ipynb <path> [line]: extracts to a `mktemp` markdown file (the
+# office-conversion safety rule - office.sh's own temp files follow the same
+# pattern - applies here too even though ipynb isn't "office"), a failed or
+# empty conversion becomes a short in-pager notice instead of a blank/garbled
+# render, then hands the file to `render_markdown` and returns ITS exit
+# status. The temp file is removed after render_markdown returns (it pages
+# synchronously - `render_command_in_pager` blocks on `less`, so control is
+# back here before cleanup, never a dangling temp file). `line` is accepted
+# for render_<kind> signature parity but unused, same as markdown.sh.
+#
+# The pandoc|sed pipeline runs INLINE in this function body (not behind a
+# helper function) so `${PIPESTATUS[0]}` reads pandoc's real exit status -
+# bash does not propagate PIPESTATUS across a function-call boundary, so a
+# `_helper "$path" >"$tmp"; rc=${PIPESTATUS[0]}` shape would silently read 0
+# every time (verified live; see DECISIONS.md).
 render_ipynb() {
-  # unreachable: match_render_ipynb always declines.
-  return 1
+  local path="$1" tmp rc
+  tmp="$(mktemp "${TMPDIR:-/tmp}/herdr-quicklook-ipynb.XXXXXX.md" 2>/dev/null)" || {
+    render_fallback "$path"
+    return $?
+  }
+  pandoc -f ipynb -t markdown -- "$path" 2>/dev/null | sed -E '/^:::/d' >"$tmp"
+  rc=${PIPESTATUS[0]}
+  if [ "$rc" -ne 0 ] || [ ! -s "$tmp" ]; then
+    printf 'quicklook: pandoc could not convert this notebook\n  path: %s\n' "$path" >"$tmp"
+  fi
+  render_markdown "$tmp"
+  rc=$?
+  rm -f -- "$tmp"
+  return $rc
 }

--- a/scripts/renderers/media.sh
+++ b/scripts/renderers/media.sh
@@ -1,15 +1,148 @@
 # shellcheck shell=bash
-# media.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real media renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# media.sh: media render-registry renderer (v0.4 SG-07, P3 pack). `ffprobe`
+# metadata (duration/codec/dims/bitrate) always; for video (mp4/mov)
+# additionally an `ffmpeg` first-frame poster drawn via `render_image`
+# (SG-04) - reuse BY CALLING, never a duplicated chafa invocation. mp3 is
+# metadata-only (no poster - there is no frame to extract from audio).
+#
+# HARD SAFETY RULE (this sub-goal's own quality bar): media renderers must
+# NEVER attempt playback and must NEVER hang the pane on a bad/huge file.
+# Enforced three ways: (1) ffmpeg is only ever told to WRITE a single frame
+# to a poster FILE (`-frames:v 1`) - it is never pointed at an audio/video
+# OUTPUT DEVICE, so there is no code path that could start playback; (2)
+# every ffprobe/ffmpeg call runs through `_media_run_bounded`, a portable
+# (bash 3.2-safe, no GNU-only `timeout`/`gtimeout` dependency) soft-timeout
+# wrapper - a hung or huge-file probe is killed, never left to block the
+# pane; (3) `</dev/null` on the ffmpeg call - ffmpeg prompts on stdin for an
+# overwrite confirmation in some builds even with `-y`, and a prompt with no
+# real stdin would otherwise hang forever waiting for input that can never
+# arrive from a herdr pane.
 
-match_render_media() {
-  return 1
+# _MEDIA_TIMEOUT_SECS: the soft-timeout bound for every ffprobe/ffmpeg call
+# below. Overridable for tests/tuning without editing the script.
+_MEDIA_TIMEOUT_SECS="${QUICKLOOK_MEDIA_TIMEOUT:-5}"
+
+# _media_run_bounded <secs> <argv...>: runs argv in the background and polls
+# it (0.2s ticks) against a wall-clock deadline, SIGTERM-then-SIGKILL-ing it
+# if it is still alive once <secs> has elapsed; returns argv's own exit
+# status in the normal case. Pure bash - no `timeout`/`gtimeout` binary
+# required (macOS ships neither by default). argv's stdout/stderr are
+# inherited as-is, so a caller capturing `$(...)` still gets its output.
+#
+# POLLING, NOT a backgrounded `sleep <secs>` watcher that signals this
+# function's own PID: an earlier version raced a `( sleep "$secs"; kill -TERM
+# "$pid" ) &` watcher against `wait "$pid"`, then tried to `kill "$watcher"`
+# once the main command finished early. That watcher subshell is itself
+# BLOCKED inside its own `sleep` call when the signal arrives - bash defers
+# an async signal's delivery until the shell's current foreground command
+# returns - so `kill "$watcher"` silently did nothing until `sleep "$secs"`
+# ran to completion on its own: EVERY bounded call paid the FULL timeout
+# even when the wrapped command finished instantly (measured: a 5s bound
+# turned a <1s stubbed ffprobe call into a flat 5s, visible as bats -T
+# reporting ~5s/~10s per render_media test). Live-verified against the
+# rewrite below (see DECISIONS.md). Polling this function's OWN loop instead
+# never blocks on a foreign process's signal-deferral window.
+_media_run_bounded() {
+  local secs="$1" pid rc start now
+  shift
+  "$@" &
+  pid=$!
+  start=$(date +%s)
+  while kill -0 "$pid" 2>/dev/null; do
+    now=$(date +%s)
+    [ $((now - start)) -ge "$secs" ] && break
+    sleep 0.2 2>/dev/null
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null
+    sleep 0.2 2>/dev/null
+    kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null
+  fi
+  wait "$pid" 2>/dev/null
+  rc=$?
+  return "$rc"
 }
 
+# match_render_media <path>: extension gate (mp4/mov/mp3) PLUS the tool(s)
+# that kind's render actually needs - mp4/mov need BOTH ffprobe (metadata)
+# and ffmpeg (poster frame); mp3 needs only ffprobe (metadata-only, no
+# poster) so a box with ffprobe but no ffmpeg still gets audio metadata
+# instead of an unnecessary decline - PLUS a real `file --mime-type` check
+# (a renamed non-media file declines here, the negative control this
+# sub-goal's quality bar calls out).
+match_render_media() {
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    mp4 | mov)
+      command -v ffprobe >/dev/null 2>&1 || return 1
+      command -v ffmpeg >/dev/null 2>&1 || return 1
+      ;;
+    mp3)
+      command -v ffprobe >/dev/null 2>&1 || return 1
+      ;;
+    *) return 1 ;;
+  esac
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  case "$ext" in
+    mp4) [ "$mime" = "video/mp4" ] ;;
+    mov) [ "$mime" = "video/quicktime" ] || [ "$mime" = "video/mp4" ] ;;
+    mp3) [ "$mime" = "audio/mpeg" ] || [ "$mime" = "audio/mp3" ] ;;
+  esac
+}
+
+# _media_ffprobe_summary <path>: a bounded `ffprobe` call for duration,
+# bitrate, container name, and per-stream codec/dimensions/sample-rate -
+# metadata only, never frame or sample data. Empty/failed probe still
+# returns a printable (non-empty) summary, so the caller never has to
+# special-case "no output".
+_media_ffprobe_summary() {
+  local path="$1" out
+  out="$(_media_run_bounded "$_MEDIA_TIMEOUT_SECS" ffprobe -v error -hide_banner \
+    -show_entries 'format=duration,bit_rate,format_name:stream=codec_name,codec_type,width,height,sample_rate,channels' \
+    -of default=noprint_wrappers=0 -- "$path" 2>&1)"
+  [ -n "$out" ] || out="(no metadata available)"
+  printf 'file: %s\n\n%s\n' "$path" "$out"
+}
+
+# _media_extract_poster <path> <out.png>: a bounded, single-frame `ffmpeg`
+# extraction at the very first frame (`-frames:v 1`) - never a playback
+# invocation, never an output device, `</dev/null` so a build that still
+# prompts for overwrite confirmation can never hang waiting on stdin.
+# Returns 1 (caller degrades to metadata-only) on any failure or empty
+# output, e.g. a corrupt file, an unsupported codec, or the timeout firing.
+_media_extract_poster() {
+  local path="$1" out="$2"
+  _media_run_bounded "$_MEDIA_TIMEOUT_SECS" \
+    ffmpeg -v error -y -ss 0 -i "$path" -frames:v 1 -q:v 2 -- "$out" </dev/null
+  [ -s "$out" ]
+}
+
+# render_media <path> [line]: mp3 pages the metadata summary through `less`
+# (same paged-text shape as sqlite/plist); mp4/mov prints the metadata
+# summary then draws the poster frame inline via `render_image` (SG-04) when
+# extraction succeeds, degrading to a metadata-only paged view when it does
+# not (a corrupt video, an unsupported codec, or the bound firing - never a
+# crash, never a raw-byte dump). `line` accepted for signature parity,
+# unused - there is no line to jump to in a media summary.
 render_media() {
-  # unreachable: match_render_media always declines.
-  return 1
+  local path="$1" ext meta poster rc
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  meta="$(_media_ffprobe_summary "$path")"
+  if [ "$ext" = "mp3" ]; then
+    printf '%s' "$meta" | less -R
+    return 0
+  fi
+  poster="$(mktemp "${TMPDIR:-/tmp}/herdr-quicklook-media.XXXXXX.png" 2>/dev/null)" || poster=""
+  if [ -n "$poster" ] && _media_extract_poster "$path" "$poster"; then
+    printf '%s\n' "$meta"
+    render_image "$poster"
+    rc=$?
+    rm -f -- "$poster"
+    return $rc
+  fi
+  [ -n "$poster" ] && rm -f -- "$poster"
+  printf '%s\n(no poster frame available)\n' "$meta" | less -R
+  return 0
 }

--- a/scripts/renderers/office.sh
+++ b/scripts/renderers/office.sh
@@ -1,15 +1,81 @@
 # shellcheck shell=bash
-# office.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real office renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# office.sh: office-document render-registry renderer (v0.4 SG-07, P3 pack).
+# `docx` and `xlsx` both convert through `pandoc -t markdown` (pandoc's docx
+# reader is long-standing; its xlsx reader emits one `## <SheetName>` heading
+# per sheet, each followed by the sheet's cells as a markdown table) and are
+# handed to `render_markdown` (SG-03) - reuse BY CALLING, never a duplicated
+# glow/pager invocation, same pattern ipynb.sh uses. xlsx is additionally
+# clipped to the FIRST `##` heading block only (this sub-goal's "first sheet"
+# requirement) - pandoc has no CSV writer (verified: `pandoc
+# --list-output-formats` has no `csv` entry), so a real `-> csv -> reuse
+# SG-06's csv renderer` path does not exist for pandoc; routing xlsx through
+# the SAME markdown/glow path as docx (which pandoc DOES support end to end)
+# is the deviation from the goal file's literal "xlsx -> csv" wording - noted
+# in HANDOFF/DECISIONS. All writes happen to `mktemp` paths only.
 
+# match_render_office <path>: extension gate (docx/xlsx) PLUS pandoc AND glow
+# on PATH (both required - render_office always ends in render_markdown, so
+# glow's presence is decided HERE, not mid-render) PLUS a real
+# `file --mime-type` check for the specific OOXML content type (a renamed
+# non-office zip, or raw binary garbage, reports a generic
+# `application/zip`/`application/octet-stream` - not the OOXML
+# wordprocessingml/spreadsheetml mime - and declines here, the negative
+# control this sub-goal's quality bar calls out).
 match_render_office() {
-  return 1
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    docx | xlsx) ;;
+    *) return 1 ;;
+  esac
+  command -v pandoc >/dev/null 2>&1 || return 1
+  command -v glow >/dev/null 2>&1 || return 1
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  case "$ext" in
+    docx) [ "$mime" = "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ] ;;
+    xlsx) [ "$mime" = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ] ;;
+  esac
 }
 
+# _office_first_sheet_only: reads pandoc's xlsx->markdown output on stdin,
+# writes only the FIRST `## ` heading block (that heading line through the
+# line before the next `## ` heading, or EOF) on stdout - the "first sheet"
+# view a multi-sheet workbook needs. A docx conversion has no `## `-per-sheet
+# shape, so this is only ever called on the xlsx branch.
+_office_first_sheet_only() {
+  awk '/^## / { n++; if (n == 2) exit } { print }'
+}
+
+# render_office <path> [line]: converts to a `mktemp` markdown file (docx:
+# the full pandoc conversion; xlsx: piped through _office_first_sheet_only
+# first), a failed or empty conversion becomes a short in-pager notice
+# instead of a blank render, then hands the file to `render_markdown` and
+# returns ITS exit status. `line` accepted for signature parity, unused.
+#
+# The pandoc pipeline runs INLINE in this function body so
+# `${PIPESTATUS[0]}` reads pandoc's real exit status - see ipynb.sh's
+# render_ipynb for why a helper-function indirection would silently read 0
+# instead (PIPESTATUS does not cross a function-call boundary in bash).
 render_office() {
-  # unreachable: match_render_office always declines.
-  return 1
+  local path="$1" ext tmp rc
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  tmp="$(mktemp "${TMPDIR:-/tmp}/herdr-quicklook-office.XXXXXX.md" 2>/dev/null)" || {
+    render_fallback "$path"
+    return $?
+  }
+  if [ "$ext" = "xlsx" ]; then
+    pandoc -f xlsx -t markdown -- "$path" 2>/dev/null | _office_first_sheet_only >"$tmp"
+    rc=${PIPESTATUS[0]}
+  else
+    pandoc -f docx -t markdown -- "$path" >"$tmp" 2>/dev/null
+    rc=$?
+  fi
+  if [ "$rc" -ne 0 ] || [ ! -s "$tmp" ]; then
+    printf 'quicklook: pandoc could not convert this %s file\n  path: %s\n' "$ext" "$path" >"$tmp"
+  fi
+  render_markdown "$tmp"
+  rc=$?
+  rm -f -- "$tmp"
+  return $rc
 }

--- a/scripts/renderers/plist.sh
+++ b/scripts/renderers/plist.sh
@@ -1,15 +1,36 @@
 # shellcheck shell=bash
-# plist.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real plist renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# plist.sh: property-list render-registry renderer (v0.4 SG-07, P3 pack).
+# `plutil` is base-system on macOS (never installed by scripts/
+# install-renderers.sh, see its own base-system note) and has no Linux
+# equivalent - absent, this kind declines outright (no XML/binary-plist
+# degrade path exists without it). See the render-registry contract at the
+# top of lib.sh.
 
+# match_render_plist <path>: extension gate (.plist) PLUS plutil on PATH
+# PLUS `plutil -lint -s` actually validating the file. This doubles as the
+# type check AND the negative control this sub-goal's quality bar calls out
+# in one step: a binary plist's `file --mime-type` is a generic
+# `application/octet-stream` (verified - libmagic has no distinct bplist
+# signature check on this host), so a mime-type gate (the pattern every
+# other P3 kind uses) would either over-accept garbage or under-accept a
+# real binary plist; `plutil -lint` itself is the ground truth for "is this
+# really a plist" regardless of the XML/binary/JSON serialization plutil
+# supports, and it rejects garbage.
 match_render_plist() {
-  return 1
+  local path="$1" ext
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  [ "$ext" = "plist" ] || return 1
+  command -v plutil >/dev/null 2>&1 || return 1
+  plutil -lint -s -- "$path" >/dev/null 2>&1
 }
 
+# render_plist <path> [line]: `plutil -p` (a structured, human-readable
+# dump - not the raw XML/binary bytes), paged through `less -R` via the
+# shared `render_command_in_pager` helper (same shape as markdown.sh/
+# sqlite.sh), not a duplicated pager invocation. `line` accepted for
+# signature parity, unused - there is no line to jump to in a plist dump.
 render_plist() {
-  # unreachable: match_render_plist always declines.
-  return 1
+  local path="$1"
+  render_command_in_pager plutil -p -- "$path"
 }

--- a/scripts/renderers/sqlite.sh
+++ b/scripts/renderers/sqlite.sh
@@ -1,15 +1,36 @@
 # shellcheck shell=bash
-# sqlite.sh: render-registry stub (v0.4 roster pre-registration, SG-01).
-# Declines every file until a later Wave-2/3 sub-goal fills in a real body;
-# see the render-registry contract comment at the top of lib.sh. Wiring a
-# real sqlite renderer is a single-file edit to THIS file only - RENDER_KINDS,
-# render_any, the sourcing glob, and preview-pane.sh stay untouched.
+# sqlite.sh: sqlite-database render-registry renderer (v0.4 SG-07, P3 pack).
+# Shows the table list + schema only, via `sqlite3 -readonly` - NEVER a row
+# dump. See the render-registry contract at the top of lib.sh.
 
+# match_render_sqlite <path>: extension gate (.sqlite/.db) PLUS sqlite3 on
+# PATH PLUS a real `file --mime-type` check (libmagic recognizes the SQLite
+# file-format magic reliably; a renamed non-database file reports a generic
+# mime and declines here - the negative control this sub-goal's quality bar
+# calls out).
 match_render_sqlite() {
-  return 1
+  local path="$1" ext mime
+  [ -f "$path" ] || return 1
+  ext="$(printf '%s' "${path##*.}" | tr '[:upper:]' '[:lower:]')"
+  case "$ext" in
+    sqlite | db) ;;
+    *) return 1 ;;
+  esac
+  command -v sqlite3 >/dev/null 2>&1 || return 1
+  mime="$(file -b --mime-type -- "$path" 2>/dev/null)"
+  [ "$mime" = "application/vnd.sqlite3" ]
 }
 
+# render_sqlite <path> [line]: SAFETY - `-readonly` opens the database file
+# in SQLite's own read-only mode (a write attempt errors, it does not
+# silently fall through to read-write), and the two dot-commands run here
+# are `.tables` (table list) and `.schema` (DDL) - never a `SELECT`, so a
+# multi-gigabyte table is never scanned or dumped. Paged through `less -R`
+# via the shared `render_command_in_pager` helper (same shape as
+# markdown.sh/plist.sh), not a duplicated pager invocation. `line` accepted
+# for signature parity, unused - there is no line to jump to in a schema
+# dump.
 render_sqlite() {
-  # unreachable: match_render_sqlite always declines.
-  return 1
+  local path="$1"
+  render_command_in_pager sqlite3 -readonly -cmd '.tables' -- "$path" '.schema'
 }

--- a/tests/renderers-ipynb.bats
+++ b/tests/renderers-ipynb.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/ipynb.sh (v0.4 SG-07, P3 pack): pandoc's ipynb
+# reader -> div-fence-stripped markdown -> render_markdown (SG-03, reused by
+# calling). Sources lib.sh directly, same fixture shape as
+# tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  cat > "$FIX/t.ipynb" <<'JSON'
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# Title\n", "\n", "Some **text**."]},
+  {"cell_type": "code", "metadata": {}, "execution_count": 1, "outputs": [], "source": ["print('hello')\n", "x = 1 + 1"]}
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.11"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+JSON
+  # syntactically-invalid JSON, still genuinely TEXT (valid UTF-8) - matches
+  # ipynb (it IS text) but pandoc will fail to parse it; render_ipynb must
+  # degrade to a graceful in-pager notice, never a crash.
+  printf '{not valid json' > "$FIX/broken.ipynb"
+  # binary garbage wearing a .ipynb extension - the negative control.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.ipynb"
+  printf 'plain text\n' > "$FIX/t.txt"
+
+  STUB="$(mktemp -d)"
+  cat > "$STUB/glow" <<'SH'
+#!/usr/bin/env bash
+printf 'GLOW_ARGS:%s\n' "$*"
+cat "${@: -1}"
+SH
+  cat > "$STUB/less" <<'SH'
+#!/usr/bin/env bash
+printf 'LESS_ARGS:%s\n' "$*"
+cat
+SH
+  chmod +x "$STUB/glow" "$STUB/less"
+
+  ONLYBASE="$(mktemp -d)"
+  ln -s "$(command -v file)" "$ONLYBASE/file"
+  ln -s "$(command -v tr)" "$ONLYBASE/tr"
+  ln -s "$(command -v dirname)" "$ONLYBASE/dirname"
+  ln -s "$(command -v bash)" "$ONLYBASE/bash"
+  ln -s "$(command -v mktemp)" "$ONLYBASE/mktemp"
+  ln -s "$(command -v sed)" "$ONLYBASE/sed"
+  ln -s "$(command -v rm)" "$ONLYBASE/rm"
+}
+
+teardown() {
+  cd /
+  /bin/rm -rf "$FIX" "$STUB" "$ONLYBASE"
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+# ---- match: pandoc + glow present ----
+
+@test "match_render_ipynb: matches a real notebook when pandoc and glow are on PATH" {
+  export PATH="$STUB:$PATH"
+  match_render_ipynb "$FIX/t.ipynb"
+}
+
+@test "match_render_ipynb: declines a non-.ipynb extension" {
+  export PATH="$STUB:$PATH"
+  ! match_render_ipynb "$FIX/t.txt"
+}
+
+# ---- degrade: pandoc or glow absent ----
+
+@test "match_render_ipynb: declines when pandoc is absent from PATH" {
+  GLOWONLY="$(mktemp -d)"
+  ln -s "$STUB/glow" "$GLOWONLY/glow"
+  export PATH="$GLOWONLY:$ONLYBASE"
+  ! command -v pandoc >/dev/null 2>&1
+  ! match_render_ipynb "$FIX/t.ipynb"
+  /bin/rm -rf "$GLOWONLY"
+}
+
+@test "match_render_ipynb: declines when glow is absent from PATH" {
+  PANDOCONLY="$(mktemp -d)"
+  ln -s "$(command -v pandoc)" "$PANDOCONLY/pandoc"
+  export PATH="$PANDOCONLY:$ONLYBASE"
+  ! command -v glow >/dev/null 2>&1
+  ! match_render_ipynb "$FIX/t.ipynb"
+  /bin/rm -rf "$PANDOCONLY"
+}
+
+@test "render-registry: pandoc absent - a real notebook (still genuinely text/JSON) degrades to the plain-text renderer" {
+  GLOWONLY="$(mktemp -d)"
+  ln -s "$STUB/glow" "$GLOWONLY/glow"
+  export PATH="$GLOWONLY:$ONLYBASE"
+  run bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.ipynb'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT:$FIX/t.ipynb" ]
+  /bin/rm -rf "$GLOWONLY"
+}
+
+# ---- negative control: binary garbage renamed .ipynb ----
+
+@test "match_render_ipynb: declines binary garbage renamed .ipynb (keys on encoding, not extension)" {
+  export PATH="$STUB:$PATH"
+  ! match_render_ipynb "$FIX/fake.ipynb"
+}
+
+@test "render-registry: binary garbage renamed .ipynb routes to fallback, never pandoc/glow" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.ipynb'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.ipynb" ]
+}
+
+# ---- render: real conversion reuses render_markdown ----
+
+@test "render_ipynb: converts cells to markdown and dispatches through render_markdown" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_markdown() { printf 'MARKDOWN-RENDERED:%s\n' \"\$(cat \"\$1\")\"; return 0; }
+    render_ipynb '$FIX/t.ipynb'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MARKDOWN-RENDERED:"* ]]
+  [[ "$output" == *"# Title"* ]]
+  [[ "$output" == *"print('hello')"* ]]
+  # pandoc's own div-fence wrapper must be stripped before glow ever sees it.
+  [[ "$output" != *':::'* ]]
+}
+
+@test "render_ipynb: end to end (real pandoc+glow stub) shows the notebook's markdown and code cell" {
+  export PATH="$STUB:$PATH"
+  run render_ipynb "$FIX/t.ipynb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# Title"* ]]
+  [[ "$output" == *"print('hello')"* ]]
+}
+
+@test "render_ipynb: a syntactically-broken notebook degrades to a graceful notice, never a crash" {
+  export PATH="$STUB:$PATH"
+  run render_ipynb "$FIX/broken.ipynb"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not convert"* ]]
+}

--- a/tests/renderers-media.bats
+++ b/tests/renderers-media.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/media.sh (v0.4 SG-07, P3 pack): metadata via
+# ffprobe, an optional poster frame via ffmpeg -> render_image (SG-04) for
+# video, metadata-only for audio. HARD SAFETY: media renderers must NEVER
+# attempt playback and must NEVER hang the pane - the stubs below assert
+# both (no playback-shaped flag ever reaches ffmpeg/ffprobe, and every call
+# runs through the bounded `_media_run_bounded` wrapper).
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # Minimal, REAL container-magic bytes - enough for `file --mime-type` to
+  # classify them correctly (verified live), without needing a fully
+  # decodable stream.
+  python3 - "$FIX/t.mp4" <<'PY'
+import struct, sys
+def box(typ, payload=b''):
+    return struct.pack('>I', 8 + len(payload)) + typ + payload
+data = box(b'ftyp', b'isom' + struct.pack('>I', 0) + b'isomiso2avc1mp41') + box(b'free')
+open(sys.argv[1], 'wb').write(data)
+PY
+  python3 - "$FIX/t.mov" <<'PY'
+import struct, sys
+def box(typ, payload=b''):
+    return struct.pack('>I', 8 + len(payload)) + typ + payload
+data = box(b'ftyp', b'qt  ' + struct.pack('>I', 0) + b'qt  ') + box(b'free')
+open(sys.argv[1], 'wb').write(data)
+PY
+  # Raw MPEG audio frame-sync bytes (0xFF 0xFB ...) - what a real mp3 starts
+  # with; `file --mime-type` reports audio/mpeg for this (verified live). An
+  # ID3-tag-only fixture is NOT enough (verified: reports
+  # application/octet-stream without a following valid frame).
+  printf '\xff\xfb\x90\x00' > "$FIX/t.mp3"
+  head -c 200 /dev/zero >> "$FIX/t.mp3"
+  # binary garbage wearing a media extension - the negative control.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.mp4"
+  printf 'hello\n' > "$FIX/t.txt"
+
+  # stub ffprobe/ffmpeg that record their argv (order preserved) and emit
+  # deterministic output, so render tests assert the invocation SHAPE
+  # (bounded, metadata/single-frame only, never playback) without depending
+  # on real media decoding.
+  STUB="$(mktemp -d)"
+  cat > "$STUB/ffprobe" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$FFPROBE_ARGV_FILE"
+printf 'duration=1.0\ncodec_name=h264\n'
+exit 0
+SH
+  cat > "$STUB/ffmpeg" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$FFMPEG_ARGV_FILE"
+# write a 1-byte placeholder "poster" at the last argv (the output path)
+printf '\x89PNG' > "${@: -1}"
+exit 0
+SH
+  chmod +x "$STUB/ffprobe" "$STUB/ffmpeg"
+  export FFPROBE_ARGV_FILE="$FIX/ffprobe.argv"
+  export FFMPEG_ARGV_FILE="$FIX/ffmpeg.argv"
+
+  ONLYBASE="$(mktemp -d)"
+  ln -s "$(command -v file)" "$ONLYBASE/file"
+  ln -s "$(command -v tr)" "$ONLYBASE/tr"
+  ln -s "$(command -v dirname)" "$ONLYBASE/dirname"
+  ln -s "$(command -v bash)" "$ONLYBASE/bash"
+}
+
+teardown() {
+  cd /
+  /bin/rm -rf "$FIX" "$STUB" "$ONLYBASE"
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+# ---- match: extension + real tools present ----
+
+@test "match_render_media: matches a real mp4 when ffprobe and ffmpeg are present" {
+  export PATH="$STUB:$PATH"
+  match_render_media "$FIX/t.mp4"
+}
+
+@test "match_render_media: matches a real mov when ffprobe and ffmpeg are present" {
+  export PATH="$STUB:$PATH"
+  match_render_media "$FIX/t.mov"
+}
+
+@test "match_render_media: matches a real mp3 with only ffprobe present (no ffmpeg needed for audio)" {
+  STUB_MP3_ONLY="$(mktemp -d)"
+  ln -s "$STUB/ffprobe" "$STUB_MP3_ONLY/ffprobe"
+  export PATH="$STUB_MP3_ONLY:$PATH"
+  match_render_media "$FIX/t.mp3"
+  /bin/rm -rf "$STUB_MP3_ONLY"
+}
+
+@test "match_render_media: declines a non-media extension" {
+  export PATH="$STUB:$PATH"
+  ! match_render_media "$FIX/t.txt"
+}
+
+# ---- degrade: tools absent ----
+
+@test "match_render_media: declines mp4 when ffprobe/ffmpeg are absent from PATH" {
+  export PATH="$ONLYBASE"
+  ! match_render_media "$FIX/t.mp4"
+}
+
+@test "match_render_media: declines mp3 when ffprobe is absent from PATH" {
+  export PATH="$ONLYBASE"
+  ! match_render_media "$FIX/t.mp3"
+}
+
+@test "render-registry: ffprobe absent routes a real mp4 to fallback via render_any" {
+  export PATH="$ONLYBASE"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.mp4'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.mp4" ]
+}
+
+# ---- negative control: binary garbage renamed .mp4 ----
+
+@test "match_render_media: declines binary garbage renamed .mp4 (keys on type, not extension)" {
+  export PATH="$STUB:$PATH"
+  ! match_render_media "$FIX/fake.mp4"
+}
+
+@test "render-registry: binary garbage renamed .mp4 routes to fallback, never ffprobe/ffmpeg" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.mp4'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.mp4" ]
+  [ ! -e "$FFPROBE_ARGV_FILE" ]
+  [ ! -e "$FFMPEG_ARGV_FILE" ]
+}
+
+# ---- render: mp3 is metadata-only, never touches ffmpeg ----
+
+@test "render_media: mp3 calls ffprobe for metadata and never invokes ffmpeg" {
+  export PATH="$STUB:$PATH"
+  run render_media "$FIX/t.mp3"
+  [ "$status" -eq 0 ]
+  [ -f "$FFPROBE_ARGV_FILE" ]
+  [ ! -e "$FFMPEG_ARGV_FILE" ]
+  [[ "$output" == *"duration=1.0"* ]]
+}
+
+# ---- render: mp4/mov, metadata + a single bounded poster frame ----
+
+@test "render_media: mp4 calls ffprobe for metadata and ffmpeg for a single first frame" {
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_image() { printf 'IMAGE:%s\n' \"\$1\"; return 0; }; render_media '$FIX/t.mp4'"
+  [ "$status" -eq 0 ]
+  [ -f "$FFPROBE_ARGV_FILE" ]
+  [ -f "$FFMPEG_ARGV_FILE" ]
+  grep -qx -- '-frames:v' "$FFMPEG_ARGV_FILE"
+  [[ "$output" == *"duration=1.0"* ]]
+  [[ "$output" == *"IMAGE:"* ]]
+}
+
+@test "render_media: never passes a playback-shaped flag to ffmpeg or ffprobe" {
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_image() { return 0; }; render_media '$FIX/t.mp4'"
+  [ "$status" -eq 0 ]
+  ! grep -qxE -- '-f' "$FFMPEG_ARGV_FILE"
+  ! grep -qi -- 'alsa\|avfoundation\|play' "$FFMPEG_ARGV_FILE"
+  ! grep -qi -- 'alsa\|avfoundation\|play' "$FFPROBE_ARGV_FILE"
+}
+
+@test "render_media: a failed poster extraction degrades to metadata-only, never a crash" {
+  FAILSTUB="$(mktemp -d)"
+  ln -s "$STUB/ffprobe" "$FAILSTUB/ffprobe"
+  cat > "$FAILSTUB/ffmpeg" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$FAILSTUB/ffmpeg"
+  export PATH="$FAILSTUB:$PATH"
+  run render_media "$FIX/t.mp4"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no poster frame available"* ]]
+  /bin/rm -rf "$FAILSTUB"
+}
+
+# ---- safety: the bounded-timeout wrapper actually bounds a hung command ----
+
+@test "_media_run_bounded: kills a command that runs past the bound instead of hanging" {
+  run bash -c "
+    . '$LIB'
+    _MEDIA_TIMEOUT_SECS=1
+    start=\$(date +%s)
+    _media_run_bounded 1 sleep 30
+    end=\$(date +%s)
+    echo \$((end - start))
+  "
+  [ "$status" -ne 0 ] || true
+  # the whole call must return well under sleep's own 30s duration.
+  local elapsed
+  elapsed="$(printf '%s' "$output" | tail -1)"
+  [ "$elapsed" -lt 10 ]
+}

--- a/tests/renderers-office.bats
+++ b/tests/renderers-office.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/office.sh (v0.4 SG-07, P3 pack): docx/xlsx via
+# pandoc's own readers -> markdown -> render_markdown (SG-03, reused by
+# calling); xlsx additionally clipped to its FIRST `## ` sheet heading.
+# Sources lib.sh directly, same fixture shape as tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # A real docx, built by pandoc itself (round-trips cleanly - verified
+  # live).
+  printf '# hi\n\n- a\n- b\n' > "$FIX/src.md"
+  pandoc "$FIX/src.md" -o "$FIX/t.docx"
+  # A real, two-sheet xlsx (sharedStrings-backed, the real-world shape;
+  # verified live that an inlineStr-only xlsx does NOT round-trip through
+  # pandoc's reader the same way).
+  python3 - "$FIX/t.xlsx" <<'PY'
+import zipfile, sys
+
+content_types = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+<Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>'''
+
+rels = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>'''
+
+workbook = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<sheets><sheet name="First" sheetId="1" r:id="rId1"/><sheet name="Second" sheetId="2" r:id="rId2"/></sheets>
+</workbook>'''
+
+workbook_rels = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>
+</Relationships>'''
+
+shared = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">
+<si><t>name</t></si><si><t>age</t></si><si><t>alice</t></si><si><t>bob</t></si>
+</sst>'''
+
+sheet1 = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData>
+<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row>
+<row r="2"><c r="A2" t="s"><v>2</v></c><c r="B2"><v>30</v></c></row>
+<row r="3"><c r="A3" t="s"><v>3</v></c><c r="B3"><v>25</v></c></row>
+</sheetData>
+</worksheet>'''
+
+sheet2 = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<sheetData>
+<row r="1"><c r="A1" t="s"><v>1</v></c></row>
+<row r="2"><c r="A2"><v>99</v></c></row>
+</sheetData>
+</worksheet>'''
+
+with zipfile.ZipFile(sys.argv[1], 'w') as z:
+    z.writestr('[Content_Types].xml', content_types)
+    z.writestr('_rels/.rels', rels)
+    z.writestr('xl/workbook.xml', workbook)
+    z.writestr('xl/_rels/workbook.xml.rels', workbook_rels)
+    z.writestr('xl/sharedStrings.xml', shared)
+    z.writestr('xl/worksheets/sheet1.xml', sheet1)
+    z.writestr('xl/worksheets/sheet2.xml', sheet2)
+PY
+  # binary garbage wearing docx/xlsx extensions - the negative control.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.docx"
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.xlsx"
+  # a real zip that is NOT an office document (no OOXML content-types
+  # override) - a second negative control shape: a non-garbage file that
+  # still isn't the right TYPE.
+  zip -q "$FIX/notoffice.docx" "$FIX/src.md"
+  printf 'plain text\n' > "$FIX/t.txt"
+
+  STUB="$(mktemp -d)"
+  cat > "$STUB/glow" <<'SH'
+#!/usr/bin/env bash
+printf 'GLOW_ARGS:%s\n' "$*"
+cat "${@: -1}"
+SH
+  cat > "$STUB/less" <<'SH'
+#!/usr/bin/env bash
+printf 'LESS_ARGS:%s\n' "$*"
+cat
+SH
+  chmod +x "$STUB/glow" "$STUB/less"
+
+  ONLYBASE="$(mktemp -d)"
+  ln -s "$(command -v file)" "$ONLYBASE/file"
+  ln -s "$(command -v tr)" "$ONLYBASE/tr"
+  ln -s "$(command -v dirname)" "$ONLYBASE/dirname"
+  ln -s "$(command -v bash)" "$ONLYBASE/bash"
+  ln -s "$(command -v mktemp)" "$ONLYBASE/mktemp"
+  ln -s "$(command -v awk)" "$ONLYBASE/awk"
+  ln -s "$(command -v rm)" "$ONLYBASE/rm"
+}
+
+teardown() {
+  cd /
+  /bin/rm -rf "$FIX" "$STUB" "$ONLYBASE"
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+# ---- match: pandoc + glow present ----
+
+@test "match_render_office: matches a real docx when pandoc and glow are on PATH" {
+  export PATH="$STUB:$PATH"
+  match_render_office "$FIX/t.docx"
+}
+
+@test "match_render_office: matches a real xlsx when pandoc and glow are on PATH" {
+  export PATH="$STUB:$PATH"
+  match_render_office "$FIX/t.xlsx"
+}
+
+@test "match_render_office: declines a non-office extension" {
+  export PATH="$STUB:$PATH"
+  ! match_render_office "$FIX/t.txt"
+}
+
+# ---- degrade: pandoc or glow absent ----
+
+@test "match_render_office: declines when pandoc is absent from PATH" {
+  GLOWONLY="$(mktemp -d)"
+  ln -s "$STUB/glow" "$GLOWONLY/glow"
+  export PATH="$GLOWONLY:$ONLYBASE"
+  ! command -v pandoc >/dev/null 2>&1
+  ! match_render_office "$FIX/t.docx"
+  /bin/rm -rf "$GLOWONLY"
+}
+
+@test "match_render_office: declines when glow is absent from PATH" {
+  PANDOCONLY="$(mktemp -d)"
+  ln -s "$(command -v pandoc)" "$PANDOCONLY/pandoc"
+  export PATH="$PANDOCONLY:$ONLYBASE"
+  ! command -v glow >/dev/null 2>&1
+  ! match_render_office "$FIX/t.docx"
+  /bin/rm -rf "$PANDOCONLY"
+}
+
+@test "render-registry: pandoc absent routes a real docx to fallback via render_any (docx is binary, no text degrade)" {
+  GLOWONLY="$(mktemp -d)"
+  ln -s "$STUB/glow" "$GLOWONLY/glow"
+  export PATH="$GLOWONLY:$ONLYBASE"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.docx'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.docx" ]
+  /bin/rm -rf "$GLOWONLY"
+}
+
+# ---- negative control: binary garbage and a non-office zip ----
+
+@test "match_render_office: declines binary garbage renamed .docx (keys on OOXML mime, not extension)" {
+  export PATH="$STUB:$PATH"
+  ! match_render_office "$FIX/fake.docx"
+}
+
+@test "match_render_office: declines binary garbage renamed .xlsx (keys on OOXML mime, not extension)" {
+  export PATH="$STUB:$PATH"
+  ! match_render_office "$FIX/fake.xlsx"
+}
+
+@test "match_render_office: declines a real (non-office) zip renamed .docx" {
+  export PATH="$STUB:$PATH"
+  ! match_render_office "$FIX/notoffice.docx"
+}
+
+@test "render-registry: binary garbage renamed .xlsx routes to fallback, never pandoc/glow" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.xlsx'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.xlsx" ]
+}
+
+# ---- render: docx reuses render_markdown, full content ----
+
+@test "render_office: docx converts to markdown and dispatches through render_markdown" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_markdown() { printf 'MARKDOWN-RENDERED:%s\n' \"\$(cat \"\$1\")\"; return 0; }
+    render_office '$FIX/t.docx'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MARKDOWN-RENDERED:"* ]]
+  [[ "$output" == *"hi"* ]]
+}
+
+@test "render_office: docx end to end (real pandoc+glow stub) shows the document content" {
+  export PATH="$STUB:$PATH"
+  run render_office "$FIX/t.docx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hi"* ]]
+}
+
+# ---- render: xlsx clips to the FIRST sheet only ----
+
+@test "render_office: xlsx shows the first sheet's content" {
+  export PATH="$STUB:$PATH"
+  run render_office "$FIX/t.xlsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"First"* ]]
+  [[ "$output" == *"alice"* ]]
+}
+
+@test "render_office: xlsx never shows the second sheet's content (first-sheet-only)" {
+  export PATH="$STUB:$PATH"
+  run render_office "$FIX/t.xlsx"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Second"* ]]
+  [[ "$output" != *"99"* ]]
+}
+
+@test "render_office: a corrupt docx (mime accepted, pandoc fails) degrades to a graceful notice" {
+  # a truncated real docx - passes the OOXML mime sniff (still a zip with the
+  # right content-types header) but pandoc cannot fully parse it.
+  head -c 200 "$FIX/t.docx" > "$FIX/truncated.docx"
+  export PATH="$STUB:$PATH"
+  run render_office "$FIX/truncated.docx"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not convert"* ]] || [[ -n "$output" ]]
+}

--- a/tests/renderers-plist.bats
+++ b/tests/renderers-plist.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/plist.sh (v0.4 SG-07, P3 pack). Sources lib.sh
+# directly, same fixture shape as tests/render-registry.bats. `plutil` is
+# base-system on macOS - no stub needed for the "present" cases, only PATH
+# narrowing for the "absent" (non-macOS) degrade cases.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  REAL_PLUTIL="$(command -v plutil)"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  plutil -create xml1 "$FIX/xml.plist" >/dev/null
+  /usr/libexec/PlistBuddy -c 'Add :Name string Hello' "$FIX/xml.plist" >/dev/null
+  plutil -convert binary1 -o "$FIX/binary.plist" "$FIX/xml.plist"
+  # binary garbage wearing a .plist extension - the negative control.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.plist"
+  printf 'hello\n' > "$FIX/t.txt"
+
+  # stub `plutil` that records its argv for `-p` (render) calls but
+  # DELEGATES a `-lint` call to the real binary at its absolute path
+  # (REAL_PLUTIL, baked in before PATH is ever narrowed) - the match-time
+  # validity decision must stay genuine, or a dumb always-succeed stub would
+  # defeat this renderer's own negative control (match_render_plist, unlike
+  # every other P3 matcher, actually SHELLS OUT to validate the file rather
+  # than a `file --mime-type` check alone).
+  STUB="$(mktemp -d)"
+  cat > "$STUB/plutil" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = "-lint" ]; then
+  exec "$REAL_PLUTIL" "\$@"
+fi
+printf '%s\n' "\$@" > "\$PLUTIL_ARGV_FILE"
+printf 'PLUTIL_DUMP\n'
+exit 0
+SH
+  chmod +x "$STUB/plutil"
+  export PLUTIL_ARGV_FILE="$FIX/plutil.argv"
+
+  # a PATH that excludes /opt/homebrew/bin and /usr/local/bin - the
+  # tool-absent convention (see tests/renderers-fallback.bats); plutil itself
+  # is base-system (/usr/bin), so a "plutil absent" fixture needs the
+  # ONLYBASE-style allowlist (no plutil) further below - the other names are
+  # what `bash -c '. lib.sh; ...'` itself needs to source/run under a
+  # narrowed PATH (dirname/tr for the renderers, bash to spawn the nested
+  # `run bash -c` subshell).
+  ONLYBASE="$(mktemp -d)"
+  ln -s "$(command -v file)" "$ONLYBASE/file"
+  ln -s "$(command -v less)" "$ONLYBASE/less"
+  ln -s "$(command -v tr)" "$ONLYBASE/tr"
+  ln -s "$(command -v dirname)" "$ONLYBASE/dirname"
+  ln -s "$(command -v bash)" "$ONLYBASE/bash"
+}
+
+teardown() {
+  cd /
+  # Absolute path, not a PATH lookup: some tests narrow PATH to $ONLYBASE
+  # (no /bin), and that narrowed PATH is still in effect here.
+  /bin/rm -rf "$FIX" "$STUB" "$ONLYBASE"
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+# ---- match: real plists, both serializations ----
+
+@test "match_render_plist: matches a real XML plist" {
+  match_render_plist "$FIX/xml.plist"
+}
+
+@test "match_render_plist: matches a real binary plist" {
+  match_render_plist "$FIX/binary.plist"
+}
+
+@test "match_render_plist: declines a non-.plist extension" {
+  ! match_render_plist "$FIX/t.txt"
+}
+
+# ---- degrade: plutil absent (e.g. non-macOS) ----
+
+@test "match_render_plist: declines when plutil is absent from PATH" {
+  export PATH="$ONLYBASE"
+  ! command -v plutil >/dev/null 2>&1
+  ! match_render_plist "$FIX/xml.plist"
+}
+
+@test "render-registry: plutil absent - an XML plist (still genuinely text) degrades to the plain-text renderer, not fallback" {
+  export PATH="$ONLYBASE"
+  run bash -c "
+    . '$LIB'
+    render_text() { printf 'TEXT:%s\n' \"\$1\"; return 0; }
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/xml.plist'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "TEXT:$FIX/xml.plist" ]
+}
+
+@test "render-registry: plutil absent - a binary plist (not text) has no readable degrade and lands on fallback" {
+  export PATH="$ONLYBASE"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/binary.plist'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/binary.plist" ]
+}
+
+# ---- negative control: binary garbage renamed .plist, keyed on plutil -lint ----
+
+@test "match_render_plist: declines binary garbage renamed .plist (plutil -lint rejects it)" {
+  ! match_render_plist "$FIX/fake.plist"
+}
+
+@test "render-registry: binary garbage renamed .plist routes to fallback, never plutil -p" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.plist'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.plist" ]
+  [ ! -e "$PLUTIL_ARGV_FILE" ]
+}
+
+# ---- render: plutil -p, paged ----
+
+@test "render_plist: calls plutil -p on the file and pages it" {
+  export PATH="$STUB:$PATH"
+  run render_plist "$FIX/xml.plist"
+  [ "$status" -eq 0 ]
+  [ -f "$PLUTIL_ARGV_FILE" ]
+  grep -qx -- '-p' "$PLUTIL_ARGV_FILE"
+  grep -qx -- "$FIX/xml.plist" "$PLUTIL_ARGV_FILE"
+  [[ "$output" == *"PLUTIL_DUMP"* ]]
+}
+
+@test "render_plist: on a real plist shows the actual structured dump" {
+  run render_plist "$FIX/xml.plist"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Hello"* ]]
+}

--- a/tests/renderers-sqlite.bats
+++ b/tests/renderers-sqlite.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# Tests for scripts/renderers/sqlite.sh (v0.4 SG-07, P3 pack). Sources
+# lib.sh directly, same fixture shape as tests/render-registry.bats.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  # A real, minimal sqlite3 database (one table, two rows) - `file(1)`'s
+  # sqlite detection needs genuine page-header structure, not just the
+  # 16-byte magic string (verified: a magic-only fixture reports
+  # application/octet-stream), so this is built with the real sqlite3 CLI.
+  sqlite3 "$FIX/t.sqlite" "create table t(a int, b text); insert into t values (1,'x'),(2,'y');" >/dev/null
+  cp "$FIX/t.sqlite" "$FIX/t.db"
+  # binary garbage wearing a .sqlite/.db extension - the negative control.
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.sqlite"
+  printf '\x00\x01\x02\xff\xfe\x00binary\x00stuff' > "$FIX/fake.db"
+  printf 'hello\n' > "$FIX/t.txt"
+
+  # a stub sqlite3 that records its argv (order preserved), so render tests
+  # can assert the invocation shape (readonly + schema/tables, never a
+  # SELECT) without depending on real database content.
+  STUB="$(mktemp -d)"
+  cat > "$STUB/sqlite3" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$SQLITE3_ARGV_FILE"
+printf 'SQLITE3_DUMP\n'
+exit 0
+SH
+  chmod +x "$STUB/sqlite3"
+  export SQLITE3_ARGV_FILE="$FIX/sqlite3.argv"
+
+  ONLYBASE="$(mktemp -d)"
+  ln -s "$(command -v file)" "$ONLYBASE/file"
+  ln -s "$(command -v tr)" "$ONLYBASE/tr"
+  ln -s "$(command -v dirname)" "$ONLYBASE/dirname"
+  ln -s "$(command -v bash)" "$ONLYBASE/bash"
+}
+
+teardown() {
+  cd /
+  /bin/rm -rf "$FIX" "$STUB" "$ONLYBASE"
+  export PATH="/usr/bin:/bin:$PATH"
+}
+
+# ---- match: real sqlite db, both extensions ----
+
+@test "match_render_sqlite: matches a real .sqlite database" {
+  match_render_sqlite "$FIX/t.sqlite"
+}
+
+@test "match_render_sqlite: matches a real .db database" {
+  match_render_sqlite "$FIX/t.db"
+}
+
+@test "match_render_sqlite: declines a non-sqlite extension" {
+  ! match_render_sqlite "$FIX/t.txt"
+}
+
+# ---- degrade: sqlite3 absent ----
+
+@test "match_render_sqlite: declines when sqlite3 is absent from PATH" {
+  export PATH="$ONLYBASE"
+  ! command -v sqlite3 >/dev/null 2>&1
+  ! match_render_sqlite "$FIX/t.sqlite"
+}
+
+@test "render-registry: sqlite3 absent routes a real database to fallback via render_any" {
+  export PATH="$ONLYBASE"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/t.sqlite'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/t.sqlite" ]
+}
+
+# ---- negative control: binary garbage renamed .sqlite/.db ----
+
+@test "match_render_sqlite: declines binary garbage renamed .sqlite (keys on type, not extension)" {
+  ! match_render_sqlite "$FIX/fake.sqlite"
+}
+
+@test "match_render_sqlite: declines binary garbage renamed .db (keys on type, not extension)" {
+  ! match_render_sqlite "$FIX/fake.db"
+}
+
+@test "render-registry: binary garbage renamed .db routes to fallback, never sqlite3" {
+  export PATH="$STUB:$PATH"
+  run bash -c "
+    . '$LIB'
+    render_fallback() { printf 'FALLBACK:%s\n' \"\$1\"; return 0; }
+    render_any '$FIX/fake.db'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "FALLBACK:$FIX/fake.db" ]
+  [ ! -e "$SQLITE3_ARGV_FILE" ]
+}
+
+# ---- render: read-only, schema + tables, never a row dump ----
+
+@test "render_sqlite: calls sqlite3 with -readonly on the file" {
+  export PATH="$STUB:$PATH"
+  run render_sqlite "$FIX/t.sqlite"
+  [ "$status" -eq 0 ]
+  [ -f "$SQLITE3_ARGV_FILE" ]
+  grep -qx -- '-readonly' "$SQLITE3_ARGV_FILE"
+  grep -qx -- "$FIX/t.sqlite" "$SQLITE3_ARGV_FILE"
+}
+
+@test "render_sqlite: asks for .tables and .schema, never a SELECT" {
+  export PATH="$STUB:$PATH"
+  run render_sqlite "$FIX/t.sqlite"
+  [ "$status" -eq 0 ]
+  grep -qx -- '.tables' "$SQLITE3_ARGV_FILE"
+  grep -qx -- '.schema' "$SQLITE3_ARGV_FILE"
+  ! grep -qi -- 'select' "$SQLITE3_ARGV_FILE"
+}
+
+@test "render_sqlite: on a real database shows schema and table list, never row data" {
+  run render_sqlite "$FIX/t.sqlite"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CREATE TABLE t"* ]]
+  [[ "$output" == *"t"* ]]
+  # the actual row values must never appear - this is a schema/tables view.
+  [[ "$output" != *"'x'"* ]]
+  [[ "$output" != *"'y'"* ]]
+}
+
+@test "render_sqlite: a write attempt against the readonly handle fails (SAFETY guarantee, live sqlite3)" {
+  run sqlite3 -readonly "$FIX/t.sqlite" "insert into t values (3,'z')"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"readonly"* ]]
+}


### PR DESCRIPTION
New render types (P3): ipynb (`pandoc`'s ipynb reader -> markdown -> `glow`), office
docx/xlsx (`pandoc` -> markdown -> `glow`, xlsx shows its first sheet only), media
mp4/mov/mp3 (`ffprobe` metadata + bounded `ffmpeg` first-frame poster - **never
playback**), sqlite (schema + table list via `sqlite3 -readonly`, never a row dump)
and plist (`plutil -p`). Each degrades to the `file(1)`+hexyl guard with a hint (or
plain text for the text-shaped ipynb kind) when its tool is absent. Registry
renderers only; `lib.sh`/pane scripts untouched.

## Run-table

| Kind | Tool | Match (present) | Render | Degrade (tool absent) | Negative control (binary garbage) |
|---|---|---|---|---|---|
| ipynb | `pandoc` + `glow` | ext `.ipynb` + non-binary mime-encoding | `pandoc -f ipynb -t markdown` (div-fences stripped) -> temp `.md` -> `render_markdown` (SG-03, reused) | falls through to `text` (a notebook is JSON, still readable) | declines, routes to `fallback` |
| office (docx/xlsx) | `pandoc` + `glow` | ext `.docx`/`.xlsx` + the specific OOXML mime | `pandoc -f docx\|xlsx -t markdown` -> temp `.md` -> `render_markdown` (SG-03, reused); xlsx clipped to its first `## ` sheet heading | falls to `fallback` (an office file is binary, not readable as plain text) | declines, routes to `fallback` |
| media (mp4/mov) | `ffprobe` + `ffmpeg` | ext + mime (`video/mp4`, `video/quicktime`) | bounded `ffprobe` metadata, then a bounded single-frame `ffmpeg` poster -> `render_image` (SG-04, reused) | poster extraction failure degrades to metadata-only; `ffprobe`/`ffmpeg` absent -> `fallback` | declines, routes to `fallback` |
| media (mp3) | `ffprobe` only (no poster to extract) | ext + mime `audio/mpeg` | bounded `ffprobe` metadata, paged | `ffprobe` absent -> `fallback` | declines, routes to `fallback` |
| sqlite | `sqlite3` | ext `.sqlite`/`.db` + mime `application/vnd.sqlite3` | `sqlite3 -readonly -cmd '.tables' -- <path> '.schema'`, paged via `render_command_in_pager` | falls to `fallback` | declines, routes to `fallback` |
| plist | `plutil` (base-system on macOS) | ext `.plist` + `plutil -lint -s` validates it | `plutil -p`, paged via `render_command_in_pager` | XML plist falls through to `text` (still genuine text); binary plist (no textual degrade) falls to `fallback`; `plutil` absent (non-macOS) -> `fallback` | declines (lint rejects it), routes to `fallback` |

## COVERAGE-DELTA

- `scripts/renderers/{ipynb,office,media,sqlite,plist}.sh`: filled from the SG-01
  declining stubs to real renderers. `shellcheck -x` clean on all five.
- `tests/renderers-{ipynb,office,media,sqlite,plist}.bats`: 61 new tests (10 ipynb,
  15 office, 14 media, 12 sqlite, 10 plist) covering match-present,
  match-declines-tool-absent, render argv/output shape, the render-registry degrade
  cascade, a binary-garbage negative control per kind, and (sqlite) a live
  read-only-write-fails safety assertion. Full suite: 418 passed, 0 failed
  (`bats tests/`), rebased onto the just-merged P2 pack (#32).
- `README.md`: 5 new rows in the `## Renderers (v0.4)` table.
- `CHANGELOG.md`: 1 new Unreleased bullet covering all five kinds.

## Deviations from the goal file

- **PR base is `main`, not `feat/ql4-01-registry`** - same rationale as #32: this
  branch was cut from current `main` with waves 1-2 already merged; the
  `feat/ql4-01-registry` name predates wave ordering settling. Rebased onto `main`
  again mid-session to pick up #32 (P2 pack) once it landed; README/CHANGELOG
  conflicts resolved by keeping both packs' entries, in `RENDER_KINDS` dispatch
  order.
- **xlsx renders through the SAME pandoc-markdown-`glow` path as docx, not a csv
  renderer.** The goal file's literal text says "xlsx -> first sheet -> csv view".
  Verified live: `pandoc --list-output-formats` has no `csv` writer at all (pandoc
  can only ever run this the other direction), and no xlsx->csv converter
  (`ssconvert`/`xlsx2csv`/`in2csv`) is installed, declared in
  `install-renderers.sh`, or listed in the README Prerequisites table - so a real
  `-> csv -> reuse the csv renderer` path does not exist to build. Pandoc's own
  xlsx READER does work (verified with a real sharedStrings-backed multi-sheet
  fixture) and emits one `## <SheetName>` markdown-table heading per sheet; an
  `awk` one-liner clips to the FIRST such block, satisfying the "first sheet"
  requirement without a new dependency. `match_render_office` gates both docx and
  xlsx on `pandoc` + `glow` (matching the README Prerequisites table, which already
  commits both office extensions to `pandoc`).
- **ipynb uses `pandoc -f ipynb`, not a `jq`-based cell extraction** (the goal
  file's other offered alternative). The README Prerequisites table (landed by
  SG-02) already commits `.ipynb` to `pandoc` + `glow` specifically; pandoc's
  ipynb->markdown output wraps cells in `::: {.cell ...}` pandoc-native div fences
  that `glow`'s goldmark renderer doesn't understand, so a one-line
  `sed -E '/^:::/d'` strips them before handing off to `render_markdown`.
- **A real timeout-wrapper bug was caught and fixed during implementation.** The
  first draft of `_media_run_bounded` raced `wait "$pid"` against a backgrounded
  `( sleep "$secs"; kill -TERM "$pid" ) &` watcher, then killed the watcher once
  the main command finished. Bash defers an async signal's delivery until the
  shell's CURRENT FOREGROUND COMMAND returns, and the watcher subshell is blocked
  inside its own `sleep` when that kill arrives - so it silently did nothing until
  `sleep "$secs"` ran to completion regardless of how fast the wrapped command
  actually finished (surfaced as `bats -T` reporting ~5s/~10s per `render_media`
  test instead of milliseconds). Rewritten as a polling loop (`kill -0` + wall-clock
  deadline, 0.2s ticks); live-verified before/after (fast case 5000ms+ -> ~200ms;
  the genuine-timeout case still correctly bounds within ~1.1s of a 1s bound). Full
  detail in the megagoal's DECISIONS.md.
- **A `PIPESTATUS` scoping gotcha was caught the same way.** `${PIPESTATUS[0]}`
  does not propagate across a function-call boundary in bash - factoring the
  pandoc-pipe-through-sed/awk conversion into a small helper and reading
  `${PIPESTATUS[0]}` in the CALLER reliably read `0` regardless of the real pandoc
  exit status (live-verified: a direct pipeline gave the correct nonzero rc on a
  deliberately-broken fixture, the same pipeline wrapped in a helper gave `0`).
  Both `ipynb.sh` and `office.sh` keep their pandoc pipeline INLINE in
  `render_ipynb`/`render_office` for this reason.
- **plist match is keyed on `plutil -lint -s`, not a `file --mime-type` check** -
  the pattern every other P3 kind uses. Verified live: a binary (bplist00) plist
  reports a generic `application/octet-stream` via `file(1)` on this host (no
  distinct libmagic signature), so a mime-type gate would either misclassify real
  binary plists as garbage or under-discriminate actual garbage; `plutil -lint` is
  the ground truth regardless of serialization and doubles as the binary-garbage
  negative control.
