### PR TITLE
uppercase hint letter opens a full tab pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- UPPERCASE hint letter opens the pick in a full persistent tab pane;
+  lowercase (and click) keep the 90% popup.
+
 - The workspace sweep also probes each repo's house-standard worktrees
   (.claude/worktrees/*), so a gate-branch artifact opens from any pane; the
   not-found message now names every rung.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The log lives outside any git repo, at `${XDG_STATE_HOME:-~/.local/state}/herdr-
 
 ## Hint picker (`prefix+v`)
 
-The one picker. Press the binding and the pane re-renders dimmed with a one-letter hint overlaid, pluck-style, on every openable token: the letter replaces the token's first character (bold black on bright yellow), the rest of the token turns yellow, and columns never shift, so you keep the full context of the screen you were reading. Type the letter and the token opens by TYPE: a file in the preview popup, a directory in the file-viewer's own tab, a URL in the browser, a SHA through `git show`. `Esc` or `q` cancels.
+The one picker. Press the binding and the pane re-renders dimmed with a one-letter hint overlaid, pluck-style, on every openable token: the letter replaces the token's first character (bold black on bright yellow), the rest of the token turns yellow, and columns never shift, so you keep the full context of the screen you were reading. Type the letter and the token opens by TYPE: a file in the 90% preview popup (UPPERCASE the letter to open a FULL persistent tab pane instead), a directory in the file-viewer's own tab, a URL in the browser, a SHA through `git show`. `Esc` or `q` cancels.
 
 Every hinted token is also an OSC-8 link on this plugin's `.invalid` sentinel transport, so Ctrl+click opens the same way the letter does. The sentinel URLs are accepted only after a canonical encode/decode check; they are an internal transport, never a network destination.
 

--- a/scripts/hint-pane.sh
+++ b/scripts/hint-pane.sh
@@ -253,7 +253,8 @@ open_pick() {
     export QUICKLOOK_KEEP_CWD=1
     exec bash "$script_dir/open-in-viewer.sh" "${tokens[$i]}"
   fi
-  QUICKLOOK_PREVIEW_CWD="$PWD" exec bash "$script_dir/open-popup.sh" "${tokens[$i]}"
+  QUICKLOOK_PREVIEW_CWD="$PWD" QUICKLOOK_OPEN_PLACEMENT="${QUICKLOOK_OPEN_PLACEMENT:-popup}" \
+    exec bash "$script_dir/open-popup.sh" "${tokens[$i]}"
 }
 
 # hit_test <col> <row> -> token idx via $HIT, rc 1 on miss.
@@ -293,9 +294,18 @@ while IFS= read -rsn1 key <"$tty_in"; do
       ;;
     '') continue ;;
     *)
+      # UPPERCASE hint letter = open in a FULL TAB pane instead of the popup
+      # (Q stays cancel). Lowercase = popup, click = popup.
+      placement=popup
+      case "$key" in
+        [A-Z])
+          placement=tab
+          key="$(printf '%s' "$key" | tr 'A-Z' 'a-z')"
+          ;;
+      esac
       idx="$(hint_index_for_key "$key" 2>/dev/null)" || continue
       [ "$idx" -lt "${#tokens[@]}" ] || continue
-      open_pick "$idx"
+      QUICKLOOK_OPEN_PLACEMENT="$placement" open_pick "$idx"
       ;;
   esac
 done

--- a/scripts/open-popup.sh
+++ b/scripts/open-popup.sh
@@ -15,13 +15,18 @@ herdr_bin="${HERDR_BIN_PATH:-herdr}"
 token="${1:-}"
 [ -n "$token" ] || exit 0
 
+# QUICKLOOK_OPEN_PLACEMENT=tab opens a FULL persistent tab pane instead of
+# the transient popup (the hint overlay's UPPERCASE pick).
+placement="${QUICKLOOK_OPEN_PLACEMENT:-popup}"
 set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint preview \
-  --placement popup \
-  --width 90% --height 90% \
+  --placement "$placement" \
   --focus \
   --env "QUICKLOOK_TOKEN=$token"
+if [ "$placement" = "popup" ]; then
+  set -- "$@" --width 90% --height 90%
+fi
 
 if [ -n "${QUICKLOOK_PREVIEW_CWD:-$PWD}" ]; then
   set -- "$@" --env "QUICKLOOK_PREVIEW_CWD=${QUICKLOOK_PREVIEW_CWD:-$PWD}"

--- a/tests/find.bats
+++ b/tests/find.bats
@@ -118,6 +118,14 @@ SH
   grep -qx 'QUICKLOOK_TOKEN=src/target.md' <<<"$output"
 }
 
+@test "open-popup honors QUICKLOOK_OPEN_PLACEMENT=tab (full pane, no size flags)" {
+  export HERDR_BIN_PATH="$STUB/herdr"
+  QUICKLOOK_OPEN_PLACEMENT=tab run bash "$ROOT/scripts/open-popup.sh" 'src/target.md'
+  [ "$status" -eq 0 ]
+  grep -qx 'tab' <<<"$output"
+  ! grep -qx -- '--width' <<<"$output"
+}
+
 @test "manifest registers the find overlay and action" {
   python3 - "$ROOT/herdr-plugin.toml" <<'PY'
 import sys


### PR DESCRIPTION
Concern: the popup-terminal flow looked like it dropped full-pane viewing and the file-viewer integration. The integration was intact (dir pick -> viewer tab; `o` in the popup -> file-viewer at file+line; prefix+f bindings), but a FULL-PANE open from the hint overlay genuinely had no affordance. Now: lowercase hint letter (or click) = 90% popup as before; UPPERCASE letter = the same render in a full persistent TAB pane (`Q` stays cancel). open-popup.sh grows a QUICKLOOK_OPEN_PLACEMENT env (popup default; size flags only for popup - herdr rejects them elsewhere). New bats for the placement forwarding; full suite green.