### PR TITLE
fix(hint): trim unmatched wrapping punctuation from scanned spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- The hint scanner trims UNMATCHED wrapping punctuation: prose like
+  `(assets/markdown-style.json copied ...)` splits the opener onto the span
+  with its closer words away, so the token kept a leading `(` and never
+  resolved. An opener with no closer in the span comes off the left, a
+  closer with no opener off the right; spans holding both (`foo(1).md`,
+  wiki-style URLs) stay untouched.
+
 ## 0.5.0 (2026-07-26)
 
 - The bare-filename fallback (rung 7) widens to the workspace: when the

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1211,6 +1211,36 @@ pick_scan_text() {
             s = substr(s, 2, length(s) - 2)
           }
         }
+        # UNMATCHED wrapper: prose like "(assets/style.json copied ...)"
+        # whitespace-splits the opener onto the span with its closer words
+        # away, so the matched rule above never fires. An opener whose
+        # closer never appears in the span comes off the left; a closer
+        # whose opener never appears comes off the right. A span holding
+        # both (foo(1).md, a wiki URL with _(bar)) is untouched.
+        if (length(s) >= 2) {
+          first = substr(s, 1, 1)
+          if ((first == "(" && index(s, ")") == 0) ||
+              (first == "[" && index(s, "]") == 0) ||
+              (first == "{" && index(s, "}") == 0) ||
+              (first == "<" && index(s, ">") == 0) ||
+              (first == dq && index(substr(s, 2), dq) == 0) ||
+              (first == sq && index(substr(s, 2), sq) == 0) ||
+              (first == bq && index(substr(s, 2), bq) == 0)) {
+            s = substr(s, 2)
+          }
+        }
+        if (length(s) >= 2) {
+          last = substr(s, length(s), 1)
+          if ((last == ")" && index(s, "(") == 0) ||
+              (last == "]" && index(s, "[") == 0) ||
+              (last == "}" && index(s, "{") == 0) ||
+              (last == ">" && index(s, "<") == 0) ||
+              (last == dq && index(substr(s, 1, length(s) - 1), dq) == 0) ||
+              (last == sq && index(substr(s, 1, length(s) - 1), sq) == 0) ||
+              (last == bq && index(substr(s, 1, length(s) - 1), bq) == 0)) {
+            s = substr(s, 1, length(s) - 1)
+          }
+        }
         if (s == prev) break
       }
       return s

--- a/tests/pick-scan.bats
+++ b/tests/pick-scan.bats
@@ -38,6 +38,21 @@ teardown() {
   [ "$output" = "$(printf 'sub/inrepo.md\tpath\t1')" ]
 }
 
+@test "pick_scan_text: an unmatched leading paren comes off (prose wrapping splits the closer away)" {
+  run pick_scan_text <<<'see (sub/inrepo.md copied from the discussion)'
+  [[ "$output" == *"$(printf 'sub/inrepo.md\tpath\t1')"* ]]
+}
+
+@test "pick_scan_text: an unmatched trailing paren comes off" {
+  run pick_scan_text <<<'(the file is sub/inrepo.md)'
+  [[ "$output" == *"$(printf 'sub/inrepo.md\tpath\t1')"* ]]
+}
+
+@test "pick_scan_text: a span holding BOTH parens keeps them (wiki-style URL)" {
+  run pick_scan_text <<<'https://en.wikipedia.org/wiki/Foo_(bar) explains it'
+  [[ "$output" == *"$(printf 'https://en.wikipedia.org/wiki/Foo_(bar)\turl\t1')"* ]]
+}
+
 @test "pick_scan_text: a generic URL -> kind url" {
   run pick_scan_text <<<'see https://example.com/a/b for docs'
   [ "$output" = "$(printf 'https://example.com/a/b\turl\t1')" ]


### PR DESCRIPTION
The trimmer only stripped MATCHED wrappers, so a paren opened on one
word and closed words later left the token with a leading '(' that no
resolution rung could hit; the same token pasted clean from the
clipboard worked, which is exactly the reported asymmetry. Openers with
no closer in-span come off the left, closers with no opener off the
right, iterated with the existing rules until stable.
