### PR TITLE
feat: installed plugin roots join the implicit workspace roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Installed herdr plugin roots join the implicit workspace roots, so a
+  plugin-relative token (e.g. `assets/markdown-style.json`) resolves into
+  the plugin's checkout under `~/.config/herdr/plugins/`.
+
 - Markdown previews pick up herdr-file-viewer's bundled color palette when
   that plugin is installed, so the preview overlay and the viewer render
   markdown identically; `QUICKLOOK_GLOW_STYLE` (a glow style name or JSON

--- a/scripts/agent-suggest.sh
+++ b/scripts/agent-suggest.sh
@@ -7,12 +7,16 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=scripts/lib.sh
 . "$script_dir/lib.sh"
 
-load_config
+# Env only before the gate: the off mode must exit with ZERO herdr calls
+# (augment_roots makes one for the plugin roots), so roots are augmented
+# only once the mode says this hook will actually do work.
+load_config_env
 mode="${QUICKLOOK_AGENT_SUGGESTIONS:-off}"
 case "$mode" in
   notify | preview) ;;
   *) exit 0 ;;
 esac
+augment_roots
 
 command -v jq >/dev/null 2>&1 || exit 0
 event_json="${HERDR_PLUGIN_EVENT_JSON:-}"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -251,40 +251,63 @@ recents_latest() {
 
 # Optional config: QUICKLOOK_ROOTS, colon-separated extra roots to try for
 # relative paths (e.g. the parent directory holding all your repos).
+# load_config = env + implicit roots. A script whose config gate can decline
+# ALL work (agent-suggest's off mode) calls load_config_env first and
+# augment_roots only past the gate, so the declined path stays subprocess-free.
 load_config() {
+  load_config_env
+  augment_roots
+}
+
+load_config_env() {
   local dir="${HERDR_PLUGIN_CONFIG_DIR:-}"
   [ -n "$dir" ] || dir="$("$herdr_bin" plugin config-dir herdr-quicklook 2>/dev/null)"
   # shellcheck disable=SC1091
   [ -n "$dir" ] && [ -f "$dir/.env" ] && . "$dir/.env"
-  augment_roots
 }
 
-# augment_roots: append the current repo root's parents (1..N levels, N =
-# QUICKLOOK_PARENT_SWEEP, default 2, 0 disables) to QUICKLOOK_ROOTS, deduped.
-# Side-by-side repo layouts (~/ws/<repo>, ~/ws/<org>/<repo>) then resolve
-# cross-repo tokens with ZERO config: every existing roots loop (resolve,
-# dir/github handlers, the pick mirrors) picks the parents up unchanged.
+# _append_root <dir>: append one directory to QUICKLOOK_ROOTS, skipping
+# empties, non-directories, and duplicates. rc 0 always.
+_append_root() {
+  local base="$1" r
+  [ -n "$base" ] && [ -d "$base" ] || return 0
+  local IFS=':'
+  for r in ${QUICKLOOK_ROOTS:-}; do
+    [ "$r" = "$base" ] && return 0
+  done
+  unset IFS
+  QUICKLOOK_ROOTS="${QUICKLOOK_ROOTS:+$QUICKLOOK_ROOTS:}$base"
+}
+
+# augment_roots: append IMPLICIT roots to QUICKLOOK_ROOTS, deduped, so every
+# existing roots loop (resolve, dir/github handlers, the pick mirrors) picks
+# them up unchanged. Two sources:
+#   1. The current repo root's parents (1..N levels, N =
+#      QUICKLOOK_PARENT_SWEEP, default 2, 0 disables): side-by-side repo
+#      layouts (~/ws/<repo>, ~/ws/<org>/<repo>) then resolve cross-repo
+#      tokens with ZERO config.
+#   2. Every installed herdr plugin's own root: a plugin-relative token
+#      (assets/markdown-style.json from a plugin discussion) lives under
+#      ~/.config/herdr/plugins/..., which no workspace parent covers.
 # Still bounded: each added root costs one stat per first-level child, and
 # only on a full miss of every earlier rung.
 augment_roots() {
-  local levels="${QUICKLOOK_PARENT_SWEEP:-2}" base up=0 r found
+  local levels="${QUICKLOOK_PARENT_SWEEP:-2}" base up=0 r
   case "$levels" in '' | *[!0-9]*) levels=2 ;; esac
-  [ "$levels" -eq 0 ] && return 0
-  base="$(git rev-parse --show-toplevel 2>/dev/null)"
-  [ -z "$base" ] && base="$PWD"
-  while [ "$up" -lt "$levels" ]; do
-    base="${base%/*}"
-    up=$((up + 1))
-    [ -n "$base" ] && [ -d "$base" ] || break
-    found=0
-    local IFS=':'
-    for r in ${QUICKLOOK_ROOTS:-}; do
-      [ "$r" = "$base" ] && { found=1; break; }
+  if [ "$levels" -gt 0 ]; then
+    base="$(git rev-parse --show-toplevel 2>/dev/null)"
+    [ -z "$base" ] && base="$PWD"
+    while [ "$up" -lt "$levels" ]; do
+      base="${base%/*}"
+      up=$((up + 1))
+      [ -n "$base" ] && [ -d "$base" ] || break
+      _append_root "$base"
     done
-    unset IFS
-    [ "$found" -eq 1 ] && continue
-    QUICKLOOK_ROOTS="${QUICKLOOK_ROOTS:+$QUICKLOOK_ROOTS:}$base"
-  done
+  fi
+  while IFS= read -r r; do
+    _append_root "$r"
+  done < <("$herdr_bin" plugin list --json 2>/dev/null \
+    | jq -r '.result.plugins[].plugin_root // empty' 2>/dev/null)
   return 0
 }
 

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -91,7 +91,7 @@ else
 fi
 
 [ -z "${target:-}" ] && pause_close "quicklook: not a file I can find: $raw" \
-  "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS, the workspace sweep incl. other repos' worktrees, repo filename search)"
+  "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS incl. implicit parents + plugin roots, the workspace sweep incl. other repos' worktrees, repo filename search)"
 
 record_open "$raw"
 

--- a/tests/parent-sweep.bats
+++ b/tests/parent-sweep.bats
@@ -6,6 +6,9 @@
 # 0 disables) and every existing roots loop picks them up unchanged.
 
 setup() {
+  # herdr_bin binds at source time; point it at a failing binary BEFORE
+  # sourcing so the host's real plugin roots never leak into assertions.
+  export HERDR_BIN_PATH=/usr/bin/false
   LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
   # shellcheck disable=SC1090
   . "$LIB"
@@ -67,4 +70,28 @@ teardown() {
   augment_roots
   ! resolve "sibling/docs/note.md"
   ! resolve "docs/note.md"
+}
+
+@test "augment_roots: installed herdr plugin roots join the implicit set" {
+  STUB="$(mktemp -d)"
+  mkdir -p "$STUB/proot/assets"
+  printf '{}' > "$STUB/proot/assets/style.json"
+  cat > "$STUB/herdr" <<'SH'
+#!/usr/bin/env bash
+printf '{}'
+SH
+  cat > "$STUB/jq" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "$STUB/proot"
+SH
+  chmod +x "$STUB/herdr" "$STUB/jq"
+  herdr_bin="$STUB/herdr"
+  export PATH="$STUB:$PATH"
+  QUICKLOOK_PARENT_SWEEP=0
+  augment_roots
+  [[ ":$QUICKLOOK_ROOTS:" == *":$STUB/proot:"* ]]
+  # a plugin-relative token (the assets/markdown-style.json case) resolves
+  run resolve "assets/style.json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$STUB/proot/assets/style.json" ]
 }


### PR DESCRIPTION
A plugin-relative token (assets/markdown-style.json copied from a plugin
discussion) lives under ~/.config/herdr/plugins/, which no workspace
parent covers, so the preview reported not-found. augment_roots now also
appends every installed plugin's plugin_root (herdr plugin list --json),
deduped via the new _append_root helper.

load_config splits into load_config_env + augment_roots so gated early
exits stay subprocess-free: agent-suggest's off mode asserts zero herdr
calls, and augment_roots now makes one.
