### PR TITLE
diff moves to D; d returns to less's half-page scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Diff moved from `d` to `D` in the preview: lowercase `d` is less's own
+  half-page-down and the old binding shadowed basic scrolling.
+
 - A settled pick (hint key, mouse click, or the clipboard gate) now opens in
   herdr's 90% POPUP surface; the overlay is for choosing, the popup for
   reading. Plain left-click on a hinted token opens it (SGR mouse tracking

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ valid action id if you'd rather bind that directly instead.
 | `q` or `Esc Esc` | Close the overlay (a bare Esc cannot coexist with arrow-key scrolling in less, so quit is double-Esc) |
 | `o` (or `v`) | **Escalate**: close the overlay and open this file, at the same line, in the herdr-file-viewer pane (when that plugin is installed) |
 | `e` | **Edit**: open this file, at the same line, in `$EDITOR` (config-overridable, default `zed --wait`); the overlay resumes when the editor exits |
-| `d` | **Diff**: open a nested pager on `git diff` for this file (delta-colored if installed, else git's own color); press `d` again (or `q`) to close it and resume the file view. A clean file just prints a no-changes notice |
+| `D` | **Diff** (shift-d): open a nested pager on `git diff` for this file (delta-colored if installed, else git's own color); `q` closes it and resumes the file view. A clean file just prints a no-changes notice. Lowercase `d` stays less's half-page-down scroll |
+| `d` / `u`, `j` / `k`, `Space` / `b`, `g` / `G` | less's own navigation: half-page down/up, line down/up, page forward/back, top/bottom |
 | `/`, `n`, `N` | Search inside the file |
 | arrows / PgUp / PgDn | Scroll |
 
@@ -125,7 +126,7 @@ Repository URLs (GitHub blob/raw/PR, GitLab blob, Bitbucket source) are ALSO Ctr
 
 ## Find a file (`prefix+/` suggested)
 
-The `find` action opens an fzf overlay over the repo's tracked files (outside a repo, a bounded `find`), with a live bat preview rendering WHILE you type. Enter opens the pick in the same preview overlay as every other open, so `o`/`e`/`d` keep working; Esc closes. This is the proactive complement to the passive bare-name fallback (a copied ambiguous filename already fzf-picks among its matches).
+The `find` action opens an fzf overlay over the repo's tracked files (outside a repo, a bounded `find`), with a live bat preview rendering WHILE you type. Enter opens the pick in the same preview overlay as every other open, so `o`/`e`/`D` keep working; Esc closes. This is the proactive complement to the passive bare-name fallback (a copied ambiguous filename already fzf-picks among its matches).
 
 ## Agent suggestions (opt-in)
 
@@ -212,7 +213,7 @@ already-tagged version.
 
 ![tokens tour: path, GitHub blob URL, commit SHA, PR reference, and a directory, all opened from the clipboard](demo/tokens-tour.gif)
 
-**The three in-overlay keys** - `d` (dirty-diff toggle), `e` (edit in `$EDITOR`), `o` (escalate to herdr-file-viewer):
+**The three in-overlay keys** - `D` (dirty-diff toggle), `e` (edit in `$EDITOR`), `o` (escalate to herdr-file-viewer):
 
 ![overlay keys tour: d toggles a git diff, e opens $EDITOR, o escalates into herdr-file-viewer](demo/overlay-keys-tour.gif)
 

--- a/lesskey
+++ b/lesskey
@@ -11,7 +11,9 @@
 # filename); QUICKLOOK_EDITOR_SCRIPT is exported by preview-pane.sh.
 # Verified against a real less 668 session (PR proof).
 #
-# `d` -> git diff: bound to `shell` (the `!` slot), a THIRD distinct action
+# `D` -> git diff (shift-d; lowercase `d` stays less's own half-page-down
+# scroll - the binding used to sit on `d` and shadowed basic navigation):
+# bound to `shell` (the `!` slot), a THIRD distinct action
 # from `o`'s `visual` and `e`'s `pshell`. `shell`'s extra string uses a
 # DIFFERENT %-expansion than pshell/visual: a bare `%` (not the two-char
 # `%g`) is replaced by the current filename , confirmed empirically (a real
@@ -30,4 +32,4 @@
 \e\e quit
 o visual
 e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n
-d shell \020"$(dirname "$QUICKLOOK_EDITOR_SCRIPT")/dirty-diff.sh" %\n
+D shell \020"$(dirname "$QUICKLOOK_EDITOR_SCRIPT")/dirty-diff.sh" %\n


### PR DESCRIPTION
The lesskey map bound lowercase `d` to the dirty-diff toggle, shadowing less's own half-page-down - so basic navigation (`d`/`u`) was half-broken in every preview. Diff now sits on `D` (shift-d); `d`, `u`, `j`/`k`, `Space`/`b`, `g`/`G` are all stock less navigation again, documented in the README key table. Full suite green, dirty-diff/editor/pager bats unchanged and passing.