### PR TITLE
chore: character classes in tr for the uppercase mapping

### DIFF
--- a/scripts/hint-pane.sh
+++ b/scripts/hint-pane.sh
@@ -300,7 +300,7 @@ while IFS= read -rsn1 key <"$tty_in"; do
       case "$key" in
         [A-Z])
           placement=tab
-          key="$(printf '%s' "$key" | tr 'A-Z' 'a-z')"
+          key="$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')"
           ;;
       esac
       idx="$(hint_index_for_key "$key" 2>/dev/null)" || continue


### PR DESCRIPTION
The release gate's shellcheck pass (info level included) flagged SC2018/SC2019 on the uppercase-hint mapping from #42. `tr '[:upper:]' '[:lower:]'` instead. hint bats green.