### PR TITLE
fix(gif): chafa animate flags and a real wall-clock duration bound

### DIFF
--- a/scripts/renderers/gif.sh
+++ b/scripts/renderers/gif.sh
@@ -34,8 +34,23 @@ _GIF_ANIMATE_DURATION="${QUICKLOOK_GIF_ANIMATE_DURATION:-8}"
 # No `o`/`d`/`e` overlay keys - same documented scope edge as image.sh.
 render_gif() {
   local path="$1"
-  if ! chafa --animate -d "$_GIF_ANIMATE_DURATION" -- "$path" 2>/dev/null; then
-    chafa --format symbols -- "$path" 2>/dev/null
+  # --animate takes an explicit =BOOL on chafa >= 1.18 (a bare --animate eats
+  # the next argv and errors), and its --duration does NOT bound an animated
+  # gif (measured: a 21s gif plays in full with --duration=2), so the bound
+  # is enforced here with a wall-clock kill. The still fallback needs
+  # --animate=off or chafa animates a multi-frame gif FOREVER even in
+  # symbols format.
+  chafa --animate=on -- "$path" 2>/dev/null &
+  local _gif_pid=$! _gif_deadline=$((SECONDS + _GIF_ANIMATE_DURATION))
+  while kill -0 "$_gif_pid" 2>/dev/null && [ "$SECONDS" -lt "$_gif_deadline" ]; do
+    sleep 0.2
+  done
+  if kill -0 "$_gif_pid" 2>/dev/null; then
+    kill "$_gif_pid" 2>/dev/null
+    printf '\033[?25h\033[0m\n'
+  fi
+  if ! wait "$_gif_pid" 2>/dev/null; then
+    chafa --animate=off --format symbols -- "$path" 2>/dev/null
   fi
   read -r -n1 -p 'press any key to close' _ 2>/dev/null || sleep 2
   return 0

--- a/tests/renderers-gif.bats
+++ b/tests/renderers-gif.bats
@@ -39,7 +39,7 @@ _stub_chafa_animate_unavailable() {
   cat > "$STUB/chafa" <<'SH'
 #!/usr/bin/env bash
 for a in "$@"; do
-  [ "$a" = "--animate" ] && exit 1
+  case "$a" in --animate=on) exit 1 ;; esac
 done
 printf '%s\n' "$@" > "$CHAFA_ARGV_FILE"
 exit 0
@@ -109,8 +109,7 @@ SH
   run bash -c ". '$LIB'; render_gif '$FIX/t.gif' <<<'x'"
   [ "$status" -eq 0 ]
   [ -f "$FIX/chafa.argv" ]
-  grep -qx -- '--animate' "$FIX/chafa.argv"
-  grep -qx -- '-d' "$FIX/chafa.argv"
+  grep -qx -- '--animate=on' "$FIX/chafa.argv"
   grep -qx -- "$FIX/t.gif" "$FIX/chafa.argv"
 }
 
@@ -124,5 +123,6 @@ SH
   [ -f "$FIX/chafa.argv" ]
   grep -qx -- '--format' "$FIX/chafa.argv"
   grep -qx -- 'symbols' "$FIX/chafa.argv"
-  ! grep -qx -- '--animate' "$FIX/chafa.argv"
+  grep -qx -- '--animate=off' "$FIX/chafa.argv"
+  ! grep -qx -- '--animate=on' "$FIX/chafa.argv"
 }


### PR DESCRIPTION
## Summary

Found while recording the SG-08 demos: on chafa 1.18.2, a bare `--animate` eats the next argv and errors ('Missing argument for --animate'), and chafa's own `--duration` does NOT bound an animated gif (measured: a 21s gif plays in full with `--duration=2`) - worse, the still fallback without `--animate=off` animates a multi-frame gif forever in a live TTY.

- animate path: `chafa --animate=on` under a wall-clock kill loop ($SECONDS deadline, same pattern as media.sh's bounded runner), cursor restored after a mid-animation kill
- fallback path: `chafa --animate=off --format symbols`
- stub + assertions updated to the new argv shape

## Run-table

| Command | Result |
|---|---|
| `bash -c '. scripts/lib.sh; render_gif demo/linkify.gif'` on a 21s multi-frame gif | returns in ~10s (8s bound + pause), was infinite |
| `shellcheck -x scripts/renderers/gif.sh` | clean |
| `bats tests/ </dev/null` | full suite, 0 failures |