### PR TITLE
polish: 90% overlays, no wrapping bat header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Overlays open at 90% of the pane; the bat header line is gone (the less
+  status line already shows the full path, and the header wrapped on narrow
+  overlays).
+
 - Workspace sweep: a relative path referenced from another repo's pane
   resolves by probing each root's first-level children (root/<repo>/<path>),
   files and directories alike, as the last resolution rung.

--- a/scripts/find.sh
+++ b/scripts/find.sh
@@ -24,6 +24,7 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint find-pane \
   --placement overlay \
+  --width 90% --height 90% \
   --focus
 
 if [ -n "$repo" ] && [ -d "$repo" ]; then

--- a/scripts/hint.sh
+++ b/scripts/hint.sh
@@ -118,6 +118,7 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint hint-pane \
   --placement overlay \
+  --width 90% --height 90% \
   --focus \
   --env "QUICKLOOK_HINT_TOKENS_FILE=$tokens_file" \
   --env "QUICKLOOK_HINT_SNAP_FILE=$snap_file"

--- a/scripts/open-preview.sh
+++ b/scripts/open-preview.sh
@@ -21,6 +21,7 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint preview \
   --placement overlay \
+  --width 90% --height 90% \
   --focus
 
 # env, never --cwd: --cwd breaks the pane's relative command resolution and

--- a/scripts/open-suggestion.sh
+++ b/scripts/open-suggestion.sh
@@ -25,6 +25,7 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint preview \
   --placement overlay \
+  --width 90% --height 90% \
   --focus \
   --env "QUICKLOOK_TOKEN=$token"
 # env, never --cwd: --cwd breaks the pane's relative command resolution and

--- a/scripts/recents.sh
+++ b/scripts/recents.sh
@@ -25,6 +25,7 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint recents-pick \
   --placement overlay \
+  --width 90% --height 90% \
   --focus
 
 if [ -n "$repo" ] && [ -d "$repo" ]; then

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -31,7 +31,7 @@ render_text() {
   # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
   export QUICKLOOK_EDITOR_SCRIPT="$LIB_DIR/escalate-editor.sh"
   if command -v bat >/dev/null 2>&1; then
-    export LESSOPEN='|bat --color=always --style=numbers,header %s'
+    export LESSOPEN='|bat --color=always --style=numbers %s'
     exec less -R "${lesskey_args[@]}" ${line:++$line} "$target"
   fi
   exec less -N "${lesskey_args[@]}" ${line:++$line} "$target"


### PR DESCRIPTION
## Summary

- Every overlay open (`hint`, `preview`, `recents`, `agent-suggestion`, `find`) now passes `--width 90% --height 90%`.
- The bat `header` style is dropped from the text renderer's LESSOPEN: it printed the absolute path which WRAPPED on narrow overlays, and the less status line at the bottom already shows the full path.

## Run-table

| Command | Result |
|---|---|
| `bats tests/ </dev/null` | full suite, 0 failures |
| `shellcheck -x` on the six touched scripts | clean |