### PR TITLE
workspace sweep reaches other repos' worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- The workspace sweep also probes each repo's house-standard worktrees
+  (.claude/worktrees/*), so a gate-branch artifact opens from any pane; the
+  not-found message now names every rung.
+
 - Diff moved from `d` to `D` in the preview: lowercase `d` is less's own
   half-page-down and the old binding shadowed basic scrolling.
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -475,6 +475,15 @@ resolve() {
           [ -f "$d$stripped" ] && { printf '%s' "$d$stripped"; return 0; }
         done
       done
+      # ... and each repo's house-standard worktrees (a gate-branch artifact
+      # reviewed from another repo's pane lives exactly there). Still one
+      # stat per candidate, still only on a full miss.
+      for r in ${QUICKLOOK_ROOTS:-}; do
+        [ -n "$r" ] && [ -d "$r" ] || continue
+        for d in "$r"/*/.claude/worktrees/*/; do
+          [ -f "$d$stripped" ] && { printf '%s' "$d$stripped"; return 0; }
+        done
+      done
       ;;
   esac
   return 1
@@ -843,6 +852,15 @@ _pick_resolve_local() {
       for r in ${QUICKLOOK_ROOTS:-}; do
         [ -n "$r" ] && [ -d "$r" ] || continue
         for d in "$r"/*/; do
+          [ -f "$d$stripped" ] && { printf '%s' "$d$stripped"; return 0; }
+        done
+      done
+      # ... and each repo's house-standard worktrees (a gate-branch artifact
+      # reviewed from another repo's pane lives exactly there). Still one
+      # stat per candidate, still only on a full miss.
+      for r in ${QUICKLOOK_ROOTS:-}; do
+        [ -n "$r" ] && [ -d "$r" ] || continue
+        for d in "$r"/*/.claude/worktrees/*/; do
           [ -f "$d$stripped" ] && { printf '%s' "$d$stripped"; return 0; }
         done
       done

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -91,7 +91,7 @@ else
 fi
 
 [ -z "${target:-}" ] && pause_close "quicklook: not a file I can find: $raw" \
-  "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS, repo filename search)"
+  "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS, the workspace sweep incl. other repos' worktrees, repo filename search)"
 
 record_open "$raw"
 

--- a/tests/hint.bats
+++ b/tests/hint.bats
@@ -41,6 +41,16 @@ setup() {
   cd /; rm -rf "$FIX"
 }
 
+@test "workspace sweep: reaches another repo's house-standard worktrees" {
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/root/repoA/.claude/worktrees/wt1/demo" "$FIX/elsewhere"
+  printf 'x\n' >"$FIX/root/repoA/.claude/worktrees/wt1/demo/artifact.gif"
+  cd "$FIX/elsewhere"
+  QUICKLOOK_ROOTS="$FIX/root" resolve_any_token 'demo/artifact.gif'
+  [ "$RESOLVED_TARGET" = "$FIX/root/repoA/.claude/worktrees/wt1/demo/artifact.gif" ]
+  cd /; rm -rf "$FIX"
+}
+
 @test "workspace sweep: a slash-less token never sweeps (no false hits)" {
   FIX="$(cd "$(mktemp -d)" && pwd -P)"
   mkdir -p "$FIX/root/repoA" "$FIX/elsewhere"


### PR DESCRIPTION
Han tried to open a gate-branch demo gif (living in herdr-quicklook/.claude/worktrees/ql4-08/) from an ops-toolkit pane: the sweep probes each repo's ROOT only, so a branch-only artifact was unreachable. New sub-rung: after root/<repo>/<path> misses, probe root/<repo>/.claude/worktrees/*/<path> (the house-standard worktree location). Still stat-only, still only on a full miss. The preview's not-found message now names every rung including the sweep. Live-verified cross-repo worktree resolution + new bats; full suite green.