### PR TITLE
fix: apply session review-lens findings, perf + tests + notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Review-batch fixes (advisor + security/architecture/test lenses over the
+  session): escalate-editor/find-pane/recents-pane load env-only config (no
+  wasted git+herdr forks); augment_roots' one plugin-list fork also captures
+  the viewer root so render_markdown never re-queries; the cross-repo viewer
+  re-root notifies where it rooted; bat theme flag shared via _bat_theme_flag;
+  the not-found message mentions the workspace filename search; hint-pane's
+  tty fallback probes openability (bare -r passes with no controlling tty).
+  New tests: hint-pane bottom-align (headless stty stub), glow -w width,
+  CLICOLOR_FORCE, viewer re-root failure + :line goto, oversized sweep guard.
+
 - The hint overlay bottom-aligns the snapshot: the origin pane anchors its
   content to the bottom rows, so a snapshot shorter than the overlay pads
   blank rows on TOP instead of floating up and leaving a blank band below.

--- a/config.example
+++ b/config.example
@@ -14,7 +14,10 @@
 # QUICKLOOK_PARENT_SWEEP: how many parent levels of the current repo root are
 # added as IMPLICIT roots (side-by-side repo layouts then resolve cross-repo
 # tokens with zero config). Default 2 (parent + grandparent); 0 disables,
-# leaving only the explicit QUICKLOOK_ROOTS above.
+# leaving only the explicit QUICKLOOK_ROOTS above. Depth-shape-sensitive:
+# 2 fits ws/<org>/<repo> layouts; if your repos sit DIRECTLY under the
+# workspace root (ws/<repo>), set 1 so the sweep stops at the workspace
+# instead of reaching one level above it.
 #QUICKLOOK_PARENT_SWEEP=2
 
 # QUICKLOOK_GLOW_STYLE: glow style for markdown previews, a glow style name

--- a/scripts/escalate-editor.sh
+++ b/scripts/escalate-editor.sh
@@ -17,7 +17,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=scripts/lib.sh
 . "$script_dir/lib.sh"
 
-load_config
+# env only: this runs on every `e` keypress and reads QUICKLOOK_EDITOR,
+# never roots; augment_roots' git+herdr forks would be pure latency here.
+load_config_env
 
 line=""
 file=""

--- a/scripts/find-pane.sh
+++ b/scripts/find-pane.sh
@@ -16,7 +16,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck disable=SC1091
 . "$script_dir/lib.sh"
 
-load_config
+# env only: this pane resolves nothing itself; it execs preview-pane.sh,
+# which runs the full load_config (roots) in the child anyway.
+load_config_env
 
 if [ -n "${QUICKLOOK_FIND_CWD:-}" ] && [ -d "$QUICKLOOK_FIND_CWD" ]; then
   cd "$QUICKLOOK_FIND_CWD" || true
@@ -43,11 +45,9 @@ list_files() {
   fi
 }
 
-# Same theme rule as text.sh: the user's bat config decides (viewer parity);
-# QUICKLOOK_BAT_THEME adds a --theme flag only when explicitly set.
-bat_theme_flag=""
-[ -n "${QUICKLOOK_BAT_THEME:-}" ] && bat_theme_flag="--theme=${QUICKLOOK_BAT_THEME} "
-preview_cmd="bat --color=always ${bat_theme_flag}--style=numbers {} 2>/dev/null || cat {} 2>/dev/null"
+# Theme rule shared with text.sh via lib.sh's _bat_theme_flag: the user's
+# bat config decides unless QUICKLOOK_BAT_THEME is explicitly set.
+preview_cmd="bat --color=always $(_bat_theme_flag)--style=numbers {} 2>/dev/null || cat {} 2>/dev/null"
 command -v bat >/dev/null 2>&1 || preview_cmd='cat {} 2>/dev/null'
 
 # QUICKLOOK_FIND_QUERY pre-seeds the fzf query: the hint flow drops an

--- a/scripts/hint-pane.sh
+++ b/scripts/hint-pane.sh
@@ -47,8 +47,10 @@ cleanup() {
   [ -n "$snap_file" ] && rm -f "$snap_file" 2>/dev/null
 }
 
+# -r passes on /dev/tty even with no controlling terminal (the open is what
+# fails, "Device not configured"), so probe by actually opening it.
 tty_in=/dev/tty
-[ -r "$tty_in" ] || tty_in=/dev/stdin
+{ : <"$tty_in"; } 2>/dev/null || tty_in=/dev/stdin
 
 wait_close() {
   printf '%s\n\n(press any key to close)' "$*"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -266,6 +266,15 @@ load_config_env() {
   [ -n "$dir" ] && [ -f "$dir/.env" ] && . "$dir/.env"
 }
 
+# _bat_theme_flag -> "--theme=<name> " (trailing space) when
+# QUICKLOOK_BAT_THEME is set, else "". Shared by text.sh's LESSOPEN and
+# find-pane.sh's fzf preview so the viewer-parity rule (no flag by default,
+# the user's bat config decides) lives in exactly one place.
+_bat_theme_flag() {
+  [ -n "${QUICKLOOK_BAT_THEME:-}" ] && printf -- '--theme=%s ' "$QUICKLOOK_BAT_THEME"
+  return 0
+}
+
 # _append_root <dir>: append one directory to QUICKLOOK_ROOTS, skipping
 # empties, non-directories, and duplicates. rc 0 always.
 _append_root() {
@@ -304,10 +313,15 @@ augment_roots() {
       _append_root "$base"
     done
   fi
-  while IFS= read -r r; do
+  # One fork serves two consumers: every plugin_root joins the roots, and
+  # the file-viewer's root is captured for _markdown_glow_style so the
+  # markdown renderer never re-runs this same herdr+jq query per render.
+  local pid
+  while IFS=$'\t' read -r pid r; do
     _append_root "$r"
+    [ "$pid" = "herdr-file-viewer" ] && QUICKLOOK_VIEWER_ROOT="$r"
   done < <("$herdr_bin" plugin list --json 2>/dev/null \
-    | jq -r '.result.plugins[].plugin_root // empty' 2>/dev/null)
+    | jq -r '.result.plugins[] | [.plugin_id, .plugin_root // empty] | @tsv' 2>/dev/null)
   return 0
 }
 

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -103,6 +103,10 @@ if [ -z "$root" ] || { [ "$target" != "$root" ] && [[ "$target" != "$root"/* ]];
   root="$(git -C "$tdir" rev-parse --show-toplevel 2>/dev/null)"
   [ -z "$root" ] && root="$tdir"
   viewer_cwd="$root"
+  # Scope just widened silently otherwise: an on-screen token is about to
+  # drive a navigable viewer OUTSIDE the repo the user is standing in, so
+  # say where it re-rooted (security-lens finding, session review).
+  notify "viewer re-rooted at $root (outside this repo)"
 fi
 rel="${target#"$root"/}"
 [ "$rel" = "$target" ] && rel=""

--- a/scripts/preview-pane.sh
+++ b/scripts/preview-pane.sh
@@ -91,7 +91,7 @@ else
 fi
 
 [ -z "${target:-}" ] && pause_close "quicklook: not a file I can find: $raw" \
-  "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS incl. implicit parents + plugin roots, the workspace sweep incl. other repos' worktrees, repo filename search)"
+  "(tried as-is, \$PWD, this repo's worktrees, QUICKLOOK_ROOTS incl. implicit parents + plugin roots, the workspace sweep incl. other repos' worktrees, repo filename search, then the workspace's filename search)"
 
 record_open "$raw"
 

--- a/scripts/recents-pane.sh
+++ b/scripts/recents-pane.sh
@@ -18,7 +18,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck disable=SC1091
 . "$script_dir/lib.sh"
 
-load_config
+# env only: this pane resolves nothing itself; the open step execs a
+# script that runs the full load_config (roots) in the child anyway.
+load_config_env
 
 # Enter the origin repo (forwarded as env, never --cwd: --cwd flash-closes
 # the pane) so a relative recents entry resolves against the right repo.

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -39,9 +39,16 @@ _markdown_glow_style() {
     printf '%s' "$QUICKLOOK_GLOW_STYLE"
     return 0
   fi
-  local vroot
-  vroot="$("${HERDR_BIN_PATH:-herdr}" plugin list --json 2>/dev/null \
-    | jq -r '.result.plugins[] | select(.plugin_id == "herdr-file-viewer") | .plugin_root // empty' 2>/dev/null)"
+  # augment_roots (load_config) already captured the viewer root from its
+  # own plugin-list fork; querying again here would pay the same herdr+jq
+  # cost twice per render. The query below is only the fallback for callers
+  # that never ran load_config (tests sourcing lib.sh directly).
+  local vroot="${QUICKLOOK_VIEWER_ROOT:-}"
+  if [ -z "$vroot" ]; then
+    # shellcheck disable=SC2154  # herdr_bin is set by lib.sh before this file is sourced
+    vroot="$("$herdr_bin" plugin list --json 2>/dev/null \
+      | jq -r '.result.plugins[] | select(.plugin_id == "herdr-file-viewer") | .plugin_root // empty' 2>/dev/null)"
+  fi
   if [ -n "$vroot" ] && [ -f "$vroot/assets/markdown-style.json" ]; then
     printf '%s' "$vroot/assets/markdown-style.json"
     return 0

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -38,9 +38,8 @@ render_text() {
     # --theme flag ONLY when explicitly set. style=numbers,header: the
     # viewer's numbers gutter, plus a filename header standing in for the
     # viewer's own title UI.
-    local theme_flag=""
-    [ -n "${QUICKLOOK_BAT_THEME:-}" ] && theme_flag="--theme=${QUICKLOOK_BAT_THEME} "
-    export LESSOPEN="|bat --color=always ${theme_flag}--style=numbers,header %s"
+    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers,header %s"
+    export LESSOPEN
     exec less -R "${lesskey_args[@]}" ${line:++$line} "$target"
   fi
   exec less -N "${lesskey_args[@]}" ${line:++$line} "$target"

--- a/tests/handlers-dir.bats
+++ b/tests/handlers-dir.bats
@@ -33,6 +33,9 @@ if [ "\$1" = "plugin" ] && [ "\$2" = "action" ] && [ "\$3" = "list" ]; then
   [ "\${HERDR_VIEWER_INSTALLED:-0}" = "1" ] && exit 0
   exit 1
 fi
+if [ "\$1" = "plugin" ] && [ "\$2" = "pane" ] && [ "\$3" = "open" ]; then
+  [ "\${HERDR_PANE_OPEN_FAIL:-0}" = "1" ] && exit 1
+fi
 exit 0
 HERDR
   chmod +x "$STUB/herdr"
@@ -211,4 +214,30 @@ teardown() {
   grep -qF -- "--cwd $FIX/sibling" "$HLOG"
   grep -qF "pane send-text STUBPANE docs/note.md" "$HLOG"
   grep -qF "pane send-keys STUBPANE Enter" "$HLOG"
+  # the re-root is announced, never silent (scope widened outside the repo)
+  grep -q "notification show quicklook --body viewer re-rooted at" "$HLOG"
+}
+
+@test "a sibling-repo file WITH a line number re-roots and sends the :N goto" {
+  mkdir -p "$FIX/sibling/docs"
+  git -C "$FIX/sibling" init -q -b main 2>/dev/null || true
+  printf 'x\ny\nz\n' > "$FIX/sibling/docs/lined.md"
+  export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_TOKEN="$FIX/sibling/docs/lined.md:7"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -qF -- "--cwd $FIX/sibling" "$HLOG"
+  grep -qF "pane send-text STUBPANE docs/lined.md" "$HLOG"
+  grep -qF "pane send-text STUBPANE :" "$HLOG"
+  grep -qF "pane send-text STUBPANE 7" "$HLOG"
+}
+
+@test "cross-repo re-root: a failing pane open notifies and exits 1" {
+  export HERDR_VIEWER_INSTALLED=1
+  export HERDR_PANE_OPEN_FAIL=1
+  export QUICKLOOK_TOKEN="$FIX/outside/adir"
+  run bash "$VIEWER"
+  [ "$status" -eq 1 ]
+  grep -q "notification show quicklook --body file viewer did not open (cross-repo)" "$HLOG"
+  ! grep -q "pane send-text" "$HLOG"
 }

--- a/tests/hint-pane.bats
+++ b/tests/hint-pane.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# Script-level tests for hint-pane.sh's bottom-align paint: a snapshot
+# SHORTER than the overlay pads blank rows on TOP (the origin pane anchors
+# content to the bottom), never floats up leaving a blank band below. Headless:
+# `rows` comes from `stty size <$tty_in` and stty resolves via PATH, so a
+# stub stty pins the overlay height; /dev/tty is unreadable under bats so
+# tty_in falls back to /dev/stdin, and a piped `q` exits the key loop.
+
+setup() {
+  export HERDR_BIN_PATH=/usr/bin/false
+  PANE="$BATS_TEST_DIRNAME/../scripts/hint-pane.sh"
+
+  SNAP="$(mktemp)"
+  TOK="$(mktemp)"
+  printf 'open sub/inrepo.md now\nline two\nline three\nline four\nline five\n' > "$SNAP"
+  printf 'sub/inrepo.md\t1\t\tsub/inrepo.md\n' > "$TOK"
+  export QUICKLOOK_HINT_SNAP_FILE="$SNAP"
+  export QUICKLOOK_HINT_TOKENS_FILE="$TOK"
+
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nprintf "24 80\\n"\n' > "$STUB/stty"
+  chmod +x "$STUB/stty"
+  export PATH="$STUB:/usr/bin:/bin"
+}
+
+teardown() {
+  rm -rf "$STUB" 2>/dev/null
+  # SNAP/TOK are deleted by the pane's own cleanup
+}
+
+@test "hint-pane: a short snapshot is bottom-aligned (pad rows on top, none below)" {
+  run bash "$PANE" <<<'q'
+  [ "$status" -eq 0 ]
+  # 24 rows - 5 snapshot lines = 19 blank pad rows between HOME and the
+  # first dimmed snapshot line, in the first paint. printf -v, not $(...):
+  # command substitution strips the trailing newlines the pad IS made of.
+  local pad
+  printf -v pad '\n%.0s' {1..19}
+  expected=$'\033[H'"${pad}"$'\033[2;90m'
+  [[ "$output" == *"$expected"* ]]
+  # the old top-aligned form (content directly after HOME) must be gone
+  bad=$'\033[H\033[2;90m'
+  [[ "$output" != *"$bad"* ]]
+}
+
+@test "hint-pane: a snapshot as tall as the overlay gets no pad" {
+  # 24 lines exactly fills rows=24: content starts right after HOME
+  for i in $(seq 1 24); do printf 'row %s\n' "$i"; done > "$SNAP"
+  run bash "$PANE" <<<'q'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'\033[H\033[2;90m'* ]]
+}

--- a/tests/parent-sweep.bats
+++ b/tests/parent-sweep.bats
@@ -51,6 +51,15 @@ teardown() {
   [ "$QUICKLOOK_ROOTS" = "$FIX/ws/org:$FIX/ws" ]
 }
 
+@test "augment_roots: an oversized sweep stops at the filesystem root, no empty segments" {
+  QUICKLOOK_PARENT_SWEEP=99
+  augment_roots
+  [ -n "$QUICKLOOK_ROOTS" ]
+  [[ "$QUICKLOOK_ROOTS" != *"::"* ]]
+  [[ "$QUICKLOOK_ROOTS" != :* ]]
+  [[ "$QUICKLOOK_ROOTS" != *: ]]
+}
+
 @test "resolve: an org-prefixed cross-repo token resolves with zero config" {
   augment_roots
   run resolve "sibling/docs/note.md"
@@ -82,7 +91,7 @@ printf '{}'
 SH
   cat > "$STUB/jq" <<SH
 #!/usr/bin/env bash
-printf '%s\n' "$STUB/proot"
+printf 'herdr-file-viewer\t%s\n' "$STUB/proot"
 SH
   chmod +x "$STUB/herdr" "$STUB/jq"
   herdr_bin="$STUB/herdr"

--- a/tests/renderers-json.bats
+++ b/tests/renderers-json.bats
@@ -144,3 +144,9 @@ SH
   [ "$status" -eq 0 ]
   grep -qx -- '-C' "$JQ_ARGV_FILE"
 }
+
+@test "render_command_in_pager: exports CLICOLOR_FORCE=1 to the renderer subprocess" {
+  run bash -c ". '$LIB'; render_command_in_pager bash -c 'printf \"CF=%s\n\" \"\${CLICOLOR_FORCE:-unset}\"'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CF=1"* ]]
+}

--- a/tests/renderers-markdown.bats
+++ b/tests/renderers-markdown.bats
@@ -138,6 +138,22 @@ SH
   [[ "$output" == *"-s auto"* ]]
 }
 
+@test "render_markdown: always passes an explicit -w width to glow" {
+  stub_with_glow
+  run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ -w\ [0-9]+ ]]
+}
+
+@test "render_markdown: -w carries the measured TTY width (stubbed tput)" {
+  stub_with_glow
+  printf '#!/usr/bin/env bash\nprintf "132\\n"\n' > "$STUB/tput"
+  chmod +x "$STUB/tput"
+  run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-w 132"* ]]
+}
+
 # ---- render_any dispatch: glow-present renders, glow-absent degrades ----
 
 @test "render_any: glow present - a .md file dispatches to the markdown renderer" {


### PR DESCRIPTION
Advisor/security/architecture/test-coverage batch:
- load_config_env in escalate-editor.sh (per-keypress path), find-pane.sh,
  recents-pane.sh (both exec a child that reloads config; roots were
  throwaway) - augment_roots' forks stay off paths that never use roots.
- augment_roots emits plugin_id+root TSV and captures QUICKLOOK_VIEWER_ROOT,
  so _markdown_glow_style reads it instead of re-forking herdr+jq per
  markdown render (fallback query kept for direct lib sourcing).
- open-in-viewer notifies 'viewer re-rooted at <root>' when the target sits
  outside the focused repo (silent scope-widening, security lens).
- _bat_theme_flag shared helper replaces the duplicated flag build.
- preview-pane not-found message now names the workspace filename search.
- hint-pane tty_in probes openability; [ -r /dev/tty ] passes without a
  controlling terminal and stty then read rows=0 (found by the new test).
- tests: hint-pane bottom-align pad (stty stub, headless), pad-less exact
  -fit control, glow -w present + stubbed-tput width, CLICOLOR_FORCE=1
  through render_command_in_pager, cross-repo pane-open failure branch,
  sibling file with :N goto, re-root notify, PARENT_SWEEP=99 root-walk
  guard.
