### PR TITLE
feat: bare-filename search widens to sibling repos on a repo miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- The bare-filename fallback (rung 7) widens to the workspace: when the
+  current repo's tracked files have no hit, every first-level child repo of
+  QUICKLOOK_ROOTS is searched (bounded, deduped, current repo skipped), so a
+  cockpit row's bare filename opens from any pane.
+
 - Installed herdr plugin roots join the implicit workspace roots, so a
   plugin-relative token (e.g. `assets/markdown-style.json`) resolves into
   the plugin's checkout under `~/.config/herdr/plugins/`.

--- a/scripts/handlers/bare-name.sh
+++ b/scripts/handlers/bare-name.sh
@@ -13,20 +13,50 @@
 
 match_bare_name() { return 1; }
 
+# _bare_name_sweep <clip_path> <current-root> -> ABSOLUTE-path matches, one
+# per line, from the tracked files of every first-level child repo of every
+# QUICKLOOK_ROOTS entry (implicit parents + plugin roots included), skipping
+# the current repo (already searched). Only runs after the current-repo
+# search found nothing, and stays bounded: one .git stat per child, one
+# ls-files per actual repo, 100 lines total.
+_bare_name_sweep() {
+  local clip_path="$1" cur="$2" r d
+  local IFS=':'
+  for r in ${QUICKLOOK_ROOTS:-}; do
+    [ -n "$r" ] && [ -d "$r" ] || continue
+    for d in "$r"/*/; do
+      d="${d%/}"
+      [ "$d" = "$cur" ] && continue
+      [ -e "$d/.git" ] || continue
+      git -C "$d" ls-files 2>/dev/null | grep -iF -- "$clip_path" \
+        | while IFS= read -r m; do printf '%s/%s\n' "$d" "$m"; done
+    done
+  done | awk '!seen[$0]++' | head -100
+}
+
 # handle_bare_name <clip_path> -> a single or fzf-picked match: sets
-# RESOLVED_TARGET (mode=file) and returns 0. Zero matches, no repo root, or
-# an fzf cancel: returns 1 (caller shows its own "not found"). Multiple
-# matches with no fzf installed: prints the candidate list itself and exits
-# the CALLING SCRIPT directly, exactly matching the pre-refactor inline
-# behavior.
+# RESOLVED_TARGET (mode=file) and returns 0. Searches the current repo's
+# tracked files first; on zero hits there (or no current repo) widens to the
+# workspace sweep above. Zero matches everywhere or an fzf cancel: returns 1
+# (caller shows its own "not found"). Multiple matches with no fzf
+# installed: prints the candidate list itself and exits the CALLING SCRIPT
+# directly, exactly matching the pre-refactor inline behavior.
 handle_bare_name() {
-  local clip_path="$1" root matches n pick
-  root="$(git rev-parse --show-toplevel 2>/dev/null)"
-  [ -z "$root" ] && return 1
-  matches="$(git -C "$root" ls-files 2>/dev/null | grep -iF -- "$clip_path" | head -100)"
+  local clip_path="$1" root matches n pick scope join
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || root=""
+  matches=""
+  scope="this repo"
+  join="$root/"
+  [ -n "$root" ] && matches="$(git -C "$root" ls-files 2>/dev/null | grep -iF -- "$clip_path" | head -100)"
+  if [ -z "$matches" ]; then
+    # widen: sibling repos' tracked files, absolute paths (no join prefix)
+    matches="$(_bare_name_sweep "$clip_path" "$root")"
+    scope="the workspace"
+    join=""
+  fi
   n="$(printf '%s' "$matches" | grep -c . 2>/dev/null)"
   if [ "$n" -eq 1 ]; then
-    RESOLVED_TARGET="$root/$matches"
+    RESOLVED_TARGET="$join$matches"
     RESOLVED_LINE=""
     RESOLVED_MODE="file"
     return 0
@@ -34,12 +64,12 @@ handle_bare_name() {
     if command -v fzf >/dev/null 2>&1; then
       pick="$(printf '%s\n' "$matches" | fzf --prompt="$clip_path ▸ " --reverse --cycle --height=100%)" || exit 0
       [ -z "$pick" ] && return 1
-      RESOLVED_TARGET="$root/$pick"
+      RESOLVED_TARGET="$join$pick"
       RESOLVED_LINE=""
       RESOLVED_MODE="file"
       return 0
     else
-      printf '%s matches "%s" in this repo (install fzf for an interactive pick):\n\n' "$n" "$clip_path"
+      printf '%s matches "%s" in %s (install fzf for an interactive pick):\n\n' "$n" "$clip_path" "$scope"
       printf '%s\n' "$matches"
       printf '\n'
       read -r -n1 -p "press any key to close" _ 2>/dev/null || sleep 2

--- a/tests/bare-name-sweep.bats
+++ b/tests/bare-name-sweep.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# Tests for the bare-name workspace sweep (handlers/bare-name.sh): when the
+# current repo's tracked files have no hit, the fuzzy filename fallback
+# widens to every first-level child repo of QUICKLOOK_ROOTS. Non-interactive
+# paths only (single hit / no hit); the fzf pick is interactive by design.
+
+setup() {
+  export HERDR_BIN_PATH=/usr/bin/false
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/ws/org/repo" "$FIX/ws/org/sibling/docs"
+  git -C "$FIX/ws/org/repo" init -q -b main
+  printf 'local\n' > "$FIX/ws/org/repo/afile.md"
+  git -C "$FIX/ws/org/repo" add -A
+  git -C "$FIX/ws/org/repo" -c user.email=t@t -c user.name=t commit -qm f
+  git -C "$FIX/ws/org/sibling" init -q -b main
+  printf 'remote\n' > "$FIX/ws/org/sibling/docs/uniq-note.md"
+  git -C "$FIX/ws/org/sibling" add -A
+  git -C "$FIX/ws/org/sibling" -c user.email=t@t -c user.name=t commit -qm f
+  cd "$FIX/ws/org/repo"
+  QUICKLOOK_ROOTS="$FIX/ws/org"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+@test "bare-name: a filename tracked only in a sibling repo resolves absolute" {
+  handle_bare_name "uniq-note"
+  [ "$RESOLVED_TARGET" = "$FIX/ws/org/sibling/docs/uniq-note.md" ]
+  [ "$RESOLVED_MODE" = "file" ]
+}
+
+@test "bare-name: a current-repo hit still wins, the sweep never runs" {
+  # same name tracked in BOTH; the current repo's must win as the single hit
+  printf 'shadow\n' > "$FIX/ws/org/sibling/afile.md"
+  git -C "$FIX/ws/org/sibling" add -A
+  git -C "$FIX/ws/org/sibling" -c user.email=t@t -c user.name=t commit -qm s
+  handle_bare_name "afile"
+  [ "$RESOLVED_TARGET" = "$FIX/ws/org/repo/afile.md" ]
+}
+
+@test "bare-name: no hit anywhere returns 1" {
+  ! handle_bare_name "no-such-file-anywhere"
+}
+
+@test "bare-name: outside any repo, the sweep alone still resolves" {
+  mkdir -p "$FIX/ws/nowhere"
+  cd "$FIX/ws/nowhere"
+  QUICKLOOK_ROOTS="$FIX/ws/org"
+  handle_bare_name "uniq-note"
+  [ "$RESOLVED_TARGET" = "$FIX/ws/org/sibling/docs/uniq-note.md" ]
+}


### PR DESCRIPTION
handle_bare_name searched only the current repo's tracked files, so a
bare filename copied from the cockpit (whose file lives in another repo)
was a dead end. On zero current-repo hits (or no current repo at all) it
now sweeps every first-level child repo of QUICKLOOK_ROOTS (implicit
parents + plugin roots included) via _bare_name_sweep: one .git stat per
child, ls-files only for real repos, deduped, capped at 100, absolute
paths so the single-hit and fzf-pick arms need only an empty join prefix.
Current-repo hits keep absolute priority; the sweep never runs then.
