### PR TITLE
workspace sweep: cross-repo relative paths resolve via roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Workspace sweep: a relative path referenced from another repo's pane
+  resolves by probing each root's first-level children (root/<repo>/<path>),
+  files and directories alike, as the last resolution rung.
+
 - Five new render types (P2 pack): svg (`.svg`, `rsvg-convert` -> a temp png
   -> the same inline chafa render as still images), pdf (`.pdf`, a page-1
   poster via `pdftoppm`+chafa plus extracted text via `pdftotext`, paged

--- a/scripts/handlers/dir.sh
+++ b/scripts/handlers/dir.sh
@@ -28,6 +28,19 @@ _dir_candidates() {
   for r in ${QUICKLOOK_ROOTS:-}; do
     [ -n "$r" ] && printf '%s\n' "$r/$p"
   done
+  # Workspace sweep, mirroring resolve()'s last rung (the walks must stay
+  # aligned so a file at an earlier rung always beats a dir at a later one).
+  local stripped="${p#./}" d
+  case "$stripped" in
+    */*)
+      for r in ${QUICKLOOK_ROOTS:-}; do
+        [ -n "$r" ] && [ -d "$r" ] || continue
+        for d in "$r"/*/; do
+          printf '%s\n' "$d$stripped"
+        done
+      done
+      ;;
+  esac
 }
 
 # _resolve_dir <raw> -> absolute directory path on stdout, rc 0. rc 1 when no

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -460,6 +460,23 @@ resolve() {
   for r in ${QUICKLOOK_ROOTS:-}; do
     [ -n "$r" ] && [ -f "$r/$p" ] && { printf '%s' "$r/$p"; return 0; }
   done
+  # Workspace sweep, the last rung: a RELATIVE path pasted from another
+  # repo's session (./scripts/release.sh while standing in a different
+  # repo) resolves by probing each first-level child of every root
+  # (root/<repo>/<path>). One stat per child, and only after every
+  # earlier rung failed, so the common case never pays for it. Leading
+  # ./ is stripped for the join; absolute tokens never reach here.
+  local stripped="${p#./}" d
+  case "$stripped" in
+    */*)
+      for r in ${QUICKLOOK_ROOTS:-}; do
+        [ -n "$r" ] && [ -d "$r" ] || continue
+        for d in "$r"/*/; do
+          [ -f "$d$stripped" ] && { printf '%s' "$d$stripped"; return 0; }
+        done
+      done
+      ;;
+  esac
   return 1
 }
 
@@ -814,6 +831,23 @@ _pick_resolve_local() {
   for r in ${QUICKLOOK_ROOTS:-}; do
     [ -n "$r" ] && [ -f "$r/$p" ] && { printf '%s' "$r/$p"; return 0; }
   done
+  # Workspace sweep, the last rung: a RELATIVE path pasted from another
+  # repo's session (./scripts/release.sh while standing in a different
+  # repo) resolves by probing each first-level child of every root
+  # (root/<repo>/<path>). One stat per child, and only after every
+  # earlier rung failed, so the common case never pays for it. Leading
+  # ./ is stripped for the join; absolute tokens never reach here.
+  local stripped="${p#./}" d
+  case "$stripped" in
+    */*)
+      for r in ${QUICKLOOK_ROOTS:-}; do
+        [ -n "$r" ] && [ -d "$r" ] || continue
+        for d in "$r"/*/; do
+          [ -f "$d$stripped" ] && { printf '%s' "$d$stripped"; return 0; }
+        done
+      done
+      ;;
+  esac
   return 1
 }
 

--- a/tests/hint.bats
+++ b/tests/hint.bats
@@ -29,6 +29,28 @@ setup() {
   [ "$status" -ne 0 ]
 }
 
+@test "workspace sweep: a relative path from ANOTHER repo resolves via roots" {
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/root/repoA/sub" "$FIX/elsewhere"
+  printf 'x\n' >"$FIX/root/repoA/sub/deep-file.md"
+  cd "$FIX/elsewhere"
+  QUICKLOOK_ROOTS="$FIX/root" resolve_any_token './sub/deep-file.md'
+  [ "$RESOLVED_TARGET" = "$FIX/root/repoA/sub/deep-file.md" ]
+  QUICKLOOK_ROOTS="$FIX/root" resolve_any_token 'sub/deep-file.md'
+  [ "$RESOLVED_TARGET" = "$FIX/root/repoA/sub/deep-file.md" ]
+  cd /; rm -rf "$FIX"
+}
+
+@test "workspace sweep: a slash-less token never sweeps (no false hits)" {
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/root/repoA" "$FIX/elsewhere"
+  printf 'x\n' >"$FIX/root/repoA/lonely.md"
+  cd "$FIX/elsewhere"
+  run bash -c ". '$BATS_TEST_DIRNAME/../scripts/lib.sh'; QUICKLOOK_ROOTS='$FIX/root' resolve_any_token 'lonely.md'"
+  [ "$status" -ne 0 ]
+  cd /; rm -rf "$FIX"
+}
+
 @test "resolve_any_token expands a tilde path to the user's home" {
   FIX="$(mktemp -d)"
   printf 'x\n' >"$FIX/tilde-fixture.md"


### PR DESCRIPTION
## Summary

A relative path on screen (`./scripts/release.sh`) could not open when the pane's cwd was a DIFFERENT repo: the resolve walk tried $PWD, the current repo's worktrees, and a direct `root/<path>` join, none of which reach `~/workspace/tieubao/herdr-quicklook/scripts/release.sh` from an ops-toolkit pane.

- New last rung in `resolve()`: after every existing rung fails, probe each first-level child of every `QUICKLOOK_ROOTS` entry (`root/<repo>/<path>`, leading `./` stripped). One stat per child, slash-containing tokens only, so the common case pays nothing and bare words never sweep.
- `_dir_candidates` gains the mirrored rung (the file/dir walks must stay aligned so a file at an earlier rung beats a dir at a later one).
- First match wins on an ambiguous suffix (alphabetical repo order) - accepted and documented.

## Run-table

| Command | Result |
|---|---|
| `resolve_any_token './scripts/release.sh'` from an ops-toolkit cwd | `file -> .../herdr-quicklook/scripts/release.sh` |
| `bats tests/ </dev/null` | full suite, 0 failures (2 new sweep tests incl. the no-slash negative) |
| `shellcheck -x scripts/lib.sh scripts/handlers/dir.sh` | clean |