### PR TITLE
feat(render): terminal-native bat theme, framed code, colored json

### DIFF
--- a/config.example
+++ b/config.example
@@ -23,6 +23,11 @@
 # plugin is installed (so preview and viewer look identical), else "auto".
 #QUICKLOOK_GLOW_STYLE=
 
+# QUICKLOOK_BAT_THEME: bat theme for code/text previews (and the find pane's
+# fzf preview). Default "ansi" renders with the terminal's own 16 colors so
+# code matches your pane theme; any `bat --list-themes` name works.
+#QUICKLOOK_BAT_THEME=ansi
+
 # QUICKLOOK_EDITOR: command launched by `e` in the preview overlay, at the
 # current file+line. Precedence: this key > $EDITOR > "zed --wait". Set this
 # instead of (or in addition to) exporting $EDITOR in your shell: the herdr

--- a/scripts/find-pane.sh
+++ b/scripts/find-pane.sh
@@ -43,7 +43,8 @@ list_files() {
   fi
 }
 
-preview_cmd='bat --color=always --style=numbers {} 2>/dev/null || cat {} 2>/dev/null'
+# Same theme rule as text.sh: terminal-native ansi theme unless overridden.
+preview_cmd="bat --color=always --theme=${QUICKLOOK_BAT_THEME:-ansi} --style=numbers {} 2>/dev/null || cat {} 2>/dev/null"
 command -v bat >/dev/null 2>&1 || preview_cmd='cat {} 2>/dev/null'
 
 # QUICKLOOK_FIND_QUERY pre-seeds the fzf query: the hint flow drops an

--- a/scripts/renderers/json.sh
+++ b/scripts/renderers/json.sh
@@ -29,5 +29,7 @@ match_render_json() {
 # of a render - an honest degrade, not a crash.
 render_json() {
   local path="$1"
-  render_command_in_pager jq . -- "$path"
+  # -C: jq drops color when piped (the pager pipeline); force it, less -R
+  # already renders it.
+  render_command_in_pager jq -C . -- "$path"
 }

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -31,7 +31,11 @@ render_text() {
   # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
   export QUICKLOOK_EDITOR_SCRIPT="$LIB_DIR/escalate-editor.sh"
   if command -v bat >/dev/null 2>&1; then
-    export LESSOPEN='|bat --color=always --style=numbers %s'
+    # ansi theme = the terminal's own 16 colors, so code matches the pane
+    # theme (and the viewer) instead of bat's 256-color default; grid +
+    # header frame the file like the viewer does. QUICKLOOK_BAT_THEME
+    # overrides (any `bat --list-themes` name).
+    export LESSOPEN="|bat --color=always --theme=${QUICKLOOK_BAT_THEME:-ansi} --style=numbers,header,grid %s"
     exec less -R "${lesskey_args[@]}" ${line:++$line} "$target"
   fi
   exec less -N "${lesskey_args[@]}" ${line:++$line} "$target"

--- a/tests/renderers-json.bats
+++ b/tests/renderers-json.bats
@@ -132,5 +132,15 @@ SH
   printf '{"a":1}' > "$FIX/mini.json"
   run bash -c ". '$LIB'; render_json '$FIX/mini.json'"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'"a": 1'* ]]
+  # -C forces color even piped; strip ANSI before the content assertion
+  plain="$(printf '%s' "$output" | sed $'s/\x1b\[[0-9;]*m//g')"
+  [[ "$plain" == *'"a": 1'* ]]
+}
+
+@test "render_json: color is forced through the pager pipe (-C in argv)" {
+  _stub_jq
+  export PATH="$STUB:$PATH"
+  run bash -c ". '$LIB'; render_json '$FIX/t.json'"
+  [ "$status" -eq 0 ]
+  grep -qx -- '-C' "$JQ_ARGV_FILE"
 }


### PR DESCRIPTION
bat ran with its 256-color default theme, clashing with the terminal
palette; the ansi theme uses the terminal's own 16 colors so code matches
the pane and the viewer (QUICKLOOK_BAT_THEME overrides, any bat theme
name). style gains header,grid for the viewer-like frame. find-pane's
fzf preview follows the same theme rule. jq drops color when piped, so
render_json forces -C; less -R already renders it.
