### PR TITLE
feat(viewer): re-root cross-repo targets instead of refusing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- open-in-viewer no longer refuses a target outside the focused pane's repo:
+  a cross-repo path (e.g. a cockpit row pointing into a sibling repo) opens a
+  fresh viewer tab rooted at the target's own repo via `pane open --cwd`,
+  then gotos the file as usual. Non-repo targets root at their directory.
+
 - Markdown (and docx/xlsx/ipynb via the same path) no longer wraps at glow's
   hard piped default of 80 columns: `render_markdown` measures the pane's TTY
   and passes `-w`, so wide panes stop showing ragged orphan line fragments.

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -75,10 +75,9 @@ if resolve_any_token "$raw"; then
       # viewer's cursor on the directory; there is no separate "root at a
       # directory" verb in the socket protocol. Directories have no line
       # number, so CLIP_LINE stays empty and the `:N` step below is skipped
-      # naturally. This falls into the SAME containment / control-char
-      # checks below as a file target - a directory outside this repo's
-      # tree still gets "outside this repo's tree: use the preview overlay
-      # instead".
+      # naturally. This falls into the SAME re-root / control-char checks
+      # below as a file target - a directory outside this repo's tree
+      # opens a fresh viewer tab rooted at its own repo.
       target="$RESOLVED_TARGET"
       CLIP_LINE=""
       ;;
@@ -90,13 +89,20 @@ if resolve_any_token "$raw"; then
 fi
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 
-# The viewer roots at the focused pane's repo; outside targets can't show
-# there. The root itself is inside its own tree (rel stays empty: the viewer
-# opens rooted there, no goto needed).
+# The viewer roots at its launch cwd's repo. A target inside the focused
+# repo reuses the idempotent tab action; a target OUTSIDE it (a cockpit row
+# pointing into a sibling repo) re-roots a fresh viewer tab at the TARGET's
+# own repo via `plugin pane open --cwd` instead of refusing. The root itself
+# is inside its own tree (rel stays empty: the viewer opens rooted there,
+# no goto needed).
 root="$(git rev-parse --show-toplevel 2>/dev/null)"
+viewer_cwd=""
 if [ -z "$root" ] || { [ "$target" != "$root" ] && [[ "$target" != "$root"/* ]]; }; then
-  notify "outside this repo's tree: use the preview overlay instead"
-  exit 0
+  tdir="$target"
+  [ -d "$tdir" ] || tdir="${target%/*}"
+  root="$(git -C "$tdir" rev-parse --show-toplevel 2>/dev/null)"
+  [ -z "$root" ] && root="$tdir"
+  viewer_cwd="$root"
 fi
 rel="${target#"$root"/}"
 [ "$rel" = "$target" ] && rel=""
@@ -112,8 +118,17 @@ esac
 # existing viewer tab instead of opening twice): a vertical split would
 # disrupt the origin tab's layout. After the action, focus lands on the
 # viewer pane; poll `pane current` until its label reads "Files".
-"$herdr_bin" plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer >/dev/null 2>&1 \
-  || { notify "herdr-file-viewer is not installed"; exit 1; }
+# Cross-repo targets bypass the idempotent action on purpose: an existing
+# viewer tab is rooted at the WRONG repo, so a fresh tab is opened rooted
+# at the target's repo (the viewer resolves its tree root from the cwd).
+if [ -n "$viewer_cwd" ]; then
+  "$herdr_bin" plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer \
+    --placement tab --focus --cwd "$viewer_cwd" >/dev/null 2>&1 \
+    || { notify "file viewer did not open (cross-repo)"; exit 1; }
+else
+  "$herdr_bin" plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer >/dev/null 2>&1 \
+    || { notify "herdr-file-viewer is not installed"; exit 1; }
+fi
 pid=""
 for _ in $(seq 1 20); do
   pid="$("$herdr_bin" pane current 2>/dev/null | jq -r '.result.pane.pane_id // empty' 2>/dev/null)"

--- a/tests/handlers-dir.bats
+++ b/tests/handlers-dir.bats
@@ -187,11 +187,28 @@ teardown() {
   grep -qF "pane send-keys STUBPANE Enter" "$HLOG"
 }
 
-@test "negative control: a directory outside the repo notifies and never sends keys" {
+@test "a directory outside the repo re-roots a fresh viewer tab at it (no goto: it IS the root)" {
   export HERDR_VIEWER_INSTALLED=1
   export QUICKLOOK_TOKEN="$FIX/outside/adir"
   run bash "$VIEWER"
   [ "$status" -eq 0 ]
-  grep -q "notification show quicklook --body outside this repo" "$HLOG"
-  ! grep -q "pane send-keys" "$HLOG"
+  # not a git repo, so the root is the directory itself, passed as --cwd
+  grep -qF -- "--cwd $FIX/outside/adir" "$HLOG"
+  # the idempotent tab action would reuse a wrong-root tab; must not be used
+  ! grep -q "action invoke open-file-viewer-tab" "$HLOG"
+  # target IS the root: no goto keys
+  ! grep -q "pane send-text" "$HLOG"
+}
+
+@test "a file in a SIBLING repo re-roots the viewer at that repo and gotos the rel path" {
+  mkdir -p "$FIX/sibling/docs"
+  git -C "$FIX/sibling" init -q -b main
+  printf 'x\n' > "$FIX/sibling/docs/note.md"
+  export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_TOKEN="$FIX/sibling/docs/note.md"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -qF -- "--cwd $FIX/sibling" "$HLOG"
+  grep -qF "pane send-text STUBPANE docs/note.md" "$HLOG"
+  grep -qF "pane send-keys STUBPANE Enter" "$HLOG"
 }


### PR DESCRIPTION
open-in-viewer refused any target outside the focused pane's repo, which
made every cockpit row pointing into a sibling repo a dead end after
escalation. The viewer resolves its tree root from its launch cwd, and
herdr's pane open supports --cwd, so an outside target now opens a fresh
viewer tab rooted at the target's own repo (its git toplevel, else its
directory) and the goto keys use the rel path against that root. The
idempotent open-file-viewer-tab action is bypassed on purpose there: an
existing viewer tab is rooted at the wrong repo.
