### PR TITLE
feat(preview): name the pane after the object, handle glob tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- The previewed object's name moved into the pane border ("Preview:
+  vcs.sh", "Preview: PR #65"), and bat's filename header row is gone with
+  it. The name now costs no content row, cannot wrap onto a second line,
+  and no longer shifts `path:N` jumps, so the jump compensation that
+  header needed is deleted too.
+- Glob patterns stop offering an open that always fails: `scripts/*.sh`
+  hints the directory that contains it, and a bare `*.sh` is dropped.
+
 - PR previews read like a document: a title row on top (`PR #65 · <title>
   [MERGED]`), gh's always-printed-but-empty fields (labels, assignees,
   reviewers, projects, milestone) dropped, and a rule between the metadata

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1333,6 +1333,18 @@ pick_scan_text() {
         if (match(s, /^[A-Za-z_][A-Za-z0-9_]*=/)) {
           s = substr(s, RLENGTH + 1)
         }
+        # Glob patterns (`scripts/*.sh` in a shellcheck command line) name
+        # no single file, so hinting them offers an open that always
+        # fails. Point at the DIRECTORY that contains them instead, which
+        # is the useful thing to open; a bare `*.sh` with no directory
+        # part is dropped entirely.
+        if (s ~ /[*?]/) {
+          if (s ~ /\//) {
+            sub(/\/[^\/]*[*?][^\/]*$/, "", s)
+          } else {
+            s = ""
+          }
+        }
         # UNMATCHED wrapper: prose like "(assets/style.json copied ...)"
         # whitespace-splits the opener onto the span with its closer words
         # away, so the matched rule above never fires. An opener whose

--- a/scripts/open-popup.sh
+++ b/scripts/open-popup.sh
@@ -32,4 +32,23 @@ if [ -n "${QUICKLOOK_PREVIEW_CWD:-$PWD}" ]; then
   set -- "$@" --env "QUICKLOOK_PREVIEW_CWD=${QUICKLOOK_PREVIEW_CWD:-$PWD}"
 fi
 
-exec "$herdr_bin" "$@"
+# Not exec: the pane's LABEL is what the border shows, so name it after the
+# object being previewed ("Preview: vcs.sh") instead of a generic "Preview".
+# That is also why the renderer no longer draws a filename header row - the
+# name lives in the chrome, where it costs no content line and cannot wrap.
+out="$("$herdr_bin" "$@" 2>/dev/null)" || exit 0
+printf '%s' "$out"
+
+case "$token" in
+  '#'*) label="PR ${token%% *}" ;;
+  https://github.com/*/pull/*) label="PR #${token##*/}" ;;
+  *) label="${token##*/}"; [ -n "$label" ] || label="$token" ;;
+esac
+# strip a :line suffix so the label stays the object's name
+label="${label%%:*}"
+
+if [ -n "$label" ] && command -v jq >/dev/null 2>&1; then
+  pane="$(printf '%s' "$out" | jq -r '.result.plugin_pane.pane.pane_id // empty' 2>/dev/null)"
+  [ -n "$pane" ] && "$herdr_bin" pane rename "$pane" "Preview: $label" >/dev/null 2>&1
+fi
+exit 0

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -38,26 +38,14 @@ render_text() {
     # that config and un-sync the panes, so QUICKLOOK_BAT_THEME adds a
     # --theme flag ONLY when explicitly set.
     #
-    # style=numbers,header puts the FILENAME on top, where it belongs; the
-    # footer stays keys-only.
-    #
-    # The header occupies rows in the LESSOPEN-filtered stream that `less
-    # +N` counts, so a `path:N` jump must skip them. Its height is NOT a
-    # constant: bat wraps the "File: ..." line, so a long path in a narrow
-    # pane takes two rows where a short one takes one (measured both).
-    # Measure it instead of guessing, with a one-line probe render, and
-    # only when a jump was actually requested.
-    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers,header %s"
+    # style=numbers, no header: the object's name lives in the PANE LABEL
+    # (open-popup.sh renames the pane "Preview: <name>"), which costs no
+    # content row and cannot wrap. A header row would also shift every
+    # `path:N` jump, since `less +N` counts rows in this filtered stream
+    # and bat wraps a long "File: ..." path onto a second row.
+    LESSOPEN="|bat --color=always $(_bat_theme_flag)--style=numbers %s"
     export LESSOPEN
-    local jump="$line" probe
-    if [ -n "$jump" ]; then
-      probe="$(bat --color=always --style=numbers,header --line-range 1:1 -- "$target" 2>/dev/null | wc -l | tr -d ' ')"
-      case "$probe" in
-        '' | *[!0-9]*) : ;;
-        *) [ "$probe" -gt 1 ] && jump=$((jump + probe - 1)) ;;
-      esac
-    fi
-    exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${jump:++$jump} "$target"
+    exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
   fi
   exec less -N "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
 }

--- a/tests/open-preview.bats
+++ b/tests/open-preview.bats
@@ -48,3 +48,41 @@ teardown() { rm -rf "$STUB"; }
   run bash "$SCRIPT"
   ! grep -qx 'QUICKLOOK_TOKEN=plugin' <<<"$output"
 }
+
+# ---- the popup pane is named after the object it shows ----
+
+@test "open-popup: renames the pane after the file, not a generic Preview" {
+  local stub hlog
+  stub="$(mktemp -d)"; hlog="$(mktemp)"
+  cat > "$stub/herdr" <<HERDR
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$hlog"
+printf '{"result":{"plugin_pane":{"pane":{"pane_id":"POPPANE"}}}}\n'
+exit 0
+HERDR
+  chmod +x "$stub/herdr"
+  printf '#!/usr/bin/env bash\nprintf "POPPANE\\n"\n' > "$stub/jq"; chmod +x "$stub/jq"
+  PATH="$stub:/usr/bin:/bin" HERDR_BIN_PATH="$stub/herdr" \
+    run bash "$BATS_TEST_DIRNAME/../scripts/open-popup.sh" /tmp/some/vcs.sh
+  [ "$status" -eq 0 ]
+  grep -qF "pane rename POPPANE Preview: vcs.sh" "$hlog"
+  rm -rf "$stub"
+}
+
+@test "open-popup: a PR ref is labelled as a PR, not a path basename" {
+  local stub hlog
+  stub="$(mktemp -d)"; hlog="$(mktemp)"
+  cat > "$stub/herdr" <<HERDR
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$hlog"
+printf '{"result":{"plugin_pane":{"pane":{"pane_id":"POPPANE"}}}}\n'
+exit 0
+HERDR
+  chmod +x "$stub/herdr"
+  printf '#!/usr/bin/env bash\nprintf "POPPANE\\n"\n' > "$stub/jq"; chmod +x "$stub/jq"
+  PATH="$stub:/usr/bin:/bin" HERDR_BIN_PATH="$stub/herdr" \
+    run bash "$BATS_TEST_DIRNAME/../scripts/open-popup.sh" '#65'
+  [ "$status" -eq 0 ]
+  grep -qF "pane rename POPPANE Preview: PR #65" "$hlog"
+  rm -rf "$stub"
+}

--- a/tests/pick-scan.bats
+++ b/tests/pick-scan.bats
@@ -612,3 +612,16 @@ SCRIPT
   run pick_scan_text <<<'Update(sub/inrepo.md'
   [[ "$output" != *"$(printf 'Update\t')"* ]]
 }
+
+# ---- glob patterns name no single file ----
+
+@test "pick_scan_text: a glob resolves to the directory that contains it" {
+  run pick_scan_text <<<'shellcheck -x sub/*.md now'
+  [[ "$output" == *"$(printf 'sub\tpath')"* || "$output" == *"$(printf 'sub\tdir')"* ]]
+  [[ "$output" != *"*"* ]]
+}
+
+@test "pick_scan_text: a bare glob with no directory part is dropped" {
+  run pick_scan_text <<<'run *.md now'
+  [[ "$output" != *"*.md"* ]]
+}

--- a/tests/renderers-text-theme.bats
+++ b/tests/renderers-text-theme.bats
@@ -23,7 +23,7 @@ teardown() {
 @test "render_text: no theme flag by default (bat config decides, like the viewer)" {
   run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers,header"* ]]
+  [[ "$output" == *"LESSOPEN=|bat --color=always --style=numbers"* ]]
   [[ "$output" != *"--theme"* ]]
 }
 
@@ -35,33 +35,26 @@ teardown() {
 
 # ---- line-jump parity: the LESSOPEN filter must not shift line numbers ----
 
-@test "the header-height probe predicts the full render's row count" {
+@test "the LESSOPEN filter adds no row (so less +N is exact)" {
   local real_bat
   real_bat="$(PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin command -v bat)" || skip "bat not installed"
   local f="$FIX/five.txt"
   seq 1 5 | sed 's/^/line /' > "$f"
-  local probe full
-  probe="$("$real_bat" --color=always --style=numbers,header --line-range 1:1 -- "$f" | wc -l | tr -d ' ')"
-  full="$("$real_bat" --color=always --style=numbers,header -- "$f" | wc -l | tr -d ' ')"
-  # header rows = probe - 1 (the probe also renders one content row), so a
-  # 5-line file must render as 5 + (probe - 1) rows. This is the identity
-  # render_text's jump compensation relies on; a fixed constant is WRONG
-  # because bat wraps a long "File: ..." path onto a second row.
-  [ "$full" -eq "$((5 + probe - 1))" ]
+  # one rendered row per source line: the object's name lives in the pane
+  # LABEL now, so no header row can shift a path:N jump.
+  [ "$("$real_bat" --color=always --style=numbers "$f" | wc -l | tr -d ' ')" -eq 5 ]
 }
 
-@test "render_text shifts a line jump past the measured header rows" {
-  command -v bat >/dev/null 2>&1 || skip "stub bat required"
-  # stub bat prints one row for the probe -> probe=1 -> no shift; the real
-  # behaviour with a multi-row header is covered by the identity test above.
-  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt' 10"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"+1"* ]]
-}
-
-@test "render_text without bat does NOT shift the jump (no header in that stream)" {
-  rm -f "$STUB/bat"
+@test "render_text passes the jump through unchanged (no header to skip)" {
   run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt' 10"
   [ "$status" -eq 0 ]
   [[ "$output" == *"+10"* ]]
+}
+
+@test "render_text's LESSOPEN uses no line-adding decoration" {
+  run bash -c "unset QUICKLOOK_BAT_THEME; . '$LIB'; render_text '$FIX/doc.txt'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--style=numbers"* ]]
+  [[ "$output" != *"header"* ]]
+  [[ "$output" != *"grid"* ]]
 }


### PR DESCRIPTION
The filename sat in a bat header row inside the content, where a long
path wrapped onto a second line and pushed the file down. It belongs in
the chrome: open-popup.sh now renames the pane "Preview: <name>" (a path
basename, or "PR #65" for a PR ref) and the header row is dropped.

That deletes code rather than adding it: with no header in the filtered
stream, the measured line-jump compensation from the previous change is
unnecessary and gone, and less +N is exact again by construction.

Glob patterns named no single file, so hinting them offered an open that
could only fail. scripts/*.sh now points at the directory that contains
it, which is the useful thing to open, and a bare *.sh with no directory
part is dropped.
