### PR TITLE
feat(pr-view): title row, drop empty fields, rule before the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- PR previews read like a document: a title row on top (`PR #65 · <title>
+  [MERGED]`), gh's always-printed-but-empty fields (labels, assignees,
+  reviewers, projects, milestone) dropped, and a rule between the metadata
+  and the rendered body.
+
 - Fixed a line-jump regression: the bat filter briefly ran with a `header`
   row, and `less +N` counts lines in the FILTERED stream, so every
   `path:N` open landed one line off. The style is back to plain `numbers`

--- a/scripts/pr-view.sh
+++ b/scripts/pr-view.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
-# pr-view.sh <pr-ref>: `gh pr view` with the BODY rendered as markdown
-# (glow), which is what a PR body is. The fields above the body are plain
-# text and pass through untouched. QUICKLOOK_PR_RAW=1 (or glow absent)
-# falls back to gh's raw output.
+# pr-view.sh <pr-ref>: `gh pr view`, laid out for reading.
+#
+#   PR #65 · <title>  [MERGED]     <- title row, like bat's file header
+#   author/number/url/... (non-empty only)
+#   ------------------------------ <- rule
+#   <body rendered as markdown>    <- what a PR body actually is
+#
+# gh prints labels/assignees/reviewers/projects/milestone even when empty,
+# which was half the pane; those rows are dropped. QUICKLOOK_PR_RAW=1
+# prints gh's output verbatim instead.
 #
 # A script rather than a pipeline in RESOLVED_CMD: the handler contract
 # passes an argv ARRAY (no shell), so a pipe needs a real program. The ref
@@ -19,22 +25,67 @@ ref="${1:-}"
 
 out="$(gh pr view "$ref" 2>&1)" || { printf '%s\n' "$out"; exit 0; }
 
-if [ -n "${QUICKLOOK_PR_RAW:-}" ] || ! command -v glow >/dev/null 2>&1; then
+if [ -n "${QUICKLOOK_PR_RAW:-}" ]; then
   printf '%s\n' "$out"
   exit 0
 fi
 
 # gh separates its metadata block from the markdown body with a lone "--".
-head="${out%%$'\n'--$'\n'*}"
-if [ "$head" = "$out" ]; then
+head_block="${out%%$'\n'--$'\n'*}"
+if [ "$head_block" = "$out" ]; then
   printf '%s\n' "$out"
   exit 0
 fi
 body="${out#*$'\n'--$'\n'}"
 
 cols="$(tput cols 2>/dev/null)" || cols=100
-printf '%s\n\n' "$head"
-# same style resolution as the markdown renderer, so a PR body and a .md
-# preview look identical (the viewer's palette when it is installed).
-printf '%s\n' "$body" | glow -s "$(_markdown_glow_style)" -w "${cols:-100}" - 2>/dev/null \
-  || printf '%s\n' "$body"
+case "$cols" in '' | *[!0-9]*) cols=100 ;; esac
+[ "$cols" -gt 120 ] && cols=120
+
+# field <name> -> that field's value (gh prints "name<TAB>value").
+field() {
+  printf '%s\n' "$head_block" | awk -F'\t' -v k="$1:" '$1 == k { print $2; exit }'
+}
+
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+OFF=$'\033[0m'
+title="$(field title)"
+state="$(field state)"
+number="$(field number)"
+
+# Title row first, so the pane says WHAT this is before any metadata.
+printf '%s%s%s  %s%s%s\n' \
+  "$BOLD" "${number:+PR #$number · }$title" "$OFF" "$DIM" "${state:+[$state]}" "$OFF"
+
+# Metadata: skip title/state (already in the header above) and every field
+# gh printed with no value.
+printf '%s\n' "$head_block" | awk -F'\t' '
+  $1 == "title:" || $1 == "state:" { next }
+  { v = $2; gsub(/^[ \t]+|[ \t]+$/, "", v) }
+  v == "" { next }
+  { printf "%-12s %s\n", $1, v }
+'
+
+# Rule between metadata and body: they are different kinds of content and
+# ran together as one wall of text before.
+# ${rule} braces are load-bearing: Apple's bash 3.2 parses the multibyte
+# rule character as part of the VARIABLE NAME in "$rule─", and dies with
+# `unbound variable: rule─` under set -u. Homebrew bash 5 does not, so this
+# only breaks where a pane runs /bin/bash.
+rule=""
+i=0
+while [ "$i" -lt "$cols" ]; do
+  rule="${rule}─"
+  i=$((i + 1))
+done
+printf '%s%s%s\n' "$DIM" "$rule" "$OFF"
+
+if command -v glow >/dev/null 2>&1; then
+  # same style resolution as the markdown renderer, so a PR body and a .md
+  # preview look identical (the viewer's palette when it is installed).
+  printf '%s\n' "$body" | glow -s "$(_markdown_glow_style)" -w "$cols" - 2>/dev/null \
+    || printf '%s\n' "$body"
+else
+  printf '\n%s\n' "$body"
+fi

--- a/tests/pr-view.bats
+++ b/tests/pr-view.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# pr-view.sh's layout: a title row on top, empty gh fields dropped, a rule
+# between metadata and body, and the body rendered as markdown by default.
+
+setup() {
+  export HERDR_BIN_PATH=/usr/bin/false
+  PRVIEW="$BATS_TEST_DIRNAME/../scripts/pr-view.sh"
+  STUB="$(mktemp -d)"
+
+  # gh's real shape: `name<TAB>value`, empty fields still printed, then a
+  # lone `--` before the markdown body.
+  cat > "$STUB/gh" <<'GH'
+#!/usr/bin/env bash
+printf 'title:\tdocs: a capacity test plan\n'
+printf 'state:\tMERGED\n'
+printf 'author:\ttieubao (Han Ngo)\n'
+printf 'labels:\t\n'
+printf 'assignees:\t\n'
+printf 'reviewers:\t\n'
+printf 'projects:\t\n'
+printf 'milestone:\t\n'
+printf 'number:\t65\n'
+printf 'url:\thttps://example.invalid/pull/65\n'
+printf -- '--\n'
+printf '# Summary\n\nBody text here.\n'
+GH
+  chmod +x "$STUB/gh"
+  export PATH="$STUB:/usr/bin:/bin"
+  unset QUICKLOOK_PR_RAW
+}
+
+teardown() {
+  rm -rf "$STUB"
+}
+
+plain() { perl -pe 's/\e\[[0-9;]*m//g'; }
+
+@test "pr-view: the title row names the PR on the FIRST line" {
+  run bash -c "bash '$PRVIEW' 65 | perl -pe 's/\\e\\[[0-9;]*m//g' | head -1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR #65"* ]]
+  [[ "$output" == *"a capacity test plan"* ]]
+  [[ "$output" == *"[MERGED]"* ]]
+}
+
+@test "pr-view: gh's empty fields are dropped" {
+  run bash -c "bash '$PRVIEW' 65 | perl -pe 's/\\e\\[[0-9;]*m//g'"
+  [ "$status" -eq 0 ]
+  for empty in labels assignees reviewers projects milestone; do
+    [[ "$output" != *"$empty:"* ]]
+  done
+  # the fields that DO have values survive
+  [[ "$output" == *"author:"* ]]
+  [[ "$output" == *"url:"* ]]
+}
+
+@test "pr-view: title and state are not repeated below the header row" {
+  run bash -c "bash '$PRVIEW' 65 | perl -pe 's/\\e\\[[0-9;]*m//g'"
+  [[ "$output" != *"title:"* ]]
+  [[ "$output" != *"state:"* ]]
+}
+
+@test "pr-view: a rule separates the metadata from the body" {
+  run bash -c "bash '$PRVIEW' 65 | perl -pe 's/\\e\\[[0-9;]*m//g'"
+  [[ "$output" == *"────"* ]]
+  [[ "$output" == *"Body text here."* ]]
+}
+
+@test "pr-view: QUICKLOOK_PR_RAW prints gh's output verbatim" {
+  QUICKLOOK_PR_RAW=1 run bash "$PRVIEW" 65
+  [ "$status" -eq 0 ]
+  # raw keeps the empty fields and the bare -- separator
+  [[ "$output" == *"labels:"* ]]
+  [[ "$output" == *"--"* ]]
+  [[ "$output" != *"PR #65 ·"* ]]
+}
+
+@test "pr-view: no ref is a no-op, never a bare gh call" {
+  run bash "$PRVIEW"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
The PR preview opened with 13 metadata rows, five of them fields gh
prints even when empty, and the body ran straight on from them with no
separator, so the pane read as one wall of text and never said WHAT it
was showing.

Now: a title row first (PR #<n> · <title> [state]), matching how the file
preview names its file; only fields with values below it; then a rule,
then the markdown body.

Found by the new tests, not by me: 'rule="$rule─"' dies under Apple's
bash 3.2 with 'unbound variable: rule─', because 3.2 parses the multibyte
character as part of the variable name. Homebrew bash 5 accepts it, so a
live check passed while every pane running /bin/bash would have failed.
Braces fix it, and /bin/bash -n now covers the file.
