### PR TITLE
fix(debug): forward the debug flag into the overlay pane

### DIFF
--- a/scripts/hint.sh
+++ b/scripts/hint.sh
@@ -138,6 +138,7 @@ set -- plugin pane open \
   --placement overlay \
   --focus \
   --env "QUICKLOOK_VIEWER_OK=$viewer_ok" \
+  --env "QUICKLOOK_DEBUG_LOG=${QUICKLOOK_DEBUG_LOG:-}" \
   --env "QUICKLOOK_HINT_TOKENS_FILE=$tokens_file" \
   --env "QUICKLOOK_HINT_SNAP_FILE=$snap_file"
 


### PR DESCRIPTION
The plugin .env is read by the hint ACTION but not by the overlay PANE,
so the routing diagnostic added in the previous commit could never write
from open_pick, which is exactly where the answer lives. Pass
QUICKLOOK_DEBUG_LOG through --env alongside QUICKLOOK_VIEWER_OK.

Behaviour verified live while chasing this: an outside-repo directory
picked in the overlay DOES fire tab.create + the 'viewer rooted at'
notification, and the vault path driven straight through
open-in-viewer.sh does the same (rc=0). The viewer-any-folder path
itself is sound.
