### PR TITLE
feat(preview): key footer along the bottom of the pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- The preview pane now paints a key footer along its bottom line
+  (`q quit · o viewer · e edit · D diff · / search · space page`), so the
+  bindings are discoverable instead of folklore. It rides less's own short
+  prompt, so scrolling and the render registry are untouched, and the
+  nested diff view gets its own footer because its keys differ. Hide it
+  with an empty `QUICKLOOK_KEY_HINT`.
+
 - A folder picked anywhere now opens in the file viewer, rooted at that
   folder, even outside the current repo. The plugin's own pane action can
   only ever root at the focused pane, so an outside target instead gets a

--- a/config.example
+++ b/config.example
@@ -57,3 +57,14 @@
 
 # Hint picker: restore the slower fully-verified scan instead of shape-first.
 #QUICKLOOK_HINT_VERIFIED=1
+
+# QUICKLOOK_KEY_HINT: the key footer painted along the bottom of the preview
+# pane. Set to an empty string to hide it once the keys are muscle memory.
+#QUICKLOOK_KEY_HINT="q quit · o viewer · e edit · D diff · / search · space page"
+
+# QUICKLOOK_DEBUG_LOG: append one line per hint pick to
+# ~/.config/herdr/quicklook-debug.log (the computed viewer_ok, plus the
+# picked token's resolved mode and target). Off by default; useful when a
+# pick routes somewhere unexpected, because a pane's environment differs
+# from a shell's in ways that silently change routing.
+#QUICKLOOK_DEBUG_LOG=1

--- a/scripts/dirty-diff.sh
+++ b/scripts/dirty-diff.sh
@@ -67,8 +67,13 @@ q quit
 d quit
 LESSKEY
 
+# The nested view's own footer: its keys are NOT the preview's (q, d and
+# Esc-Esc all toggle back per the lesskey above), so it never advertises
+# the preview's o/e/D set.
+diff_prompt="-Psq or d: back to preview · / search"
+
 if command -v delta >/dev/null 2>&1; then
-  printf '%s\n' "$diff_output" | delta --paging=never | less -R --lesskey-src="$diff_lesskey"
+  printf '%s\n' "$diff_output" | delta --paging=never | less -R --lesskey-src="$diff_lesskey" "$diff_prompt"
 else
-  printf '%s\n' "$diff_output" | less -R --lesskey-src="$diff_lesskey"
+  printf '%s\n' "$diff_output" | less -R --lesskey-src="$diff_lesskey" "$diff_prompt"
 fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -316,6 +316,27 @@ viewer_bin() {
   printf '%s' "$bin"
 }
 
+# The keys advertised in the pager's footer. Kept in sync BY HAND with
+# ../lesskey, which is the source of truth for o/e/D; q and / are less's
+# own. Anything listed here must actually be bound there, so a new user
+# reading the footer never presses a key that does nothing.
+QUICKLOOK_KEY_HINT='q quit · o viewer · e edit · D diff · / search · space page'
+
+# pager_prompt_args -> sets the fixed global PAGER_PROMPT_ARGS to the `less`
+# prompt flag that paints the key footer along the bottom line, or to an
+# empty array when QUICKLOOK_KEY_HINT is blank (the opt-out). A fixed output
+# global, not a nameref: Apple's bash is 3.2, which has no `local -n` (same
+# reason the pick scanner uses _PICK_* globals).
+# `-Ps` selects less's SHORT prompt explicitly: a bare -P would swallow a
+# leading s/m/M/=/h/w as a prompt selector, and the hint's first character
+# is not ours to constrain. The hint carries no `%`, so none of less's
+# prompt escapes can fire on it.
+pager_prompt_args() {
+  PAGER_PROMPT_ARGS=()
+  [ -n "${QUICKLOOK_KEY_HINT:-}" ] && PAGER_PROMPT_ARGS=("-Ps$QUICKLOOK_KEY_HINT")
+  return 0
+}
+
 # _bat_theme_flag -> "--theme=<name> " (trailing space) when
 # QUICKLOOK_BAT_THEME is set, else "". Shared by text.sh's LESSOPEN and
 # find-pane.sh's fzf preview so the viewer-parity rule (no flag by default,
@@ -659,11 +680,12 @@ unset _herdr_renderer
 render_command_in_pager() {
   local lesskey_args=()
   [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
+  pager_prompt_args
   # CLICOLOR_FORCE=1: same trick herdr-file-viewer applies to every renderer
   # subprocess - termenv-based tools (glow/glamour) drop to a no-color
   # profile when stdout is a pipe even with an explicit style; harmless to
   # bat/delta/jq, which force color via their own flags.
-  CLICOLOR_FORCE=1 "$@" 2>&1 | less -R "${lesskey_args[@]}"
+  CLICOLOR_FORCE=1 "$@" 2>&1 | less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}"
 }
 
 # resolve_any_token <raw> -> see the handler-registry contract at the top of

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -26,6 +26,7 @@ render_text() {
   local target="$1" line="${2:-}"
   local lesskey_args=()
   [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
+  pager_prompt_args
 
   export VISUAL="$LIB_DIR/escalate.sh"
   # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
@@ -40,7 +41,7 @@ render_text() {
     # viewer's own title UI.
     LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers,header %s"
     export LESSOPEN
-    exec less -R "${lesskey_args[@]}" ${line:++$line} "$target"
+    exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
   fi
-  exec less -N "${lesskey_args[@]}" ${line:++$line} "$target"
+  exec less -N "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
 }

--- a/tests/pager-key-footer.bats
+++ b/tests/pager-key-footer.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# The pager's key footer: every pager path advertises the SAME keys, and
+# every key it advertises is really bound in ../lesskey (a footer that lies
+# is worse than no footer). Opt-out via an empty QUICKLOOK_KEY_HINT.
+
+setup() {
+  export HERDR_BIN_PATH=/usr/bin/false
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  LESSKEY="$BATS_TEST_DIRNAME/../lesskey"
+  # shellcheck disable=SC1090
+  . "$LIB"
+
+  FIX="$(cd "$(mktemp -d)" && pwd -P)"
+  printf 'plain text\n' > "$FIX/doc.txt"
+  STUB="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nprintf "LESS_ARGS:%%s\\n" "$*"\ncat >/dev/null\n' > "$STUB/less"
+  chmod +x "$STUB/less"
+  export PATH="$STUB:/usr/bin:/bin"
+}
+
+teardown() {
+  cd /
+  rm -rf "$FIX" "$STUB"
+}
+
+@test "pager_prompt_args: yields a less short-prompt flag carrying the hint" {
+  pager_prompt_args
+  [ "${#PAGER_PROMPT_ARGS[@]}" -eq 1 ]
+  [[ "${PAGER_PROMPT_ARGS[0]}" == "-Ps"* ]]
+  [[ "${PAGER_PROMPT_ARGS[0]}" == *"q quit"* ]]
+}
+
+@test "pager_prompt_args: an empty hint is the opt-out (no flag at all)" {
+  QUICKLOOK_KEY_HINT=""
+  pager_prompt_args
+  [ "${#PAGER_PROMPT_ARGS[@]}" -eq 0 ]
+}
+
+@test "the footer never advertises a key that is not bound" {
+  # o / e / D come from ../lesskey; q and / are less's own built-ins.
+  grep -qE '^o visual' "$LESSKEY"
+  grep -qE '^e pshell' "$LESSKEY"
+  grep -qE '^D shell' "$LESSKEY"
+  for k in o e D; do
+    [[ "$QUICKLOOK_KEY_HINT" == *"$k "* ]]
+  done
+}
+
+@test "render_command_in_pager passes the footer to less" {
+  run render_command_in_pager printf 'hello\n'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-Ps"* ]]
+  [[ "$output" == *"o viewer"* ]]
+}
+
+@test "render_text passes the same footer to less" {
+  run bash -c ". '$LIB'; render_text '$FIX/doc.txt'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-Ps"* ]]
+  [[ "$output" == *"o viewer"* ]]
+}
+
+@test "the hint carries no % so less prompt escapes cannot fire on it" {
+  [[ "$QUICKLOOK_KEY_HINT" != *"%"* ]]
+}


### PR DESCRIPTION
The preview pane's bindings (o viewer, e edit, D diff) were discoverable
only by reading lesskey. Paint them along the bottom line via less's own
short prompt (-Ps), so scrolling, the lesskey bindings and the render
registry are all untouched.

Both pager paths share one helper: render_text (exec less on the file)
and render_command_in_pager (the piped renderers). The nested diff view
carries its OWN footer, since q/d/Esc-Esc all toggle back there and it
must not advertise the preview's key set.

PAGER_PROMPT_ARGS is a fixed output global rather than a nameref: Apple's
bash is 3.2, which has no local -n (same reason the pick scanner uses
_PICK_* globals). A test asserts every key the footer advertises is
really bound in lesskey, so the footer cannot drift into lying.
