### PR TITLE
feat: viewer-matched markdown palette + implicit parent workspace roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Markdown previews pick up herdr-file-viewer's bundled color palette when
+  that plugin is installed, so the preview overlay and the viewer render
+  markdown identically; `QUICKLOOK_GLOW_STYLE` (a glow style name or JSON
+  file) overrides, fallback stays `auto`.
+- Implicit workspace roots: the current repo root's parent and grandparent
+  (`QUICKLOOK_PARENT_SWEEP`, default 2, 0 disables) are appended to
+  `QUICKLOOK_ROOTS` at config load, so side-by-side repo layouts resolve
+  cross-repo tokens with zero configuration on any machine.
+
 - open-in-viewer no longer refuses a target outside the focused pane's repo:
   a cross-repo path (e.g. a cockpit row pointing into a sibling repo) opens a
   fresh viewer tab rooted at the target's own repo via `pane open --cwd`,

--- a/config.example
+++ b/config.example
@@ -11,6 +11,18 @@
 # adding it here lets that path resolve to ~/workspace/myrepo/docs/notes.md.
 #QUICKLOOK_ROOTS="$HOME/workspace:$HOME/src"
 
+# QUICKLOOK_PARENT_SWEEP: how many parent levels of the current repo root are
+# added as IMPLICIT roots (side-by-side repo layouts then resolve cross-repo
+# tokens with zero config). Default 2 (parent + grandparent); 0 disables,
+# leaving only the explicit QUICKLOOK_ROOTS above.
+#QUICKLOOK_PARENT_SWEEP=2
+
+# QUICKLOOK_GLOW_STYLE: glow style for markdown previews, a glow style name
+# ("dark", "dracula", ...) or a path to a glow style JSON file. Unset, the
+# preview picks up herdr-file-viewer's bundled markdown palette when that
+# plugin is installed (so preview and viewer look identical), else "auto".
+#QUICKLOOK_GLOW_STYLE=
+
 # QUICKLOOK_EDITOR: command launched by `e` in the preview overlay, at the
 # current file+line. Precedence: this key > $EDITOR > "zed --wait". Set this
 # instead of (or in addition to) exporting $EDITOR in your shell: the herdr

--- a/scripts/dirty-diff.sh
+++ b/scripts/dirty-diff.sh
@@ -37,10 +37,12 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=scripts/lib.sh
 . "$script_dir/lib.sh"
 
-load_config
-
+# No-arg is a no-op; bail before load_config so the no-op stays truly free
+# (load_config's augment_roots forks a git rev-parse).
 file="${1:-}"
 [ -z "$file" ] && exit 0
+
+load_config
 
 repo_dir="$(dirname "$file")"
 diff_output="$(git -C "$repo_dir" diff --color=always -- "$file" 2>/dev/null)"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -256,6 +256,36 @@ load_config() {
   [ -n "$dir" ] || dir="$("$herdr_bin" plugin config-dir herdr-quicklook 2>/dev/null)"
   # shellcheck disable=SC1091
   [ -n "$dir" ] && [ -f "$dir/.env" ] && . "$dir/.env"
+  augment_roots
+}
+
+# augment_roots: append the current repo root's parents (1..N levels, N =
+# QUICKLOOK_PARENT_SWEEP, default 2, 0 disables) to QUICKLOOK_ROOTS, deduped.
+# Side-by-side repo layouts (~/ws/<repo>, ~/ws/<org>/<repo>) then resolve
+# cross-repo tokens with ZERO config: every existing roots loop (resolve,
+# dir/github handlers, the pick mirrors) picks the parents up unchanged.
+# Still bounded: each added root costs one stat per first-level child, and
+# only on a full miss of every earlier rung.
+augment_roots() {
+  local levels="${QUICKLOOK_PARENT_SWEEP:-2}" base up=0 r found
+  case "$levels" in '' | *[!0-9]*) levels=2 ;; esac
+  [ "$levels" -eq 0 ] && return 0
+  base="$(git rev-parse --show-toplevel 2>/dev/null)"
+  [ -z "$base" ] && base="$PWD"
+  while [ "$up" -lt "$levels" ]; do
+    base="${base%/*}"
+    up=$((up + 1))
+    [ -n "$base" ] && [ -d "$base" ] || break
+    found=0
+    local IFS=':'
+    for r in ${QUICKLOOK_ROOTS:-}; do
+      [ "$r" = "$base" ] && { found=1; break; }
+    done
+    unset IFS
+    [ "$found" -eq 1 ] && continue
+    QUICKLOOK_ROOTS="${QUICKLOOK_ROOTS:+$QUICKLOOK_ROOTS:}$base"
+  done
+  return 0
 }
 
 # Single-char hint keys for the native `hint` overlay, home-row first so the

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -27,6 +27,28 @@ match_render_markdown() {
 # formatter-piped renderer. `line` is accepted for signature parity with
 # every other render_<kind> but unused - glow has no line-jump, so a
 # best-effort render (not an error) is the contract here.
+# _markdown_glow_style -> the value for glow's -s flag, on stdout.
+# Precedence: QUICKLOOK_GLOW_STYLE (a glow style name or a JSON style file)
+# > herdr-file-viewer's bundled palette when that plugin is installed (so
+# the preview overlay and the viewer render markdown identically) > auto.
+# The viewer ships its palette at assets/markdown-style.json and treats it
+# as a trusted glow argument; pointing our glow at the same file is the
+# whole "pick up the viewer's highlighting" feature.
+_markdown_glow_style() {
+  if [ -n "${QUICKLOOK_GLOW_STYLE:-}" ]; then
+    printf '%s' "$QUICKLOOK_GLOW_STYLE"
+    return 0
+  fi
+  local vroot
+  vroot="$("${HERDR_BIN_PATH:-herdr}" plugin list --json 2>/dev/null \
+    | jq -r '.result.plugins[] | select(.plugin_id == "herdr-file-viewer") | .plugin_root // empty' 2>/dev/null)"
+  if [ -n "$vroot" ] && [ -f "$vroot/assets/markdown-style.json" ]; then
+    printf '%s' "$vroot/assets/markdown-style.json"
+    return 0
+  fi
+  printf 'auto'
+}
+
 render_markdown() {
   local target="$1" cols
   # glow's stdout is a PIPE inside render_command_in_pager, so its auto
@@ -34,5 +56,5 @@ render_markdown() {
   # than 80 then double-wrap into ragged orphan fragments. stdout here is
   # still the pane's TTY, so measure it and pass the width explicitly.
   cols="$(tput cols 2>/dev/null)" || cols=80
-  render_command_in_pager glow -s auto -w "${cols:-80}" -- "$target"
+  render_command_in_pager glow -s "$(_markdown_glow_style)" -w "${cols:-80}" -- "$target"
 }

--- a/tests/parent-sweep.bats
+++ b/tests/parent-sweep.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# Tests for augment_roots (lib.sh): implicit parent-level workspace roots.
+# Side-by-side layouts (ws/<repo>, ws/<org>/<repo>) must resolve cross-repo
+# tokens with NO QUICKLOOK_ROOTS configured; the parents of the current repo
+# root are appended (default 2 levels, QUICKLOOK_PARENT_SWEEP overrides,
+# 0 disables) and every existing roots loop picks them up unchanged.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/ws/org/repo" "$FIX/ws/org/sibling/docs"
+  git -C "$FIX/ws/org/repo" init -q -b main
+  printf 'x\n' > "$FIX/ws/org/sibling/docs/note.md"
+  cd "$FIX/ws/org/repo"
+  unset QUICKLOOK_ROOTS QUICKLOOK_PARENT_SWEEP
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+@test "augment_roots: appends the repo's parent and grandparent (default 2 levels)" {
+  augment_roots
+  [[ ":$QUICKLOOK_ROOTS:" == *":$FIX/ws/org:"* ]]
+  [[ ":$QUICKLOOK_ROOTS:" == *":$FIX/ws:"* ]]
+}
+
+@test "augment_roots: QUICKLOOK_PARENT_SWEEP=1 stops at the parent" {
+  QUICKLOOK_PARENT_SWEEP=1
+  augment_roots
+  [[ ":$QUICKLOOK_ROOTS:" == *":$FIX/ws/org:"* ]]
+  [[ ":$QUICKLOOK_ROOTS:" != *":$FIX/ws:"* ]]
+}
+
+@test "augment_roots: QUICKLOOK_PARENT_SWEEP=0 disables the sweep" {
+  QUICKLOOK_PARENT_SWEEP=0
+  augment_roots
+  [ -z "${QUICKLOOK_ROOTS:-}" ]
+}
+
+@test "augment_roots: an already-configured root is not duplicated" {
+  QUICKLOOK_ROOTS="$FIX/ws/org"
+  augment_roots
+  [ "$QUICKLOOK_ROOTS" = "$FIX/ws/org:$FIX/ws" ]
+}
+
+@test "resolve: an org-prefixed cross-repo token resolves with zero config" {
+  augment_roots
+  run resolve "sibling/docs/note.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX/ws/org/sibling/docs/note.md" ]
+}
+
+@test "resolve: a repo-relative token from a sibling repo resolves via the sweep" {
+  augment_roots
+  run resolve "docs/note.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX/ws/org/sibling/docs/note.md" ]
+}
+
+@test "negative control: with the sweep disabled, neither token resolves" {
+  QUICKLOOK_PARENT_SWEEP=0
+  augment_roots
+  ! resolve "sibling/docs/note.md"
+  ! resolve "docs/note.md"
+}

--- a/tests/renderers-ipynb.bats
+++ b/tests/renderers-ipynb.bats
@@ -9,6 +9,11 @@ setup() {
   # shellcheck disable=SC1090
   . "$LIB"
 
+  # Same hermetic pin as renderers-office.bats: this suite keeps the real
+  # PATH, so the viewer-palette lookup would leak the host's plugin-root
+  # path into the glow argv echoes.
+  export QUICKLOOK_GLOW_STYLE=auto
+
   FIX="$(cd "$(mktemp -d)" && pwd -P)"
   cat > "$FIX/t.ipynb" <<'JSON'
 {

--- a/tests/renderers-markdown.bats
+++ b/tests/renderers-markdown.bats
@@ -102,6 +102,42 @@ SH
   [[ "$output" == *"GLOW_ARGS:"* ]]
 }
 
+@test "render_markdown: QUICKLOOK_GLOW_STYLE overrides the glow style" {
+  stub_with_glow
+  QUICKLOOK_GLOW_STYLE=dracula run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-s dracula"* ]]
+}
+
+@test "render_markdown: picks up herdr-file-viewer's bundled palette when installed" {
+  stub_with_glow
+  # fake herdr + jq answering the plugin-root lookup, and a palette file at
+  # the viewer's documented asset path.
+  mkdir -p "$STUB/vroot/assets"
+  printf '{}' > "$STUB/vroot/assets/markdown-style.json"
+  cat > "$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '{}'
+SH
+  cat > "$STUB/jq" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "$STUB/vroot"
+SH
+  chmod +x "$STUB/herdr" "$STUB/jq"
+  unset QUICKLOOK_GLOW_STYLE HERDR_BIN_PATH
+  run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-s $STUB/vroot/assets/markdown-style.json"* ]]
+}
+
+@test "render_markdown: no viewer installed falls back to -s auto" {
+  stub_with_glow
+  unset QUICKLOOK_GLOW_STYLE HERDR_BIN_PATH
+  run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-s auto"* ]]
+}
+
 # ---- render_any dispatch: glow-present renders, glow-absent degrades ----
 
 @test "render_any: glow present - a .md file dispatches to the markdown renderer" {

--- a/tests/renderers-office.bats
+++ b/tests/renderers-office.bats
@@ -9,6 +9,13 @@ setup() {
   # shellcheck disable=SC1090
   . "$LIB"
 
+  # This suite keeps the REAL PATH (it needs real pandoc), so the style
+  # lookup would find the host's real herdr-file-viewer palette and leak
+  # its plugin-root path into the glow argv echo the content assertions
+  # grep. Pin the style to keep the suite hermetic; style selection has
+  # its own tests in renderers-markdown.bats.
+  export QUICKLOOK_GLOW_STYLE=auto
+
   FIX="$(cd "$(mktemp -d)" && pwd -P)"
   # A real docx, built by pandoc itself (round-trips cleanly - verified
   # live).


### PR DESCRIPTION
Two zero-config improvements:

1. render_markdown resolves glow's style through _markdown_glow_style:
   QUICKLOOK_GLOW_STYLE when set, else herdr-file-viewer's bundled
   assets/markdown-style.json when that plugin is installed (preview and
   viewer now render markdown with the same palette), else auto.

2. augment_roots (called from load_config) appends the current repo
   root's parents (QUICKLOOK_PARENT_SWEEP levels, default 2, 0 disables)
   to QUICKLOOK_ROOTS, deduped. Every existing roots loop (resolve, the
   dir/github handlers, the subprocess-free pick mirrors) picks the
   implicit roots up unchanged, so side-by-side repo layouts resolve
   cross-repo tokens with no per-machine config.

dirty-diff's no-arg no-op now bails before load_config (augment_roots
forks a git rev-parse, and the no-op must stay free); the office/ipynb
suites pin QUICKLOOK_GLOW_STYLE=auto because they keep the real PATH and
would otherwise leak the host's real viewer palette path into their glow
argv assertions.
