### PR TITLE
feat(preview): filename header, detection fixes, cross-repo SHA, PR md

### DIFF
--- a/scripts/handlers/vcs.sh
+++ b/scripts/handlers/vcs.sh
@@ -20,6 +20,29 @@ _VCS_HASHREF_RE='^#[0-9]+$'
 # .../pull/<digits> tail).
 _VCS_PR_URL_RE='^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+/?$'
 
+# _vcs_repo_with_commit <sha> -> a repo path that HAS this commit, on
+# stdout, else empty. Probes every first-level child of each
+# QUICKLOOK_ROOTS entry (the same set resolve() sweeps), one cheap
+# `cat-file -e` per repo, first hit wins.
+_vcs_repo_with_commit() {
+  local sha="$1" r d
+  local IFS=':'
+  for r in ${QUICKLOOK_ROOTS:-}; do
+    [ -n "$r" ] && [ -d "$r" ] || continue
+    unset IFS
+    for d in "$r"/*/; do
+      d="${d%/}"
+      [ -e "$d/.git" ] || continue
+      if git -C "$d" cat-file -e "${sha}^{commit}" 2>/dev/null; then
+        printf '%s' "$d"
+        return 0
+      fi
+    done
+    local IFS=':'
+  done
+  return 1
+}
+
 match_vcs() {
   [ -n "$1" ] || return 1
   [[ "$1" =~ $_VCS_SHA_RE ]] && return 0
@@ -44,7 +67,7 @@ handle_vcs() {
       RESOLVED_TARGET=""
       RESOLVED_LINE=""
       RESOLVED_MODE="command"
-      RESOLVED_CMD=(gh pr view "$n")
+      RESOLVED_CMD=(bash "$LIB_DIR/pr-view.sh" "$n")
       return 0
       ;;
     https://github.com/*)
@@ -53,7 +76,7 @@ handle_vcs() {
       RESOLVED_TARGET=""
       RESOLVED_LINE=""
       RESOLVED_MODE="command"
-      RESOLVED_CMD=(gh pr view "$raw")
+      RESOLVED_CMD=(bash "$LIB_DIR/pr-view.sh" "$raw")
       return 0
       ;;
     *)
@@ -70,7 +93,23 @@ handle_vcs() {
       RESOLVED_TARGET=""
       RESOLVED_LINE=""
       RESOLVED_MODE="command"
-      RESOLVED_CMD=(git show --end-of-options "$raw")
+      # The SHA on screen often belongs to ANOTHER repo (a commit list
+      # from a sibling checkout), and `git show` in the pane's own repo
+      # answers "fatal: ambiguous argument" instead of rendering it. Find
+      # the repo that actually has the object first; bounded, and only
+      # when the current repo does not have it.
+      # `var=$(cmd)` carries cmd's exit status, so this must not be the
+      # last command in an && / || chain, or handle_vcs returns non-zero.
+      local repo=""
+      if ! { git rev-parse --git-dir >/dev/null 2>&1 \
+        && git cat-file -e "${raw}^{commit}" 2>/dev/null; }; then
+        repo="$(_vcs_repo_with_commit "$raw" || true)"
+      fi
+      if [ -n "$repo" ]; then
+        RESOLVED_CMD=(git -C "$repo" show --end-of-options "$raw")
+      else
+        RESOLVED_CMD=(git show --end-of-options "$raw")
+      fi
       return 0
       ;;
   esac

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1321,6 +1321,18 @@ pick_scan_text() {
             s = substr(s, 2, length(s) - 2)
           }
         }
+        # Call-shape prefix: agent output writes `Update(~/a/b.sh)`,
+        # `Read(path)`, `Bash(cmd)`. The span carries BOTH parens so the
+        # unmatched rules below never fire, and the whole thing is one
+        # unopenable token whose hint lands on the `U`. Keep the inside.
+        if (match(s, /^[A-Za-z_][A-Za-z0-9_.-]*\(/) && substr(s, length(s), 1) == ")") {
+          s = substr(s, RLENGTH + 1, length(s) - RLENGTH - 1)
+        }
+        # Shell assignment prefix: `S=/private/tmp/...` hints on the `S`
+        # and resolves nothing. Keep the value.
+        if (match(s, /^[A-Za-z_][A-Za-z0-9_]*=/)) {
+          s = substr(s, RLENGTH + 1)
+        }
         # UNMATCHED wrapper: prose like "(assets/style.json copied ...)"
         # whitespace-splits the opener onto the span with its closer words
         # away, so the matched rule above never fires. An opener whose

--- a/scripts/pr-view.sh
+++ b/scripts/pr-view.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# pr-view.sh <pr-ref>: `gh pr view` with the BODY rendered as markdown
+# (glow), which is what a PR body is. The fields above the body are plain
+# text and pass through untouched. QUICKLOOK_PR_RAW=1 (or glow absent)
+# falls back to gh's raw output.
+#
+# A script rather than a pipeline in RESOLVED_CMD: the handler contract
+# passes an argv ARRAY (no shell), so a pipe needs a real program. The ref
+# arrives as one argv element and is never re-parsed by a shell.
+set -u
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=scripts/lib.sh
+. "$script_dir/lib.sh"
+load_config_env
+
+ref="${1:-}"
+[ -n "$ref" ] || exit 0
+
+out="$(gh pr view "$ref" 2>&1)" || { printf '%s\n' "$out"; exit 0; }
+
+if [ -n "${QUICKLOOK_PR_RAW:-}" ] || ! command -v glow >/dev/null 2>&1; then
+  printf '%s\n' "$out"
+  exit 0
+fi
+
+# gh separates its metadata block from the markdown body with a lone "--".
+head="${out%%$'\n'--$'\n'*}"
+if [ "$head" = "$out" ]; then
+  printf '%s\n' "$out"
+  exit 0
+fi
+body="${out#*$'\n'--$'\n'}"
+
+cols="$(tput cols 2>/dev/null)" || cols=100
+printf '%s\n\n' "$head"
+# same style resolution as the markdown renderer, so a PR body and a .md
+# preview look identical (the viewer's palette when it is installed).
+printf '%s\n' "$body" | glow -s "$(_markdown_glow_style)" -w "${cols:-100}" - 2>/dev/null \
+  || printf '%s\n' "$body"

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -26,9 +26,7 @@ render_text() {
   local target="$1" line="${2:-}"
   local lesskey_args=()
   [ -f "$LIB_DIR/../lesskey" ] && lesskey_args=(--lesskey-src="$LIB_DIR/../lesskey")
-  # %f is less's own filename escape: the footer carries the name that the
-  # dropped bat header used to show, without occupying a line.
-  pager_prompt_args '%f · '
+  pager_prompt_args
 
   export VISUAL="$LIB_DIR/escalate.sh"
   # Read by the lesskey `e` pshell binding (escalate-editor.sh); see lesskey.
@@ -40,15 +38,26 @@ render_text() {
     # that config and un-sync the panes, so QUICKLOOK_BAT_THEME adds a
     # --theme flag ONLY when explicitly set.
     #
-    # style=numbers, NOT numbers,header: `less +N` counts lines in the
-    # LESSOPEN-FILTERED stream, so bat's one-line "File: ..." header shifts
-    # every `path:N` jump down by one (measured: a 5-line file renders as 6
-    # rows with header). The viewer itself runs plain `--style=numbers`, so
-    # dropping the header is also the real parity. The filename is carried
-    # in the pager footer instead (%f), where it costs no lines.
-    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers %s"
+    # style=numbers,header puts the FILENAME on top, where it belongs; the
+    # footer stays keys-only.
+    #
+    # The header occupies rows in the LESSOPEN-filtered stream that `less
+    # +N` counts, so a `path:N` jump must skip them. Its height is NOT a
+    # constant: bat wraps the "File: ..." line, so a long path in a narrow
+    # pane takes two rows where a short one takes one (measured both).
+    # Measure it instead of guessing, with a one-line probe render, and
+    # only when a jump was actually requested.
+    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers,header %s"
     export LESSOPEN
-    exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
+    local jump="$line" probe
+    if [ -n "$jump" ]; then
+      probe="$(bat --color=always --style=numbers,header --line-range 1:1 -- "$target" 2>/dev/null | wc -l | tr -d ' ')"
+      case "$probe" in
+        '' | *[!0-9]*) : ;;
+        *) [ "$probe" -gt 1 ] && jump=$((jump + probe - 1)) ;;
+      esac
+    fi
+    exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${jump:++$jump} "$target"
   fi
   exec less -N "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
 }

--- a/tests/handlers-vcs.bats
+++ b/tests/handlers-vcs.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # Tests for scripts/handlers/vcs.sh (SG-02, vcs-tokens): a bare commit SHA ->
-# `git show`, a `#123` ref or a GitHub PR URL -> `gh pr view`, mode=command.
+# `git show`, a `#123` ref or a GitHub PR URL -> pr-view.sh (gh pr view with
+# the body rendered as markdown), mode=command.
 # Same style as registry.bats: source lib.sh directly and call
 # match_vcs/handle_vcs (they communicate through RESOLVED_* globals), not
 # `run` in a subshell, except where a test deliberately executes the built
@@ -138,24 +139,22 @@ teardown() {
   # for a bogus SHA instead of erroring").
 }
 
-@test "handle_vcs: #123 builds the exact argv gh pr view 123" {
+@test "handle_vcs: #123 builds the exact argv bash pr-view.sh 123" {
   handle_vcs "#123"
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
-  [ "${RESOLVED_CMD[0]}" = "gh" ]
-  [ "${RESOLVED_CMD[1]}" = "pr" ]
-  [ "${RESOLVED_CMD[2]}" = "view" ]
-  [ "${RESOLVED_CMD[3]}" = "123" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 3 ]
+  [ "${RESOLVED_CMD[0]}" = "bash" ]
+  [[ "${RESOLVED_CMD[1]}" == *"/pr-view.sh" ]]
+  [ "${RESOLVED_CMD[2]}" = "123" ]
 }
 
-@test "handle_vcs: a GitHub PR URL builds gh pr view <url>" {
+@test "handle_vcs: a GitHub PR URL builds bash pr-view.sh <url>" {
   handle_vcs "https://github.com/dwarvesf/herdr-quicklook/pull/42"
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
-  [ "${RESOLVED_CMD[0]}" = "gh" ]
-  [ "${RESOLVED_CMD[1]}" = "pr" ]
-  [ "${RESOLVED_CMD[2]}" = "view" ]
-  [ "${RESOLVED_CMD[3]}" = "https://github.com/dwarvesf/herdr-quicklook/pull/42" ]
+  [ "${#RESOLVED_CMD[@]}" -eq 3 ]
+  [ "${RESOLVED_CMD[0]}" = "bash" ]
+  [[ "${RESOLVED_CMD[1]}" == *"/pr-view.sh" ]]
+  [ "${RESOLVED_CMD[2]}" = "https://github.com/dwarvesf/herdr-quicklook/pull/42" ]
 }
 
 # ---- non-hex token falls through to the next handler (checklist case) ----
@@ -197,8 +196,10 @@ teardown() {
 @test "argv-shape control: a flag-injection value through the #-branch still lands as ONE arg" {
   handle_vcs '#123 --upload-pack=/tmp/evil'
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
-  [ "${RESOLVED_CMD[3]}" = '123 --upload-pack=/tmp/evil' ]
+  # bash <pr-view.sh> <ref>: the payload stays ONE argv element, so it can
+  # never be read as a flag by the program the script runs.
+  [ "${#RESOLVED_CMD[@]}" -eq 3 ]
+  [ "${RESOLVED_CMD[2]}" = '123 --upload-pack=/tmp/evil' ]
 }
 
 # ---- real execution: functional correctness + the security proof ----
@@ -250,7 +251,7 @@ teardown() {
 @test "registry: a GitHub PR URL dispatches to vcs (mode=command), not url (mode=browser)" {
   resolve_any_token "https://github.com/dwarvesf/herdr-quicklook/pull/42"
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${RESOLVED_CMD[0]}" = "gh" ]
+  [ "${RESOLVED_CMD[0]}" = "bash" ]
 }
 
 @test "registry: a bare SHA dispatches to vcs end to end through resolve_any_token" {
@@ -262,7 +263,7 @@ teardown() {
 @test "registry: a #123 hashref dispatches to vcs end to end through resolve_any_token" {
   resolve_any_token "#7"
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${RESOLVED_CMD[*]}" = "gh pr view 7" ]
+  [ "${RESOLVED_CMD[0]}" = "bash" ] && [ "${RESOLVED_CMD[2]}" = "7" ] && [ "${#RESOLVED_CMD[@]}" -eq 3 ]
 }
 
 @test "registry: a generic non-github https URL still resolves as mode=browser (reorder did not regress url.sh)" {
@@ -285,4 +286,41 @@ teardown() {
 @test "vcs.sh exports match_vcs and handle_vcs" {
   declare -F match_vcs >/dev/null
   declare -F handle_vcs >/dev/null
+}
+
+# ---- a SHA that lives in ANOTHER repo (the pane's cwd does not have it) ----
+
+@test "handle_vcs: a SHA from a sibling repo resolves against THAT repo" {
+  local ws sib here
+  ws="$(cd "$(mktemp -d)" && pwd -P)"
+  mkdir -p "$ws/sib" "$ws/here"
+  sib="$ws/sib"; here="$ws/here"
+  git -C "$sib" init -q -b main
+  printf 'x\n' > "$sib/f.txt"
+  git -C "$sib" add -A
+  git -C "$sib" -c user.email=t@t -c user.name=t commit -qm fixture
+  git -C "$here" init -q -b main
+  printf 'y\n' > "$here/g.txt"
+  git -C "$here" add -A
+  git -C "$here" -c user.email=t@t -c user.name=t commit -qm other
+  local sha
+  sha="$(git -C "$sib" log --format=%h -1)"
+
+  cd "$here"
+  QUICKLOOK_ROOTS="$ws"
+  handle_vcs "$sha"
+  # without the sweep this would be a bare `git show` in $here, which
+  # answers "fatal: ambiguous argument" instead of rendering the commit
+  [ "${RESOLVED_CMD[0]}" = "git" ]
+  [ "${RESOLVED_CMD[1]}" = "-C" ]
+  [ "${RESOLVED_CMD[2]}" = "$sib" ]
+  cd /
+  rm -rf "$ws"
+}
+
+@test "handle_vcs: a PR ref renders its body as markdown by default" {
+  handle_vcs '#123'
+  [ "${RESOLVED_CMD[0]}" = "bash" ]
+  [[ "${RESOLVED_CMD[1]}" == *"/pr-view.sh" ]]
+  [ "${RESOLVED_CMD[2]}" = "123" ]
 }

--- a/tests/pick-scan.bats
+++ b/tests/pick-scan.bats
@@ -592,3 +592,23 @@ SCRIPT
   header="$(pick_scan_text < <(printf '%s\n' "${names[@]}") | pick_count_header)"
   [ "$header" = "120 on screen · 120 path" ]
 }
+
+# ---- call-shape and assignment prefixes (agent/shell output on screen) ----
+
+@test "pick_scan_text: Update(path) yields the path, not the word Update" {
+  run pick_scan_text <<<'Update(sub/inrepo.md) touched it'
+  [[ "$output" == *"$(printf 'sub/inrepo.md\tpath\t1')"* ]]
+  [[ "$output" != *"Update("* ]]
+}
+
+@test "pick_scan_text: a shell assignment yields the value, not the VAR= prefix" {
+  run pick_scan_text <<<'S=sub/inrepo.md'
+  [[ "$output" == *"$(printf 'sub/inrepo.md\tpath\t1')"* ]]
+  [[ "$output" != *"S="* ]]
+}
+
+@test "pick_scan_text: a bare word with parens but no closer is left alone" {
+  # negative control: only a full Name(...) shape is unwrapped
+  run pick_scan_text <<<'Update(sub/inrepo.md'
+  [[ "$output" != *"$(printf 'Update\t')"* ]]
+}

--- a/tests/renderers-text-theme.bats
+++ b/tests/renderers-text-theme.bats
@@ -10,7 +10,7 @@ setup() {
   STUB="$(mktemp -d)"
   printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/bat"
   # less is exec'd by render_text; print the LESSOPEN it inherited
-  printf '#!/usr/bin/env bash\nprintf "LESSOPEN=%%s\\n" "$LESSOPEN"\n' > "$STUB/less"
+  printf '#!/usr/bin/env bash\nprintf "LESSOPEN=%%s\\nLESS_ARGS: %%s\\n" "$LESSOPEN" "$*"\n' > "$STUB/less"
   chmod +x "$STUB/bat" "$STUB/less"
   export PATH="$STUB:/usr/bin:/bin"
 }
@@ -23,7 +23,7 @@ teardown() {
 @test "render_text: no theme flag by default (bat config decides, like the viewer)" {
   run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers"* ]]
+  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers,header"* ]]
   [[ "$output" != *"--theme"* ]]
 }
 
@@ -35,24 +35,33 @@ teardown() {
 
 # ---- line-jump parity: the LESSOPEN filter must not shift line numbers ----
 
-@test "bat's LESSOPEN output has ONE row per source line (so less +N is exact)" {
-  # setup() puts a stub bat on PATH; this invariant needs the REAL one.
+@test "the header-height probe predicts the full render's row count" {
   local real_bat
   real_bat="$(PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin command -v bat)" || skip "bat not installed"
   local f="$FIX/five.txt"
   seq 1 5 | sed 's/^/line /' > "$f"
-  # the exact filter render_text installs; a decorating style that adds a
-  # header/grid row would silently shift every `path:N` jump by that many
-  # lines (regression shipped once, caught by review).
-  local rows
-  rows="$("$real_bat" --color=always --style=numbers "$f" | wc -l | tr -d ' ')"
-  [ "$rows" -eq 5 ]
+  local probe full
+  probe="$("$real_bat" --color=always --style=numbers,header --line-range 1:1 -- "$f" | wc -l | tr -d ' ')"
+  full="$("$real_bat" --color=always --style=numbers,header -- "$f" | wc -l | tr -d ' ')"
+  # header rows = probe - 1 (the probe also renders one content row), so a
+  # 5-line file must render as 5 + (probe - 1) rows. This is the identity
+  # render_text's jump compensation relies on; a fixed constant is WRONG
+  # because bat wraps a long "File: ..." path onto a second row.
+  [ "$full" -eq "$((5 + probe - 1))" ]
 }
 
-@test "render_text's LESSOPEN uses no line-adding decoration" {
-  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
+@test "render_text shifts a line jump past the measured header rows" {
+  command -v bat >/dev/null 2>&1 || skip "stub bat required"
+  # stub bat prints one row for the probe -> probe=1 -> no shift; the real
+  # behaviour with a multi-row header is covered by the identity test above.
+  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt' 10"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"--style=numbers"* ]]
-  [[ "$output" != *"header"* ]]
-  [[ "$output" != *"grid"* ]]
+  [[ "$output" == *"+1"* ]]
+}
+
+@test "render_text without bat does NOT shift the jump (no header in that stream)" {
+  rm -f "$STUB/bat"
+  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt' 10"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"+10"* ]]
 }


### PR DESCRIPTION
Five reported issues:

1. The filename moved back to the top (bat's header); the footer stays
   keys-only. The header's height is NOT constant, bat wraps a long
   'File: ...' path onto a second row, so the line-jump compensation is
   measured per render with a one-line probe instead of a fixed offset.
   A test pins the identity the probe relies on.

2/4. The scanner ate two common on-screen shapes. 'Update(~/a/b.sh)' kept
   both parens, so no unmatched-wrapper rule fired and the hint landed on
   the 'U' of an unopenable token; 'S=/private/tmp/x' hinted the 'S'. Both
   prefixes are now stripped, with a negative control so a bare 'Name('
   with no closer is left alone.

3. PR/issue refs render their body as markdown by default through a small
   pr-view.sh (the handler contract passes an argv ARRAY, so a pipeline
   needs a real program; the ref stays one argv element). It reuses the
   markdown renderer's own glow style, so a PR body and a .md preview
   look identical. QUICKLOOK_PR_RAW=1 restores raw output. The in-pager
   key toggle is NOT implemented, only the default and the config escape.

5. A SHA from a sibling repo produced 'fatal: ambiguous argument' because
   git show ran in the pane's repo. The handler now finds the repo that
   has the object first, bounded to the same roots resolve() sweeps.

Also fixed while here: a command-substitution assignment carries the
command's exit status, so the repo lookup could not be the last command in
an && / || chain without making handle_vcs return non-zero (caught by the
existing suite).
