### PR TITLE
fix(render): pass pane width to glow, not its piped 80-col default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Markdown (and docx/xlsx/ipynb via the same path) no longer wraps at glow's
+  hard piped default of 80 columns: `render_markdown` measures the pane's TTY
+  and passes `-w`, so wide panes stop showing ragged orphan line fragments.
+
 ## 0.4.1 (2026-07-20)
 
 - Demo roster pruned to living features only: removed the pick-anywhere,

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -28,6 +28,11 @@ match_render_markdown() {
 # every other render_<kind> but unused - glow has no line-jump, so a
 # best-effort render (not an error) is the contract here.
 render_markdown() {
-  local target="$1"
-  render_command_in_pager glow -s auto -- "$target"
+  local target="$1" cols
+  # glow's stdout is a PIPE inside render_command_in_pager, so its auto
+  # width is a hard 80 no matter how wide the pane is; source lines wider
+  # than 80 then double-wrap into ragged orphan fragments. stdout here is
+  # still the pane's TTY, so measure it and pass the width explicitly.
+  cols="$(tput cols 2>/dev/null)" || cols=80
+  render_command_in_pager glow -s auto -w "${cols:-80}" -- "$target"
 }


### PR DESCRIPTION
## Problem

Markdown previews showed random mid-paragraph line breaks (short orphan fragments like `page (the` / `LK-`). Root cause: `render_command_in_pager` pipes glow into `less`, so glow's stdout is a pipe and styled output hard-wraps at its 80-column default no matter how wide the pane is. Any source line wider than 80 double-wrapped into one 80-col line plus a ragged orphan.

## Fix

`render_markdown` measures the pane's TTY (`tput cols`, stdout is still the pane at that point) and passes `-w` explicitly, falling back to 80 when there is no TTY (bats). One change covers docx/xlsx/ipynb too, since they all dispatch through `render_markdown`.

## Verification

- `bats tests/renderers-markdown.bats` 10/10 green (plus office + ipynb suites).
- Behavioral check on a 100-col hard-wrapped fixture: default styled glow -> 7 padded lines at 78 visible cols (the bug); `-w 140` -> 4 lines at 138, no orphan fragments.