### PR TITLE
hotfix: overlay size flags broke every pane open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-- Overlays open at 90% of the pane; the bat header line is gone (the less
-  status line already shows the full path, and the header wrapped on narrow
-  overlays).
+- The bat header line is gone from the text renderer (the less status line
+  already shows the full path, and the header wrapped on narrow overlays).
 
 - Workspace sweep: a relative path referenced from another repo's pane
   resolves by probing each root's first-level children (root/<repo>/<path>),

--- a/scripts/find.sh
+++ b/scripts/find.sh
@@ -24,7 +24,6 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint find-pane \
   --placement overlay \
-  --width 90% --height 90% \
   --focus
 
 if [ -n "$repo" ] && [ -d "$repo" ]; then

--- a/scripts/hint.sh
+++ b/scripts/hint.sh
@@ -118,7 +118,6 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint hint-pane \
   --placement overlay \
-  --width 90% --height 90% \
   --focus \
   --env "QUICKLOOK_HINT_TOKENS_FILE=$tokens_file" \
   --env "QUICKLOOK_HINT_SNAP_FILE=$snap_file"

--- a/scripts/open-preview.sh
+++ b/scripts/open-preview.sh
@@ -21,7 +21,6 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint preview \
   --placement overlay \
-  --width 90% --height 90% \
   --focus
 
 # env, never --cwd: --cwd breaks the pane's relative command resolution and

--- a/scripts/open-suggestion.sh
+++ b/scripts/open-suggestion.sh
@@ -25,7 +25,6 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint preview \
   --placement overlay \
-  --width 90% --height 90% \
   --focus \
   --env "QUICKLOOK_TOKEN=$token"
 # env, never --cwd: --cwd breaks the pane's relative command resolution and

--- a/scripts/recents.sh
+++ b/scripts/recents.sh
@@ -25,7 +25,6 @@ set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint recents-pick \
   --placement overlay \
-  --width 90% --height 90% \
   --focus
 
 if [ -n "$repo" ] && [ -d "$repo" ]; then


### PR DESCRIPTION
PR #37 added `--width 90% --height 90%` to the five overlay opens, but herdr returns `invalid_params: width and height are only supported when placement is popup` for `--placement overlay` - so prefix+v (and every other open) failed silently. Reverts the size flags; keeps the bat-header removal. Live-verified: the hint overlay opens again after the revert. Full hint/find bats green.