### PR TITLE
fix(dir): open the viewer for directories picked in the hint overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- A DIRECTORY picked from the hint overlay opens the real file viewer again
+  instead of a tree listing in the popup. The herdr server often runs with a
+  minimal PATH, so a bare `herdr` is unreachable from the panes and actions
+  it spawns; the dir handler's viewer gate then failed silently and downgraded
+  the pick. lib.sh now resolves herdr_bin to an absolute install path when
+  PATH cannot see it (and exports it to exec'd children), and the hint action
+  answers the gate in its own context, passing QUICKLOOK_VIEWER_OK into the
+  overlay so the routing decision needs no pane-side RPC at all.
+
 - Review-batch fixes (advisor + security/architecture/test lenses over the
   session): escalate-editor/find-pane/recents-pane load env-only config (no
   wasted git+herdr forks); augment_roots' one plugin-list fork also captures

--- a/scripts/handlers/dir.sh
+++ b/scripts/handlers/dir.sh
@@ -57,8 +57,16 @@ _resolve_dir() {
 
 # _dir_viewer_available -> rc 0 if herdr-file-viewer is installed, the same
 # check open-in-viewer.sh's own soft-dependency gate uses.
+# QUICKLOOK_VIEWER_OK short-circuits the RPC: the hint ACTION already ran
+# this check in its own context and passes the answer into the overlay pane,
+# so a pane that cannot reach `herdr` still routes a directory correctly
+# (and every pick saves a round trip).
 # shellcheck disable=SC2154  # herdr_bin is set by lib.sh before this file is sourced
 _dir_viewer_available() {
+  case "${QUICKLOOK_VIEWER_OK:-}" in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
   "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1
 }
 

--- a/scripts/hint.sh
+++ b/scripts/hint.sh
@@ -115,11 +115,19 @@ fi
   rm -f "$raw_file" 2>/dev/null
 ) &
 
+# Answer the viewer gate HERE, in the action's own context, and hand the
+# result to the overlay: the pane may not be able to reach `herdr` at all
+# (minimal server PATH), and a failed gate silently downgrades a directory
+# pick from the real file viewer to a tree listing in the popup.
+viewer_ok=0
+"$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1 && viewer_ok=1
+
 set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint hint-pane \
   --placement overlay \
   --focus \
+  --env "QUICKLOOK_VIEWER_OK=$viewer_ok" \
   --env "QUICKLOOK_HINT_TOKENS_FILE=$tokens_file" \
   --env "QUICKLOOK_HINT_SNAP_FILE=$snap_file"
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -147,7 +147,31 @@
 # file); no other renderer touches it.
 # -----------------------------------------------------------------------
 
+# herdr_bin: HERDR_BIN_PATH (herdr's own convention) wins, else a bare
+# `herdr` off PATH. The bare name is NOT safe to assume inside a pane: the
+# server is often launched with a minimal PATH (measured on macOS:
+# /usr/bin:/bin:/usr/sbin:/sbin, no /opt/homebrew/bin), and every pane and
+# action it spawns inherits that. A plugin script that cannot reach `herdr`
+# does not fail loudly - it silently loses the .env, the plugin roots, and
+# the dir-handler's viewer gate, so a DIRECTORY degrades to a tree listing
+# in the popup instead of opening the real file viewer. Probe once here and
+# fall back to the usual install locations so pane context matches shell
+# context.
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
+if ! command -v "$herdr_bin" >/dev/null 2>&1; then
+  for _herdr_cand in \
+    /opt/homebrew/bin/herdr \
+    /usr/local/bin/herdr \
+    "$HOME/.cargo/bin/herdr" \
+    "$HOME/.local/bin/herdr"; do
+    if [ -x "$_herdr_cand" ]; then
+      herdr_bin="$_herdr_cand"
+      export HERDR_BIN_PATH="$_herdr_cand" # children (exec'd scripts) inherit it
+      break
+    fi
+  done
+  unset _herdr_cand
+fi
 
 clip_read() {
   if command -v pbpaste >/dev/null 2>&1; then pbpaste

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -20,7 +20,10 @@ load_config
 
 # Soft dependency: without herdr-file-viewer this action degrades to the
 # preview overlay instead of failing, so the binding still does something useful.
-if ! "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1; then
+# Same gate as dir.sh's (sourced via lib.sh), so the QUICKLOOK_VIEWER_OK
+# hint passed into a pane short-circuits it here too - this script is
+# exec'd FROM the overlay, which may not reach `herdr` on its own.
+if ! _dir_viewer_available; then
   notify "herdr-file-viewer not installed; opening the preview overlay"
   exec bash "$script_dir/open-preview.sh"
 fi

--- a/tests/pane-herdr-context.bats
+++ b/tests/pane-herdr-context.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Pane-context contract: a plugin pane/action is spawned by the herdr server,
+# which commonly has a MINIMAL PATH (measured on macOS: /usr/bin:/bin:
+# /usr/sbin:/sbin). A bare `herdr` is therefore not reachable there, and a
+# silently-failing herdr call downgrades a DIRECTORY token from the real file
+# viewer to a tree listing in the popup. Two independent guards are pinned
+# here: lib.sh resolves herdr_bin to an absolute fallback, and the
+# QUICKLOOK_VIEWER_OK hint (passed by the hint action) short-circuits the
+# gate's RPC entirely.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$FIX/adir"
+  unset QUICKLOOK_VIEWER_OK HERDR_BIN_PATH QUICKLOOK_ROOTS
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX"
+}
+
+@test "viewer gate: QUICKLOOK_VIEWER_OK=1 routes a dir to the viewer with NO herdr reachable" {
+  run env -u HERDR_BIN_PATH PATH=/usr/bin:/bin QUICKLOOK_VIEWER_OK=1 \
+    bash -c ". '$LIB'; resolve_any_token '$FIX/adir' && printf 'MODE=%s' \"\$RESOLVED_MODE\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MODE=viewer"* ]]
+}
+
+@test "viewer gate: QUICKLOOK_VIEWER_OK=0 degrades a dir to the paged tree listing" {
+  run env -u HERDR_BIN_PATH PATH=/usr/bin:/bin QUICKLOOK_VIEWER_OK=0 \
+    bash -c ". '$LIB'; resolve_any_token '$FIX/adir' && printf 'MODE=%s' \"\$RESOLVED_MODE\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MODE=command"* ]]
+}
+
+@test "herdr_bin: resolves to an absolute binary when PATH cannot see herdr" {
+  [ -x /opt/homebrew/bin/herdr ] || [ -x /usr/local/bin/herdr ] || skip "no absolute herdr install to fall back to"
+  run env -u HERDR_BIN_PATH PATH=/usr/bin:/bin \
+    bash -c ". '$LIB'; printf '%s' \"\$herdr_bin\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == /* ]]
+  [ -x "$output" ]
+}
+
+@test "regression: a dir with a minimal PATH still reaches viewer mode (was: popup)" {
+  [ -x /opt/homebrew/bin/herdr ] || [ -x /usr/local/bin/herdr ] || skip "no absolute herdr install to fall back to"
+  run env -u HERDR_BIN_PATH -u QUICKLOOK_VIEWER_OK PATH=/usr/bin:/bin \
+    bash -c ". '$LIB'; resolve_any_token '$FIX/adir' && printf 'MODE=%s' \"\$RESOLVED_MODE\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MODE=viewer"* ]]
+}
+
+@test "hint action passes the gate answer into the overlay pane" {
+  grep -q 'QUICKLOOK_VIEWER_OK=\$viewer_ok' "$BATS_TEST_DIRNAME/../scripts/hint.sh"
+}


### PR DESCRIPTION
A directory picked in the overlay opened the preview popup (tree listing)
instead of the file viewer. Root cause: the herdr server runs with a
minimal PATH (measured: /usr/bin:/bin:/usr/sbin:/sbin, no homebrew) and
every pane/action it spawns inherits it, so a bare `herdr` is not
reachable there. dir.sh's _dir_viewer_available then failed silently,
handle_dir fell back to command mode, and open_pick's viewer branch never
fired. The same silent failure also cost panes their .env and plugin
roots.

Two independent guards:
- lib.sh probes herdr_bin and falls back to the usual absolute install
  locations when PATH cannot see it, exporting HERDR_BIN_PATH so exec'd
  children inherit the resolved path.
- hint.sh answers the gate in the action's own context and passes
  QUICKLOOK_VIEWER_OK into the overlay; dir.sh short-circuits on it, so
  routing needs no pane-side RPC (and every pick saves a round trip).
  open-in-viewer.sh now reuses _dir_viewer_available instead of repeating
  the raw RPC, so it honors the same hint.
