### PR TITLE
fix(viewer): drop the impossible cross-repo re-root, hand off to preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Reverted the cross-repo viewer re-root: it could never work. The viewer's
+  manifest pane command is relative, so `pane open --cwd <dir>` made herdr
+  look for its binary under that dir and the spawn failed outright; an
+  injected context JSON is overridden by herdr, and the caller's cwd is
+  ignored. The viewer always roots at the focused pane's repo. A target
+  outside it now goes to the preview popup (which renders any path) with a
+  notice, instead of a failed spawn.
+
 - A DIRECTORY picked from the hint overlay opens the real file viewer again
   instead of a tree listing in the popup. The herdr server often runs with a
   minimal PATH, so a bare `herdr` is unreachable from the panes and actions

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -92,24 +92,24 @@ if resolve_any_token "$raw"; then
 fi
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 
-# The viewer roots at its launch cwd's repo. A target inside the focused
-# repo reuses the idempotent tab action; a target OUTSIDE it (a cockpit row
-# pointing into a sibling repo) re-roots a fresh viewer tab at the TARGET's
-# own repo via `plugin pane open --cwd` instead of refusing. The root itself
-# is inside its own tree (rel stays empty: the viewer opens rooted there,
-# no goto needed).
+# The viewer ALWAYS roots at the focused pane's repo and cannot be pointed
+# anywhere else. Verified live against herdr 0.7.5 + file-viewer 1.14.0:
+#   - `plugin pane open --cwd <dir>` does not re-root it, and actively
+#     BREAKS the spawn: the viewer's manifest pane command is the relative
+#     `./target/release/herdr-file-viewer`, which herdr resolves against
+#     that --cwd ("Unable to spawn <dir>/./target/release/... does not
+#     exist" in herdr-server.log).
+#   - an injected `--env HERDR_PLUGIN_CONTEXT_JSON` is overridden by herdr's
+#     own context, which reports the FOCUSED pane's cwd.
+#   - the calling process's own cwd is ignored for the same reason.
+# So a target outside this repo goes to the preview popup, which renders any
+# path from anywhere (a directory gets its tree listing there). Do not
+# reintroduce a --cwd re-root: it cannot work until the viewer's pane
+# command is absolute.
 root="$(git rev-parse --show-toplevel 2>/dev/null)"
-viewer_cwd=""
 if [ -z "$root" ] || { [ "$target" != "$root" ] && [[ "$target" != "$root"/* ]]; }; then
-  tdir="$target"
-  [ -d "$tdir" ] || tdir="${target%/*}"
-  root="$(git -C "$tdir" rev-parse --show-toplevel 2>/dev/null)"
-  [ -z "$root" ] && root="$tdir"
-  viewer_cwd="$root"
-  # Scope just widened silently otherwise: an on-screen token is about to
-  # drive a navigable viewer OUTSIDE the repo the user is standing in, so
-  # say where it re-rooted (security-lens finding, session review).
-  notify "viewer re-rooted at $root (outside this repo)"
+  notify "outside this repo: the viewer roots here, opening the preview instead"
+  exec bash "$script_dir/open-preview.sh" "$raw"
 fi
 rel="${target#"$root"/}"
 [ "$rel" = "$target" ] && rel=""
@@ -125,17 +125,8 @@ esac
 # existing viewer tab instead of opening twice): a vertical split would
 # disrupt the origin tab's layout. After the action, focus lands on the
 # viewer pane; poll `pane current` until its label reads "Files".
-# Cross-repo targets bypass the idempotent action on purpose: an existing
-# viewer tab is rooted at the WRONG repo, so a fresh tab is opened rooted
-# at the target's repo (the viewer resolves its tree root from the cwd).
-if [ -n "$viewer_cwd" ]; then
-  "$herdr_bin" plugin pane open --plugin herdr-file-viewer --entrypoint file-viewer \
-    --placement tab --focus --cwd "$viewer_cwd" >/dev/null 2>&1 \
-    || { notify "file viewer did not open (cross-repo)"; exit 1; }
-else
-  "$herdr_bin" plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer >/dev/null 2>&1 \
-    || { notify "herdr-file-viewer is not installed"; exit 1; }
-fi
+"$herdr_bin" plugin action invoke open-file-viewer-tab --plugin herdr-file-viewer >/dev/null 2>&1 \
+  || { notify "herdr-file-viewer is not installed"; exit 1; }
 pid=""
 for _ in $(seq 1 20); do
   pid="$("$herdr_bin" pane current 2>/dev/null | jq -r '.result.pane.pane_id // empty' 2>/dev/null)"

--- a/tests/handlers-dir.bats
+++ b/tests/handlers-dir.bats
@@ -190,20 +190,20 @@ teardown() {
   grep -qF "pane send-keys STUBPANE Enter" "$HLOG"
 }
 
-@test "a directory outside the repo re-roots a fresh viewer tab at it (no goto: it IS the root)" {
+@test "a directory outside the repo hands off to the preview, never a broken re-root" {
   export HERDR_VIEWER_INSTALLED=1
   export QUICKLOOK_TOKEN="$FIX/outside/adir"
   run bash "$VIEWER"
   [ "$status" -eq 0 ]
-  # not a git repo, so the root is the directory itself, passed as --cwd
-  grep -qF -- "--cwd $FIX/outside/adir" "$HLOG"
-  # the idempotent tab action would reuse a wrong-root tab; must not be used
-  ! grep -q "action invoke open-file-viewer-tab" "$HLOG"
-  # target IS the root: no goto keys
+  grep -q "notification show quicklook --body outside this repo" "$HLOG"
+  # the viewer cannot be re-rooted: --cwd breaks its spawn (relative pane
+  # command), so it must never be attempted again. See open-in-viewer.sh.
+  ! grep -q -- "--cwd" "$HLOG"
+  ! grep -q "plugin pane open" "$HLOG"
   ! grep -q "pane send-text" "$HLOG"
 }
 
-@test "a file in a SIBLING repo re-roots the viewer at that repo and gotos the rel path" {
+@test "a file in a SIBLING repo hands off to the preview, no viewer keystrokes" {
   mkdir -p "$FIX/sibling/docs"
   git -C "$FIX/sibling" init -q -b main
   printf 'x\n' > "$FIX/sibling/docs/note.md"
@@ -211,33 +211,7 @@ teardown() {
   export QUICKLOOK_TOKEN="$FIX/sibling/docs/note.md"
   run bash "$VIEWER"
   [ "$status" -eq 0 ]
-  grep -qF -- "--cwd $FIX/sibling" "$HLOG"
-  grep -qF "pane send-text STUBPANE docs/note.md" "$HLOG"
-  grep -qF "pane send-keys STUBPANE Enter" "$HLOG"
-  # the re-root is announced, never silent (scope widened outside the repo)
-  grep -q "notification show quicklook --body viewer re-rooted at" "$HLOG"
-}
-
-@test "a sibling-repo file WITH a line number re-roots and sends the :N goto" {
-  mkdir -p "$FIX/sibling/docs"
-  git -C "$FIX/sibling" init -q -b main 2>/dev/null || true
-  printf 'x\ny\nz\n' > "$FIX/sibling/docs/lined.md"
-  export HERDR_VIEWER_INSTALLED=1
-  export QUICKLOOK_TOKEN="$FIX/sibling/docs/lined.md:7"
-  run bash "$VIEWER"
-  [ "$status" -eq 0 ]
-  grep -qF -- "--cwd $FIX/sibling" "$HLOG"
-  grep -qF "pane send-text STUBPANE docs/lined.md" "$HLOG"
-  grep -qF "pane send-text STUBPANE :" "$HLOG"
-  grep -qF "pane send-text STUBPANE 7" "$HLOG"
-}
-
-@test "cross-repo re-root: a failing pane open notifies and exits 1" {
-  export HERDR_VIEWER_INSTALLED=1
-  export HERDR_PANE_OPEN_FAIL=1
-  export QUICKLOOK_TOKEN="$FIX/outside/adir"
-  run bash "$VIEWER"
-  [ "$status" -eq 1 ]
-  grep -q "notification show quicklook --body file viewer did not open (cross-repo)" "$HLOG"
+  grep -q "notification show quicklook --body outside this repo" "$HLOG"
+  ! grep -q -- "--cwd" "$HLOG"
   ! grep -q "pane send-text" "$HLOG"
 }


### PR DESCRIPTION
Picking a directory outside the current repo failed silently: herdr logged
'Unable to spawn <target>/./target/release/herdr-file-viewer because it
does not exist'. The file viewer's manifest pane command is RELATIVE, so
the --cwd added for cross-repo re-rooting made herdr resolve its binary
against the target directory instead of the plugin root, and the pane
never spawned.

Re-rooting is not achievable at all on herdr 0.7.5 + file-viewer 1.14.0,
verified live three ways: --cwd does not re-root (and breaks the spawn),
an injected --env HERDR_PLUGIN_CONTEXT_JSON is overridden by herdr's own
context (which reports the FOCUSED pane's cwd), and the calling process's
cwd is ignored. The viewer roots where the focused pane is, full stop.

So an outside target now execs the preview popup with a notice, the
behavior that actually works for any path. The prior tests only asserted
the --cwd argv against a herdr stub, so they validated a contract herdr
does not offer; they now assert the handoff and that --cwd is never
attempted again.
