### PR TITLE
feat(viewer): open any folder in a viewer rooted at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- A folder picked anywhere now opens in the file viewer, rooted at that
+  folder, even outside the current repo. The plugin's own pane action can
+  only ever root at the focused pane, so an outside target instead gets a
+  plain tab created at it (`tab create --cwd`) with the viewer's binary run
+  in it by absolute path; herdr injects no plugin context there, so the
+  viewer roots at its own cwd. A file+line jump rides the viewer's
+  `HERDR_FILE_VIEWER_OPEN` launch target, so that path needs no keystroke
+  injection. Falls back to the preview when the viewer binary is not built.
+
 - Reverted the cross-repo viewer re-root: it could never work. The viewer's
   manifest pane command is relative, so `pane open --cwd <dir>` made herdr
   look for its binary under that dir and the spawn failed outright; an

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -290,6 +290,32 @@ load_config_env() {
   [ -n "$dir" ] && [ -f "$dir/.env" ] && . "$dir/.env"
 }
 
+# viewer_root -> herdr-file-viewer's plugin root on stdout, rc 1 if the
+# plugin is not installed. augment_roots (load_config) already captured it
+# from its own plugin-list fork; the query is only the fallback for callers
+# that never ran load_config (tests sourcing lib.sh directly).
+viewer_root() {
+  local vroot="${QUICKLOOK_VIEWER_ROOT:-}"
+  if [ -z "$vroot" ]; then
+    vroot="$("$herdr_bin" plugin list --json 2>/dev/null \
+      | jq -r '.result.plugins[] | select(.plugin_id == "herdr-file-viewer") | .plugin_root // empty' 2>/dev/null)"
+  fi
+  [ -n "$vroot" ] || return 1
+  printf '%s' "$vroot"
+}
+
+# viewer_bin -> the file-viewer's EXECUTABLE on stdout, rc 1 when absent.
+# Launching it by absolute path is what lets a viewer be rooted anywhere:
+# the manifest's own pane command is relative, so `plugin pane open` can
+# only ever root at the focused pane (see open-in-viewer.sh's header).
+viewer_bin() {
+  local vroot bin
+  vroot="$(viewer_root)" || return 1
+  bin="$vroot/target/release/herdr-file-viewer"
+  [ -x "$bin" ] || return 1
+  printf '%s' "$bin"
+}
+
 # _bat_theme_flag -> "--theme=<name> " (trailing space) when
 # QUICKLOOK_BAT_THEME is set, else "". Shared by text.sh's LESSOPEN and
 # find-pane.sh's fzf preview so the viewer-parity rule (no flag by default,

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -92,27 +92,56 @@ if resolve_any_token "$raw"; then
 fi
 [ -z "${target:-}" ] && { notify "not found: $raw"; exit 0; }
 
-# The viewer ALWAYS roots at the focused pane's repo and cannot be pointed
-# anywhere else. Verified live against herdr 0.7.5 + file-viewer 1.14.0:
-#   - `plugin pane open --cwd <dir>` does not re-root it, and actively
-#     BREAKS the spawn: the viewer's manifest pane command is the relative
-#     `./target/release/herdr-file-viewer`, which herdr resolves against
-#     that --cwd ("Unable to spawn <dir>/./target/release/... does not
-#     exist" in herdr-server.log).
-#   - an injected `--env HERDR_PLUGIN_CONTEXT_JSON` is overridden by herdr's
-#     own context, which reports the FOCUSED pane's cwd.
-#   - the calling process's own cwd is ignored for the same reason.
-# So a target outside this repo goes to the preview popup, which renders any
-# path from anywhere (a directory gets its tree listing there). Do not
-# reintroduce a --cwd re-root: it cannot work until the viewer's pane
-# command is absolute.
+# A target INSIDE the focused repo reuses the plugin's own idempotent tab
+# action below (open-or-switch, no duplicate viewer). A target OUTSIDE it
+# needs a viewer rooted somewhere else, and the plugin action cannot do
+# that: `plugin pane open` always roots at the FOCUSED pane, and the three
+# ways to redirect it all fail (verified live, herdr 0.7.5 / file-viewer
+# 1.14.0): `--cwd` breaks the spawn outright, because the viewer's manifest
+# pane command is the relative `./target/release/herdr-file-viewer` and
+# herdr resolves it against that cwd; an injected
+# `--env HERDR_PLUGIN_CONTEXT_JSON` is overridden by herdr's own context;
+# and the caller's cwd is ignored.
+#
+# What DOES work (also verified live): a PLAIN tab created at the target
+# (`tab create --cwd`), then the viewer's binary run in it BY ABSOLUTE PATH.
+# herdr injects no plugin context into a plain pane, so the viewer's own
+# `from_env()` falls back to the process cwd and roots exactly there. The
+# jump to a file+line rides `HERDR_FILE_VIEWER_OPEN` (the viewer's
+# documented launch open-target), so this path needs no keystroke injection
+# at all.
 root="$(git rev-parse --show-toplevel 2>/dev/null)"
+outside=0
 if [ -z "$root" ] || { [ "$target" != "$root" ] && [[ "$target" != "$root"/* ]]; }; then
-  notify "outside this repo: the viewer roots here, opening the preview instead"
-  exec bash "$script_dir/open-preview.sh" "$raw"
+  outside=1
+  tdir="$target"
+  [ -d "$tdir" ] || tdir="${target%/*}"
+  root="$(git -C "$tdir" rev-parse --show-toplevel 2>/dev/null)"
+  [ -z "$root" ] && root="$tdir"
 fi
 rel="${target#"$root"/}"
 [ "$rel" = "$target" ] && rel=""
+
+if [ "$outside" -eq 1 ]; then
+  vbin="$(viewer_bin)" || {
+    notify "file viewer binary not built; opening the preview instead"
+    exec bash "$script_dir/open-preview.sh" "$raw"
+  }
+  # A fresh tab per outside target is deliberate: the idempotent action
+  # would hand back a viewer rooted at the WRONG repo.
+  set -- tab create --cwd "$root" --focus
+  [ -n "$rel" ] && set -- "$@" --env "HERDR_FILE_VIEWER_OPEN=$rel${CLIP_LINE:+:$CLIP_LINE}"
+  vpane="$("$herdr_bin" "$@" 2>/dev/null | jq -r '.result.root_pane.pane_id // empty' 2>/dev/null)"
+  [ -n "$vpane" ] || {
+    notify "could not open a viewer tab; opening the preview instead"
+    exec bash "$script_dir/open-preview.sh" "$raw"
+  }
+  "$herdr_bin" pane run "$vpane" "$vbin" >/dev/null 2>&1 \
+    || { notify "file viewer did not start"; exit 1; }
+  notify "viewer rooted at $root (outside this repo)"
+  record_open "$raw"
+  exit 0
+fi
 
 # $rel is typed into the file-viewer TUI via send-text; a control byte in the
 # filename (e.g. an embedded newline in a maliciously-named file) would inject

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -39,16 +39,10 @@ _markdown_glow_style() {
     printf '%s' "$QUICKLOOK_GLOW_STYLE"
     return 0
   fi
-  # augment_roots (load_config) already captured the viewer root from its
-  # own plugin-list fork; querying again here would pay the same herdr+jq
-  # cost twice per render. The query below is only the fallback for callers
-  # that never ran load_config (tests sourcing lib.sh directly).
-  local vroot="${QUICKLOOK_VIEWER_ROOT:-}"
-  if [ -z "$vroot" ]; then
-    # shellcheck disable=SC2154  # herdr_bin is set by lib.sh before this file is sourced
-    vroot="$("$herdr_bin" plugin list --json 2>/dev/null \
-      | jq -r '.result.plugins[] | select(.plugin_id == "herdr-file-viewer") | .plugin_root // empty' 2>/dev/null)"
-  fi
+  # viewer_root (lib.sh) prefers the root augment_roots already captured, so
+  # this costs no extra fork on the normal path.
+  local vroot
+  vroot="$(viewer_root || true)"
   if [ -n "$vroot" ] && [ -f "$vroot/assets/markdown-style.json" ]; then
     printf '%s' "$vroot/assets/markdown-style.json"
     return 0

--- a/tests/handlers-dir.bats
+++ b/tests/handlers-dir.bats
@@ -45,6 +45,7 @@ HERDR
 #!/usr/bin/env bash
 case "$*" in
   *".result.pane.pane_id"*) printf 'STUBPANE\n' ;;
+  *"root_pane.pane_id"*) printf 'VIEWTAB\n' ;;
   *".label"*) printf 'Files\n' ;;
   *) printf '{}' ;;
 esac
@@ -190,28 +191,62 @@ teardown() {
   grep -qF "pane send-keys STUBPANE Enter" "$HLOG"
 }
 
-@test "a directory outside the repo hands off to the preview, never a broken re-root" {
+@test "a directory outside the repo opens a viewer tab ROOTED there" {
+  # argv contract verified LIVE against herdr 0.7.5 + file-viewer 1.14.0:
+  # `tab create --cwd` + `pane run <abs binary>` is the only way to root a
+  # viewer outside the focused pane. `plugin pane open --cwd` breaks the
+  # spawn (relative manifest command) and must never come back.
   export HERDR_VIEWER_INSTALLED=1
+  mkdir -p "$FIX/vroot/target/release"
+  printf '#!/usr/bin/env bash\n' > "$FIX/vroot/target/release/herdr-file-viewer"
+  chmod +x "$FIX/vroot/target/release/herdr-file-viewer"
+  export QUICKLOOK_VIEWER_ROOT="$FIX/vroot"
   export QUICKLOOK_TOKEN="$FIX/outside/adir"
   run bash "$VIEWER"
   [ "$status" -eq 0 ]
-  grep -q "notification show quicklook --body outside this repo" "$HLOG"
-  # the viewer cannot be re-rooted: --cwd breaks its spawn (relative pane
-  # command), so it must never be attempted again. See open-in-viewer.sh.
-  ! grep -q -- "--cwd" "$HLOG"
+  grep -qF -- "tab create --cwd $FIX/outside/adir --focus" "$HLOG"
+  grep -qF "pane run VIEWTAB $FIX/vroot/target/release/herdr-file-viewer" "$HLOG"
+  grep -q "notification show quicklook --body viewer rooted at" "$HLOG"
   ! grep -q "plugin pane open" "$HLOG"
   ! grep -q "pane send-text" "$HLOG"
 }
 
-@test "a file in a SIBLING repo hands off to the preview, no viewer keystrokes" {
-  mkdir -p "$FIX/sibling/docs"
+@test "a file in a SIBLING repo roots the viewer there and opens it via the env target" {
+  mkdir -p "$FIX/sibling/docs" "$FIX/vroot/target/release"
   git -C "$FIX/sibling" init -q -b main
   printf 'x\n' > "$FIX/sibling/docs/note.md"
+  printf '#!/usr/bin/env bash\n' > "$FIX/vroot/target/release/herdr-file-viewer"
+  chmod +x "$FIX/vroot/target/release/herdr-file-viewer"
   export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_VIEWER_ROOT="$FIX/vroot"
   export QUICKLOOK_TOKEN="$FIX/sibling/docs/note.md"
   run bash "$VIEWER"
   [ "$status" -eq 0 ]
-  grep -q "notification show quicklook --body outside this repo" "$HLOG"
-  ! grep -q -- "--cwd" "$HLOG"
+  grep -qF -- "tab create --cwd $FIX/sibling" "$HLOG"
+  grep -qF -- "HERDR_FILE_VIEWER_OPEN=docs/note.md" "$HLOG"
   ! grep -q "pane send-text" "$HLOG"
+}
+
+@test "a sibling-repo file WITH a line number carries :N in the env open target" {
+  mkdir -p "$FIX/sibling/docs" "$FIX/vroot/target/release"
+  git -C "$FIX/sibling" init -q -b main
+  printf 'x\ny\nz\n' > "$FIX/sibling/docs/lined.md"
+  printf '#!/usr/bin/env bash\n' > "$FIX/vroot/target/release/herdr-file-viewer"
+  chmod +x "$FIX/vroot/target/release/herdr-file-viewer"
+  export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_VIEWER_ROOT="$FIX/vroot"
+  export QUICKLOOK_TOKEN="$FIX/sibling/docs/lined.md:7"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -qF -- "HERDR_FILE_VIEWER_OPEN=docs/lined.md:7" "$HLOG"
+}
+
+@test "outside target with no built viewer binary degrades to the preview" {
+  export HERDR_VIEWER_INSTALLED=1
+  export QUICKLOOK_VIEWER_ROOT="$FIX/nonexistent-vroot"
+  export QUICKLOOK_TOKEN="$FIX/outside/adir"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -q "notification show quicklook --body file viewer binary not built" "$HLOG"
+  ! grep -q "tab create" "$HLOG"
 }


### PR DESCRIPTION
A folder outside the current repo previously fell back to a tree listing
in the preview popup, because the plugin's pane action always roots the
viewer at the FOCUSED pane and the three ways to redirect it all fail
(--cwd breaks the spawn on the relative manifest command, an injected
HERDR_PLUGIN_CONTEXT_JSON is overridden by herdr, the caller's cwd is
ignored).

The working mechanism, verified live before writing any code: create a
PLAIN tab at the target with `tab create --cwd`, then run the viewer's
binary in it by absolute path. herdr injects no plugin context into a
plain pane, so the viewer's from_env() falls back to the process cwd and
roots exactly there. The file+line jump uses the viewer's documented
HERDR_FILE_VIEWER_OPEN launch target instead of send-text keystrokes.

In-repo targets keep the idempotent open-or-switch action unchanged.
viewer_root/viewer_bin move to lib.sh so markdown.sh's palette lookup and
this share one accessor. Tests assert the live-verified argv and that
`plugin pane open --cwd` never returns.
