### PR TITLE
chore(debug): gated routing diagnostic for hint picks

### DIFF
--- a/scripts/hint-pane.sh
+++ b/scripts/hint-pane.sh
@@ -292,6 +292,13 @@ printf '%s' "$frame"
 open_pick() {
   local i="$1"
   cleanup
+  if [ -n "${QUICKLOOK_DEBUG_LOG:-}" ]; then
+    resolve_any_token "${tokens[$i]}" 2>/dev/null
+    printf '%s pick: tok=%s mode=%s viewer_ok=%s target=%s\n' \
+      "$(date +%T)" "${tokens[$i]}" "${RESOLVED_MODE:-none}" \
+      "${QUICKLOOK_VIEWER_OK:-unset}" "${RESOLVED_TARGET:-none}" \
+      >> "$HOME/.config/herdr/quicklook-debug.log" 2>/dev/null || true
+  fi
   if resolve_any_token "${tokens[$i]}" 2>/dev/null && [ "${RESOLVED_MODE:-}" = "viewer" ]; then
     export QUICKLOOK_KEEP_CWD=1
     exec bash "$script_dir/open-in-viewer.sh" "${tokens[$i]}"

--- a/scripts/hint.sh
+++ b/scripts/hint.sh
@@ -122,6 +122,16 @@ fi
 viewer_ok=0
 "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1 && viewer_ok=1
 
+# Optional routing diagnostic (QUICKLOOK_DEBUG_LOG=1 in the plugin .env):
+# the pane/action environment differs from a shell in ways that silently
+# change routing, and this line is the difference between guessing and
+# knowing which branch a pick took.
+if [ -n "${QUICKLOOK_DEBUG_LOG:-}" ]; then
+  printf '%s hint: viewer_ok=%s herdr_bin=%s path=%s\n' \
+    "$(date +%T)" "$viewer_ok" "$herdr_bin" "$PATH" \
+    >> "$HOME/.config/herdr/quicklook-debug.log" 2>/dev/null || true
+fi
+
 set -- plugin pane open \
   --plugin herdr-quicklook \
   --entrypoint hint-pane \


### PR DESCRIPTION
QUICKLOOK_DEBUG_LOG=1 (plugin .env) appends one line per hint pick to
~/.config/herdr/quicklook-debug.log: the computed viewer_ok and the
resolved mode/target of the picked token. The pane and action environments
differ from a shell in ways that silently change routing, and three
successive theories about a mis-routed directory pick were wrong because
they were inferred rather than observed. Off by default; costs one extra
resolve only when enabled.
