### PR TITLE
fix(render): inherit bat config theme for true viewer parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Viewer display parity for code: the bat theme pin is gone, so the user's
+  own bat config decides the theme in BOTH panes (exactly how
+  herdr-file-viewer invokes bat); QUICKLOOK_BAT_THEME now only adds a
+  --theme flag when explicitly set. Renderer subprocesses get
+  CLICOLOR_FORCE=1 (the viewer's trick) so piped tools keep full color.
+  Code style is numbers,header (the viewer's gutter + a filename header).
+
 - The hint scanner trims UNMATCHED wrapping punctuation: prose like
   `(assets/markdown-style.json copied ...)` splits the opener onto the span
   with its closer words away, so the token kept a leading `(` and never

--- a/config.example
+++ b/config.example
@@ -23,10 +23,12 @@
 # plugin is installed (so preview and viewer look identical), else "auto".
 #QUICKLOOK_GLOW_STYLE=
 
-# QUICKLOOK_BAT_THEME: bat theme for code/text previews (and the find pane's
-# fzf preview). Default "ansi" renders with the terminal's own 16 colors so
-# code matches your pane theme; any `bat --list-themes` name works.
-#QUICKLOOK_BAT_THEME=ansi
+# QUICKLOOK_BAT_THEME: bat theme override for code/text previews (and the
+# find pane's fzf preview). UNSET (the default), no --theme flag is passed
+# and your own bat config decides, exactly like herdr-file-viewer, so the
+# two panes stay color-identical. Set only to intentionally diverge; any
+# `bat --list-themes` name works.
+#QUICKLOOK_BAT_THEME=
 
 # QUICKLOOK_EDITOR: command launched by `e` in the preview overlay, at the
 # current file+line. Precedence: this key > $EDITOR > "zed --wait". Set this

--- a/scripts/find-pane.sh
+++ b/scripts/find-pane.sh
@@ -43,8 +43,11 @@ list_files() {
   fi
 }
 
-# Same theme rule as text.sh: terminal-native ansi theme unless overridden.
-preview_cmd="bat --color=always --theme=${QUICKLOOK_BAT_THEME:-ansi} --style=numbers {} 2>/dev/null || cat {} 2>/dev/null"
+# Same theme rule as text.sh: the user's bat config decides (viewer parity);
+# QUICKLOOK_BAT_THEME adds a --theme flag only when explicitly set.
+bat_theme_flag=""
+[ -n "${QUICKLOOK_BAT_THEME:-}" ] && bat_theme_flag="--theme=${QUICKLOOK_BAT_THEME} "
+preview_cmd="bat --color=always ${bat_theme_flag}--style=numbers {} 2>/dev/null || cat {} 2>/dev/null"
 command -v bat >/dev/null 2>&1 || preview_cmd='cat {} 2>/dev/null'
 
 # QUICKLOOK_FIND_QUERY pre-seeds the fzf query: the hint flow drops an

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -595,7 +595,11 @@ unset _herdr_renderer
 render_command_in_pager() {
   local lesskey_args=()
   [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
-  "$@" 2>&1 | less -R "${lesskey_args[@]}"
+  # CLICOLOR_FORCE=1: same trick herdr-file-viewer applies to every renderer
+  # subprocess - termenv-based tools (glow/glamour) drop to a no-color
+  # profile when stdout is a pipe even with an explicit style; harmless to
+  # bat/delta/jq, which force color via their own flags.
+  CLICOLOR_FORCE=1 "$@" 2>&1 | less -R "${lesskey_args[@]}"
 }
 
 # resolve_any_token <raw> -> see the handler-registry contract at the top of

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -31,11 +31,16 @@ render_text() {
   # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
   export QUICKLOOK_EDITOR_SCRIPT="$LIB_DIR/escalate-editor.sh"
   if command -v bat >/dev/null 2>&1; then
-    # ansi theme = the terminal's own 16 colors, so code matches the pane
-    # theme (and the viewer) instead of bat's 256-color default; grid +
-    # header frame the file like the viewer does. QUICKLOOK_BAT_THEME
-    # overrides (any `bat --list-themes` name).
-    export LESSOPEN="|bat --color=always --theme=${QUICKLOOK_BAT_THEME:-ansi} --style=numbers,header,grid %s"
+    # Display parity with herdr-file-viewer, which runs bat with NO theme
+    # flag so the user's own bat config decides (Han's pins TwoDark with a
+    # "both panes read this" note). Pinning a theme here would override
+    # that config and un-sync the panes, so QUICKLOOK_BAT_THEME adds a
+    # --theme flag ONLY when explicitly set. style=numbers,header: the
+    # viewer's numbers gutter, plus a filename header standing in for the
+    # viewer's own title UI.
+    local theme_flag=""
+    [ -n "${QUICKLOOK_BAT_THEME:-}" ] && theme_flag="--theme=${QUICKLOOK_BAT_THEME} "
+    export LESSOPEN="|bat --color=always ${theme_flag}--style=numbers,header %s"
     exec less -R "${lesskey_args[@]}" ${line:++$line} "$target"
   fi
   exec less -N "${lesskey_args[@]}" ${line:++$line} "$target"

--- a/tests/renderers-text-theme.bats
+++ b/tests/renderers-text-theme.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# render_text theme contract (viewer display parity): NO --theme flag by
+# default so the user's own bat config decides (same as herdr-file-viewer's
+# bare `bat -`); QUICKLOOK_BAT_THEME adds one only when explicitly set.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf 'plain text\n' > "$FIX/doc.txt"
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/bat"
+  # less is exec'd by render_text; print the LESSOPEN it inherited
+  printf '#!/usr/bin/env bash\nprintf "LESSOPEN=%%s\\n" "$LESSOPEN"\n' > "$STUB/less"
+  chmod +x "$STUB/bat" "$STUB/less"
+  export PATH="$STUB:/usr/bin:/bin"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+@test "render_text: no theme flag by default (bat config decides, like the viewer)" {
+  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers,header"* ]]
+  [[ "$output" != *"--theme"* ]]
+}
+
+@test "render_text: QUICKLOOK_BAT_THEME adds an explicit --theme flag" {
+  run bash -c "export QUICKLOOK_BAT_THEME=zenburn; . '$LIB'; render_text '$FIX/doc.txt'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--theme=zenburn"* ]]
+}


### PR DESCRIPTION
The ansi pin from #54 overrode the user's bat config (TwoDark, whose
own comment says both panes read it to stay color-identical), which
un-synced the panes. The viewer runs bat with NO theme flag, so parity
means none here either: QUICKLOOK_BAT_THEME adds one only when set.
Also: CLICOLOR_FORCE=1 on render_command_in_pager subprocesses (the
viewer sets it on every renderer spawn; termenv tools drop color on a
pipe even with an explicit style), and style narrows to numbers,header
(the viewer has no grid).
