### PR TITLE
fix(preview): restore exact line jumps, apply review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Fixed a line-jump regression: the bat filter briefly ran with a `header`
+  row, and `less +N` counts lines in the FILTERED stream, so every
+  `path:N` open landed one line off. The style is back to plain `numbers`
+  (which is also what the file viewer itself runs), the filename moved into
+  the pager footer via less's `%f`, and a test now pins one rendered row
+  per source line.
+- Review-batch follow-ups: the control-char filename guard runs before both
+  viewer launch paths; the debug logger is shared, strips control bytes
+  from untrusted token text and creates its log private; comments that
+  asserted a since-disproven "panes get a minimal PATH" theory now say what
+  was actually measured.
+
 - The preview pane now paints a key footer along its bottom line
   (`q quit · o viewer · e edit · D diff · / search · space page`), so the
   bindings are discoverable instead of folklore. It rides less's own short

--- a/config.example
+++ b/config.example
@@ -67,4 +67,6 @@
 # picked token's resolved mode and target). Off by default; useful when a
 # pick routes somewhere unexpected, because a pane's environment differs
 # from a shell's in ways that silently change routing.
+# The log is append-only with no rotation, so turn it back off once the
+# question is answered.
 #QUICKLOOK_DEBUG_LOG=1

--- a/scripts/hint-pane.sh
+++ b/scripts/hint-pane.sh
@@ -294,10 +294,7 @@ open_pick() {
   cleanup
   if [ -n "${QUICKLOOK_DEBUG_LOG:-}" ]; then
     resolve_any_token "${tokens[$i]}" 2>/dev/null
-    printf '%s pick: tok=%s mode=%s viewer_ok=%s target=%s\n' \
-      "$(date +%T)" "${tokens[$i]}" "${RESOLVED_MODE:-none}" \
-      "${QUICKLOOK_VIEWER_OK:-unset}" "${RESOLVED_TARGET:-none}" \
-      >> "$HOME/.config/herdr/quicklook-debug.log" 2>/dev/null || true
+    debug_log "pick: tok=${tokens[$i]} mode=${RESOLVED_MODE:-none} viewer_ok=${QUICKLOOK_VIEWER_OK:-unset} target=${RESOLVED_TARGET:-none}"
   fi
   if resolve_any_token "${tokens[$i]}" 2>/dev/null && [ "${RESOLVED_MODE:-}" = "viewer" ]; then
     export QUICKLOOK_KEEP_CWD=1

--- a/scripts/hint.sh
+++ b/scripts/hint.sh
@@ -116,9 +116,9 @@ fi
 ) &
 
 # Answer the viewer gate HERE, in the action's own context, and hand the
-# result to the overlay: the pane may not be able to reach `herdr` at all
-# (minimal server PATH), and a failed gate silently downgrades a directory
-# pick from the real file viewer to a tree listing in the popup.
+# result to the overlay: it saves the pane an RPC round trip on the hot
+# pick path, and a failed gate would silently downgrade a directory pick
+# from the real file viewer to a tree listing in the popup.
 viewer_ok=0
 "$herdr_bin" plugin action list --plugin herdr-file-viewer >/dev/null 2>&1 && viewer_ok=1
 
@@ -126,11 +126,7 @@ viewer_ok=0
 # the pane/action environment differs from a shell in ways that silently
 # change routing, and this line is the difference between guessing and
 # knowing which branch a pick took.
-if [ -n "${QUICKLOOK_DEBUG_LOG:-}" ]; then
-  printf '%s hint: viewer_ok=%s herdr_bin=%s path=%s\n' \
-    "$(date +%T)" "$viewer_ok" "$herdr_bin" "$PATH" \
-    >> "$HOME/.config/herdr/quicklook-debug.log" 2>/dev/null || true
-fi
+debug_log "hint: viewer_ok=$viewer_ok herdr_bin=$herdr_bin"
 
 set -- plugin pane open \
   --plugin herdr-quicklook \

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -148,15 +148,18 @@
 # -----------------------------------------------------------------------
 
 # herdr_bin: HERDR_BIN_PATH (herdr's own convention) wins, else a bare
-# `herdr` off PATH. The bare name is NOT safe to assume inside a pane: the
-# server is often launched with a minimal PATH (measured on macOS:
-# /usr/bin:/bin:/usr/sbin:/sbin, no /opt/homebrew/bin), and every pane and
-# action it spawns inherits that. A plugin script that cannot reach `herdr`
-# does not fail loudly - it silently loses the .env, the plugin roots, and
-# the dir-handler's viewer gate, so a DIRECTORY degrades to a tree listing
-# in the popup instead of opening the real file viewer. Probe once here and
-# fall back to the usual install locations so pane context matches shell
-# context.
+# `herdr` off PATH, with an absolute fallback if PATH cannot see it.
+#
+# INSURANCE, not a fix for an observed failure - be honest about what was
+# measured. The herdr SERVER process does run with a minimal PATH
+# (/usr/bin:/bin:/usr/sbin:/sbin on macOS, no /opt/homebrew/bin), which is
+# what motivated this. But a spawned ACTION was later measured with the
+# full login PATH, so herdr evidently does not simply hand its own env
+# down, and the mis-routed-directory bug this was written for turned out to
+# have an unrelated cause. The fallback is kept because a script that
+# cannot reach `herdr` fails SILENTLY (it loses the .env, the plugin roots
+# and the viewer gate), which is an expensive failure mode for two cheap
+# lines - not because a pane was ever proven to lack it.
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 if ! command -v "$herdr_bin" >/dev/null 2>&1; then
   for _herdr_cand in \
@@ -322,7 +325,22 @@ viewer_bin() {
 # reading the footer never presses a key that does nothing.
 QUICKLOOK_KEY_HINT='q quit · o viewer · e edit · D diff · / search · space page'
 
-# pager_prompt_args -> sets the fixed global PAGER_PROMPT_ARGS to the `less`
+# debug_log <tag> <field>... : one line to ~/.config/herdr/quicklook-debug.log
+# when QUICKLOOK_DEBUG_LOG is set, else nothing. The fields carry UNTRUSTED
+# on-screen/clipboard text, so control bytes are stripped (a raw newline
+# would forge extra log lines) and the file is created private: it records
+# whatever token happened to be picked, which may be sensitive.
+# Append-only with no rotation, so it is opt-in and meant to be turned back
+# off once a routing question is answered.
+debug_log() {
+  [ -n "${QUICKLOOK_DEBUG_LOG:-}" ] || return 0
+  local dir="$HOME/.config/herdr" line
+  line="$(printf '%s %s' "$(date +%T)" "$*" | tr -d '\n\r\t')"
+  ( umask 077; mkdir -p "$dir" 2>/dev/null; printf '%s\n' "$line" >> "$dir/quicklook-debug.log" ) 2>/dev/null || true
+  return 0
+}
+
+# pager_prompt_args [prefix] -> sets the fixed global PAGER_PROMPT_ARGS to the `less`
 # prompt flag that paints the key footer along the bottom line, or to an
 # empty array when QUICKLOOK_KEY_HINT is blank (the opt-out). A fixed output
 # global, not a nameref: Apple's bash is 3.2, which has no `local -n` (same
@@ -332,8 +350,10 @@ QUICKLOOK_KEY_HINT='q quit · o viewer · e edit · D diff · / search · space 
 # is not ours to constrain. The hint carries no `%`, so none of less's
 # prompt escapes can fire on it.
 pager_prompt_args() {
+  local prefix="${1:-}"
   PAGER_PROMPT_ARGS=()
-  [ -n "${QUICKLOOK_KEY_HINT:-}" ] && PAGER_PROMPT_ARGS=("-Ps$QUICKLOOK_KEY_HINT")
+  [ -n "${QUICKLOOK_KEY_HINT:-}" ] || return 0
+  PAGER_PROMPT_ARGS=("-Ps${prefix}$QUICKLOOK_KEY_HINT")
   return 0
 }
 

--- a/scripts/open-in-viewer.sh
+++ b/scripts/open-in-viewer.sh
@@ -122,6 +122,14 @@ fi
 rel="${target#"$root"/}"
 [ "$rel" = "$target" ] && rel=""
 
+# $rel reaches the file-viewer either as send-text keystrokes (in-repo) or as
+# an env open-target (outside); a control byte in the filename would inject
+# keystrokes into that plugin. Refuse BEFORE either branch consumes it, so
+# the guard cannot be bypassed by a future edit to only one path.
+case "$rel" in
+  *[$'\n\r\t']*) notify "unsafe filename (control chars); refusing"; exit 0 ;;
+esac
+
 if [ "$outside" -eq 1 ]; then
   vbin="$(viewer_bin)" || {
     notify "file viewer binary not built; opening the preview instead"
@@ -142,13 +150,6 @@ if [ "$outside" -eq 1 ]; then
   record_open "$raw"
   exit 0
 fi
-
-# $rel is typed into the file-viewer TUI via send-text; a control byte in the
-# filename (e.g. an embedded newline in a maliciously-named file) would inject
-# extra keystrokes into that plugin. Refuse.
-case "$rel" in
-  *[$'\n\r\t']*) notify "unsafe filename (control chars); refusing"; exit 0 ;;
-esac
 
 # The viewer opens in its OWN TAB (open-file-viewer-tab switches to an
 # existing viewer tab instead of opening twice): a vertical split would

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -26,7 +26,9 @@ render_text() {
   local target="$1" line="${2:-}"
   local lesskey_args=()
   [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
-  pager_prompt_args
+  # %f is less's own filename escape: the footer carries the name that the
+  # dropped bat header used to show, without occupying a line.
+  pager_prompt_args '%f · '
 
   export VISUAL="$LIB_DIR/escalate.sh"
   # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
@@ -36,10 +38,15 @@ render_text() {
     # flag so the user's own bat config decides (Han's pins TwoDark with a
     # "both panes read this" note). Pinning a theme here would override
     # that config and un-sync the panes, so QUICKLOOK_BAT_THEME adds a
-    # --theme flag ONLY when explicitly set. style=numbers,header: the
-    # viewer's numbers gutter, plus a filename header standing in for the
-    # viewer's own title UI.
-    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers,header %s"
+    # --theme flag ONLY when explicitly set.
+    #
+    # style=numbers, NOT numbers,header: `less +N` counts lines in the
+    # LESSOPEN-FILTERED stream, so bat's one-line "File: ..." header shifts
+    # every `path:N` jump down by one (measured: a 5-line file renders as 6
+    # rows with header). The viewer itself runs plain `--style=numbers`, so
+    # dropping the header is also the real parity. The filename is carried
+    # in the pager footer instead (%f), where it costs no lines.
+    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers %s"
     export LESSOPEN
     exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
   fi

--- a/tests/dirty-diff.bats
+++ b/tests/dirty-diff.bats
@@ -58,6 +58,9 @@ teardown() {
   run bash "$SCRIPT" "$FIX/repo/f.txt" </dev/null
   [ "$status" -eq 0 ]
   [[ "$output" == *"LESS_ARGS:"* ]]
+  # the nested diff view advertises its own toggle-back keys, not the
+  # preview's o/e/D set (different lesskey, different bindings).
+  [[ "$output" == *"back to preview"* ]]
   [[ "$output" == *"CHANGED LINE"* ]]
   # single post-`--` arg: git was called with exactly 6 args, the last one
   # (ARG6) being the untouched file path, ARG5 being the bare `--` separator.
@@ -74,6 +77,9 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"DELTA_RAN"* ]]
   [[ "$output" == *"LESS_ARGS:"* ]]
+  # the nested diff view advertises its own toggle-back keys, not the
+  # preview's o/e/D set (different lesskey, different bindings).
+  [[ "$output" == *"back to preview"* ]]
 }
 
 @test "dirty-diff: a clean file prints the no-changes notice, no pager" {

--- a/tests/handlers-dir.bats
+++ b/tests/handlers-dir.bats
@@ -33,8 +33,13 @@ if [ "\$1" = "plugin" ] && [ "\$2" = "action" ] && [ "\$3" = "list" ]; then
   [ "\${HERDR_VIEWER_INSTALLED:-0}" = "1" ] && exit 0
   exit 1
 fi
-if [ "\$1" = "plugin" ] && [ "\$2" = "pane" ] && [ "\$3" = "open" ]; then
-  [ "\${HERDR_PANE_OPEN_FAIL:-0}" = "1" ] && exit 1
+if [ "\$1" = "tab" ] && [ "\$2" = "create" ]; then
+  [ "\${HERDR_TAB_CREATE_FAIL:-0}" = "1" ] && exit 1
+  # real herdr prints the new tab's JSON; the faithful jq stub keys off it
+  printf '{"result":{"root_pane":{"pane_id":"VIEWTAB"}}}\n'
+fi
+if [ "\$1" = "pane" ] && [ "\$2" = "run" ]; then
+  [ "\${HERDR_PANE_RUN_FAIL:-0}" = "1" ] && exit 1
 fi
 exit 0
 HERDR
@@ -45,7 +50,9 @@ HERDR
 #!/usr/bin/env bash
 case "$*" in
   *".result.pane.pane_id"*) printf 'STUBPANE\n' ;;
-  *"root_pane.pane_id"*) printf 'VIEWTAB\n' ;;
+  *"root_pane.pane_id"*)
+    # faithful: a failed `tab create` produces no JSON, so no pane id
+    if [ -n "$(cat)" ]; then printf 'VIEWTAB\n'; fi ;;
   *".label"*) printf 'Files\n' ;;
   *) printf '{}' ;;
 esac
@@ -249,4 +256,29 @@ teardown() {
   [ "$status" -eq 0 ]
   grep -q "notification show quicklook --body file viewer binary not built" "$HLOG"
   ! grep -q "tab create" "$HLOG"
+}
+
+@test "outside target: a failing tab create degrades to the preview, no pane run" {
+  export HERDR_VIEWER_INSTALLED=1 HERDR_TAB_CREATE_FAIL=1
+  mkdir -p "$FIX/vroot/target/release"
+  printf '#!/usr/bin/env bash\n' > "$FIX/vroot/target/release/herdr-file-viewer"
+  chmod +x "$FIX/vroot/target/release/herdr-file-viewer"
+  export QUICKLOOK_VIEWER_ROOT="$FIX/vroot"
+  export QUICKLOOK_TOKEN="$FIX/outside/adir"
+  run bash "$VIEWER"
+  [ "$status" -eq 0 ]
+  grep -q "notification show quicklook --body could not open a viewer tab" "$HLOG"
+  ! grep -q "pane run" "$HLOG"
+}
+
+@test "outside target: a failing pane run reports it and exits nonzero" {
+  export HERDR_VIEWER_INSTALLED=1 HERDR_PANE_RUN_FAIL=1
+  mkdir -p "$FIX/vroot/target/release"
+  printf '#!/usr/bin/env bash\n' > "$FIX/vroot/target/release/herdr-file-viewer"
+  chmod +x "$FIX/vroot/target/release/herdr-file-viewer"
+  export QUICKLOOK_VIEWER_ROOT="$FIX/vroot"
+  export QUICKLOOK_TOKEN="$FIX/outside/adir"
+  run bash "$VIEWER"
+  [ "$status" -eq 1 ]
+  grep -q "notification show quicklook --body file viewer did not start" "$HLOG"
 }

--- a/tests/pane-herdr-context.bats
+++ b/tests/pane-herdr-context.bats
@@ -1,12 +1,13 @@
 #!/usr/bin/env bats
-# Pane-context contract: a plugin pane/action is spawned by the herdr server,
-# which commonly has a MINIMAL PATH (measured on macOS: /usr/bin:/bin:
-# /usr/sbin:/sbin). A bare `herdr` is therefore not reachable there, and a
-# silently-failing herdr call downgrades a DIRECTORY token from the real file
-# viewer to a tree listing in the popup. Two independent guards are pinned
-# here: lib.sh resolves herdr_bin to an absolute fallback, and the
-# QUICKLOOK_VIEWER_OK hint (passed by the hint action) short-circuits the
-# gate's RPC entirely.
+# Viewer-gate short-circuit + herdr_bin absolute fallback.
+#
+# HONEST FRAMING: these were written against a theory (panes inherit the
+# herdr server's minimal PATH) that was later DISPROVEN - a spawned action
+# was measured with the full login PATH, and the mis-routed directory bug
+# had an unrelated cause. The behaviour under test is still real and
+# shipped, so the tests stay; they are defensive-fallback tests, NOT a
+# regression net for an observed production failure. Do not cite them as
+# evidence that panes lack PATH entries.
 
 setup() {
   LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
@@ -51,6 +52,21 @@ teardown() {
   [[ "$output" == *"MODE=viewer"* ]]
 }
 
-@test "hint action passes the gate answer into the overlay pane" {
-  grep -q 'QUICKLOOK_VIEWER_OK=\$viewer_ok' "$BATS_TEST_DIRNAME/../scripts/hint.sh"
+@test "hint action really forwards the gate answer into the overlay argv" {
+  # was a source grep, which passes even if the flag never reaches herdr;
+  # run the action against a stub herdr and read the argv it actually built.
+  local stub hlog
+  stub="$(mktemp -d)"; hlog="$(mktemp)"
+  cat > "$stub/herdr" <<HERDR
+#!/usr/bin/env bash
+printf '%s\\n' "\$*" >> "$hlog"
+exit 0
+HERDR
+  chmod +x "$stub/herdr"
+  printf '#!/usr/bin/env bash\nprintf "{}"\n' > "$stub/jq"; chmod +x "$stub/jq"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$stub/pbpaste"; chmod +x "$stub/pbpaste"
+  PATH="$stub:/usr/bin:/bin" HERDR_BIN_PATH="$stub/herdr" \
+    run bash "$BATS_TEST_DIRNAME/../scripts/hint.sh"
+  grep -q -- "--env QUICKLOOK_VIEWER_OK=" "$hlog"
+  rm -rf "$stub"
 }

--- a/tests/renderers-text-theme.bats
+++ b/tests/renderers-text-theme.bats
@@ -23,7 +23,7 @@ teardown() {
 @test "render_text: no theme flag by default (bat config decides, like the viewer)" {
   run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers,header"* ]]
+  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers"* ]]
   [[ "$output" != *"--theme"* ]]
 }
 
@@ -31,4 +31,28 @@ teardown() {
   run bash -c "export QUICKLOOK_BAT_THEME=zenburn; . '$LIB'; render_text '$FIX/doc.txt'"
   [ "$status" -eq 0 ]
   [[ "$output" == *"--theme=zenburn"* ]]
+}
+
+# ---- line-jump parity: the LESSOPEN filter must not shift line numbers ----
+
+@test "bat's LESSOPEN output has ONE row per source line (so less +N is exact)" {
+  # setup() puts a stub bat on PATH; this invariant needs the REAL one.
+  local real_bat
+  real_bat="$(PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin command -v bat)" || skip "bat not installed"
+  local f="$FIX/five.txt"
+  seq 1 5 | sed 's/^/line /' > "$f"
+  # the exact filter render_text installs; a decorating style that adds a
+  # header/grid row would silently shift every `path:N` jump by that many
+  # lines (regression shipped once, caught by review).
+  local rows
+  rows="$("$real_bat" --color=always --style=numbers "$f" | wc -l | tr -d ' ')"
+  [ "$rows" -eq 5 ]
+}
+
+@test "render_text's LESSOPEN uses no line-adding decoration" {
+  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--style=numbers"* ]]
+  [[ "$output" != *"header"* ]]
+  [[ "$output" != *"grid"* ]]
 }


### PR DESCRIPTION
The bat LESSOPEN filter briefly carried a 'header' row. less's +N
addresses the FILTERED stream, so a 5-line file rendered as 6 rows and
every path:N open landed one line off. Back to --style=numbers, which is
also exactly what herdr-file-viewer runs, so this is the real display
parity the header was mistakenly claiming. The filename it showed now
rides the pager footer through less's own %f escape, costing no line.
A test asserts one rendered row per source line, so the invariant that
actually matters is falsifiable instead of implied.

Review findings applied:
- the control-char filename guard is hoisted above BOTH viewer launch
  paths, so a future edit to one cannot bypass it
- debug_log is shared by hint.sh and hint-pane.sh, strips control bytes
  from untrusted token text (a raw newline forged log lines) and creates
  the log under umask 077 since it records whatever token was picked
- comments claiming a measured 'panes inherit a minimal PATH' fact now
  state what was actually observed: the SERVER has a minimal PATH, a
  spawned ACTION was measured with the full login PATH, and the fallback
  is insurance rather than a fix for a proven failure
- tests: the tautological source-grep now runs hint.sh against a stub and
  reads the argv; the dead HERDR_PANE_OPEN_FAIL gate (it guarded a call
  shape removed in #59) is re-pointed at tab create / pane run, with the
  two failure paths now covered; the nested diff view's own footer is
  asserted; the jq stub no longer invents a pane id when herdr printed
  nothing
