### PR TITLE
fix(preview): colour git show, add a left gutter, drop two false detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- `git show` renders in colour again. git only colourises when stdout is a
+  TTY and the renderer pipes it into less, so a commit diff arrived plain
+  white.
+- Text previews get a left gutter instead of starting flush against the
+  pane border.
+- Shell syntax stops being mistaken for a filename: `2>/dev/null` and any
+  other `/dev/*` device is no longer offered, and a wrapped `Bash(S=/x/y`
+  line hints the path rather than the verb.
+- A path the transcript elided with a trailing ellipsis now opens: the
+  visible part is an exact prefix, so it expands when exactly one file or
+  directory matches (an ambiguous prefix is left alone rather than
+  guessed).
+
 - The previewed object's name now shows in the pager footer
   ("vcs.sh . q quit . o viewer ..."). A plugin pane's border is drawn from
   the manifest title and ignores the pane label, so the border cannot

--- a/scripts/handlers/vcs.sh
+++ b/scripts/handlers/vcs.sh
@@ -94,6 +94,8 @@ handle_vcs() {
       RESOLVED_LINE=""
       RESOLVED_MODE="command"
       # The SHA on screen often belongs to ANOTHER repo (a commit list
+      # color.ui=always because git colours only when stdout is a TTY and
+      # the renderer pipes it into less, so the diff arrived plain white.
       # from a sibling checkout), and `git show` in the pane's own repo
       # answers "fatal: ambiguous argument" instead of rendering it. Find
       # the repo that actually has the object first; bounded, and only
@@ -106,9 +108,9 @@ handle_vcs() {
         repo="$(_vcs_repo_with_commit "$raw" || true)"
       fi
       if [ -n "$repo" ]; then
-        RESOLVED_CMD=(git -C "$repo" show --end-of-options "$raw")
+        RESOLVED_CMD=(git -C "$repo" -c color.ui=always show --end-of-options "$raw")
       else
-        RESOLVED_CMD=(git show --end-of-options "$raw")
+        RESOLVED_CMD=(git -c color.ui=always show --end-of-options "$raw")
       fi
       return 0
       ;;

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -394,6 +394,13 @@ _pane_rows() {
   printf '%s' "$sz"
 }
 
+# pad_left: one gutter of breathing room between the pane border and the
+# text. Prefix-only, so ANSI colour runs are untouched, and rows are
+# unchanged so a `path:N` jump still lands on the same line.
+pad_left() {
+  sed 's/^/  /'
+}
+
 pad_to_pane_height() {
   local rows
   rows="$(_pane_rows)"
@@ -776,7 +783,7 @@ render_command_in_pager() {
   # `printf | less` in a fresh pane, so this is the pane's behaviour, not
   # ours). Padding at END keeps the stream streaming: nothing is buffered,
   # the blank rows are only appended once the real output has ended.
-  CLICOLOR_FORCE=1 "$@" 2>&1 | pad_to_pane_height \
+  CLICOLOR_FORCE=1 "$@" 2>&1 | pad_left | pad_to_pane_height \
     | less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}"
 }
 
@@ -785,6 +792,38 @@ render_command_in_pager() {
 # RESOLVED_CMD for command mode) and returns 0 on a resolved token, or
 # returns 1 if no handler matched, or the matched handler could not resolve
 # a target (caller does its own fallback, if any).
+# expand_elided <token>: a transcript elides a long path mid-render
+# ("/private/tmp/.../f647b92b-2093-44f5-baa3-8e797a…"), leaving a token that
+# names nothing. Everything BEFORE the ellipsis is still an exact prefix,
+# so glob it. Only a UNIQUE match is accepted, since two candidates mean
+# guessing which file the user meant; anything else returns the token
+# unchanged and the normal miss path takes over. Runs before handler
+# dispatch, so the expanded path flows through the ordinary file/dir
+# handlers (a truncated DIRECTORY still opens in the viewer).
+expand_elided() {
+  local t="$1" prefix
+  case "$t" in
+    *'…' | *...) ;;
+    *) printf '%s' "$t"; return 0 ;;
+  esac
+  prefix="${t%'…'}"
+  prefix="${prefix%...}"
+  case "$prefix" in
+    '' | *[!/]*) ;;
+    *) printf '%s' "$t"; return 0 ;;
+  esac
+  [ -n "$prefix" ] || { printf '%s' "$t"; return 0; }
+  local m=()
+  # nullglob is off here on purpose: an unmatched pattern stays literal and
+  # the -e test below rejects it.
+  m=("$prefix"*)
+  if [ "${#m[@]}" -eq 1 ] && [ -e "${m[0]}" ]; then
+    printf '%s' "${m[0]}"
+    return 0
+  fi
+  printf '%s' "$t"
+}
+
 resolve_any_token() {
   local raw="$1" kind
   # A copied shell path routinely arrives tilde-form; no handler expands it,
@@ -795,6 +834,7 @@ resolve_any_token() {
     '~/'*) raw="$HOME/${raw#'~/'}" ;;
     '~') raw="$HOME" ;;
   esac
+  raw="$(expand_elided "$raw")"
   RESOLVED_TARGET=""
   RESOLVED_LINE=""
   RESOLVED_MODE=""
@@ -1399,6 +1439,23 @@ pick_scan_text() {
         # unopenable token whose hint lands on the `U`. Keep the inside.
         if (match(s, /^[A-Za-z_][A-Za-z0-9_.-]*\(/) && substr(s, length(s), 1) == ")") {
           s = substr(s, RLENGTH + 1, length(s) - RLENGTH - 1)
+        }
+        # Same call shape, but the closer is off the span: a wrapped
+        # `Bash(S=/private/...` line splits before the `)`, so the rule
+        # above cannot fire and the hint lands on the `B`. An opener whose
+        # closer never appears comes off the left.
+        if (match(s, /^[A-Za-z_][A-Za-z0-9_.-]*\(/) && index(s, ")") == 0) {
+          s = substr(s, RLENGTH + 1)
+        }
+        # Redirect prefix: `2>/dev/null`, `>out.log`, `2>&1`. The operator
+        # is shell syntax, not part of the name.
+        if (match(s, /^[0-9]*[<>]+&?/)) {
+          s = substr(s, RLENGTH + 1)
+        }
+        # Device files are not previewable content, and `/dev/null` is the
+        # single most common false positive in a shell transcript.
+        if (s ~ /^\/dev\//) {
+          s = ""
         }
         # Shell assignment prefix: `S=/private/tmp/...` hints on the `S`
         # and resolves nothing. Keep the value.

--- a/scripts/renderers/text.sh
+++ b/scripts/renderers/text.sh
@@ -60,18 +60,23 @@ render_text() {
       # nothing here, since LESSOPEN was already feeding less from a pipe.
       # shellcheck disable=SC2086
       bat --color=always $theme --style=numbers "$target" \
-        | pad_to_pane_height \
+        | pad_left | pad_to_pane_height \
         | less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line}
       return 0
     fi
     # Long file: already fills the pane, so keep less file-backed (seekable,
     # shows a real percentage) instead of buffering a pipe.
-    LESSOPEN="|bat --color=always $theme--style=numbers %s"
+    # LESSOPEN is a command STRING that less hands to a shell, so the inner
+    # quotes are meant literally and the shell does respect them; that is
+    # what SC2089/SC2090 warn about and why an array cannot be used here.
+    # shellcheck disable=SC2089
+    LESSOPEN="|bat --color=always $theme--style=numbers %s | sed 's/^/  /'"
+    # shellcheck disable=SC2090
     export LESSOPEN
     exec less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line} "$target"
   fi
   if _fits_in_pane "$target"; then
-    pad_to_pane_height < "$target" \
+    pad_left < "$target" | pad_to_pane_height \
       | less -N "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}" ${line:++$line}
     return 0
   fi

--- a/tests/handlers-vcs.bats
+++ b/tests/handlers-vcs.bats
@@ -128,11 +128,11 @@ teardown() {
 @test "handle_vcs: a valid SHA builds the exact argv git show --end-of-options <sha>" {
   handle_vcs "abc1234"
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
+  local n=${#RESOLVED_CMD[@]}
   [ "${RESOLVED_CMD[0]}" = "git" ]
-  [ "${RESOLVED_CMD[1]}" = "show" ]
-  [ "${RESOLVED_CMD[2]}" = "--end-of-options" ]
-  [ "${RESOLVED_CMD[3]}" = "abc1234" ]
+  [ "${RESOLVED_CMD[n-1]}" = "abc1234" ]
+  [ "${RESOLVED_CMD[n-2]}" = "--end-of-options" ]
+  printf '%s\n' "${RESOLVED_CMD[@]}" | grep -qx "show"
   # goal file's literal example is `git show -- <sha>`; this deliberately
   # uses `--end-of-options` instead of a trailing `--` - see the comment in
   # vcs.sh and this sub-goal's DECISIONS.md entry ("`--` silently shows HEAD
@@ -189,8 +189,9 @@ teardown() {
 @test "argv-shape control: a space-and-metacharacter value still lands as ONE arg after the SHA branch's --end-of-options" {
   handle_vcs 'abc1234 && rm -rf / #'
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${#RESOLVED_CMD[@]}" -eq 4 ]
-  [ "${RESOLVED_CMD[3]}" = 'abc1234 && rm -rf / #' ]
+  local n=${#RESOLVED_CMD[@]}
+  [ "${RESOLVED_CMD[n-1]}" = 'abc1234 && rm -rf / #' ]
+  [ "${RESOLVED_CMD[n-2]}" = "--end-of-options" ]
 }
 
 @test "argv-shape control: a flag-injection value through the #-branch still lands as ONE arg" {
@@ -234,8 +235,9 @@ teardown() {
   # proves handle_vcs's OWN argv construction is safe in depth: git rejects
   # the injected-looking flag rather than acting on it.
   handle_vcs "--upload-pack=/tmp/evil"
-  [ "${RESOLVED_CMD[2]}" = "--end-of-options" ]
-  [ "${RESOLVED_CMD[3]}" = "--upload-pack=/tmp/evil" ]
+  local n=${#RESOLVED_CMD[@]}
+  [ "${RESOLVED_CMD[n-2]}" = "--end-of-options" ]
+  [ "${RESOLVED_CMD[n-1]}" = "--upload-pack=/tmp/evil" ]
   run "${RESOLVED_CMD[@]}"
   [ "$status" -ne 0 ]
   [[ "$output" == *"must come before non-option arguments"* || "$output" == *"unknown"* || "$output" == *fatal* ]]
@@ -257,7 +259,7 @@ teardown() {
 @test "registry: a bare SHA dispatches to vcs end to end through resolve_any_token" {
   resolve_any_token "$REAL_SHA"
   [ "$RESOLVED_MODE" = "command" ]
-  [ "${RESOLVED_CMD[*]}" = "git show --end-of-options $REAL_SHA" ]
+  [ "${RESOLVED_CMD[*]}" = "git -c color.ui=always show --end-of-options $REAL_SHA" ]
 }
 
 @test "registry: a #123 hashref dispatches to vcs end to end through resolve_any_token" {
@@ -323,4 +325,11 @@ teardown() {
   [ "${RESOLVED_CMD[0]}" = "bash" ]
   [[ "${RESOLVED_CMD[1]}" == *"/pr-view.sh" ]]
   [ "${RESOLVED_CMD[2]}" = "123" ]
+}
+
+@test "a bare SHA renders git show in colour (it is piped, not on a tty)" {
+  cd "$FIX"
+  resolve_any_token "$REAL_SHA"
+  [ "$RESOLVED_MODE" = "command" ]
+  printf '%s\n' "${RESOLVED_CMD[@]}" | grep -qx "color.ui=always"
 }

--- a/tests/pick-scan.bats
+++ b/tests/pick-scan.bats
@@ -625,3 +625,42 @@ SCRIPT
   run pick_scan_text <<<'run *.md now'
   [[ "$output" != *"*.md"* ]]
 }
+
+# ---- shell syntax is not a filename ----
+
+@test "pick_scan_text: a redirect target /dev/null is not offered" {
+  mkdir -p "$FIX/repo/.githooks"
+  run pick_scan_text <<<'ls .githooks 2>/dev/null)'
+  [[ "$output" != *"/dev/null"* ]]
+  [[ "$output" == *".githooks"* ]]
+}
+
+@test "pick_scan_text: an unclosed call wrapper hints the path, not the verb" {
+  run pick_scan_text <<<"Bash(S=$FIX/repo/sub"
+  [[ "$output" != *"Bash("* ]]
+  [[ "$output" == *"$FIX/repo/sub"* ]]
+}
+
+# ---- a transcript-elided path still opens ----
+
+@test "expand_elided: a unique prefix match expands to the real path" {
+  mkdir -p "$FIX/sess-abc123def"
+  run expand_elided "$FIX/sess-abc123…"
+  [ "$output" = "$FIX/sess-abc123def" ]
+}
+
+@test "expand_elided: an ambiguous prefix is left alone rather than guessed" {
+  mkdir -p "$FIX/amb-one" "$FIX/amb-two"
+  run expand_elided "$FIX/amb-…"
+  [ "$output" = "$FIX/amb-…" ]
+}
+
+@test "expand_elided: a token with no ellipsis is untouched" {
+  run expand_elided "scripts/lib.sh"
+  [ "$output" = "scripts/lib.sh" ]
+}
+
+@test "pad_left: indents every row without disturbing the row count" {
+  run bash -c ". '$LIB'; printf 'a\nb\n' | pad_left"
+  [ "$output" = "$(printf '  a\n  b')" ]
+}


### PR DESCRIPTION
Five reported issues, four of them one-liners once the cause was clear.

git colourises only when stdout is a TTY, and the renderer pipes it into
less, so a commit diff rendered plain white; -c color.ui=always restores
it. CLICOLOR_FORCE, which the renderer already sets, does not reach git.

Text previews started flush against the pane border, so every render path
now goes through a left gutter.

Two false detections came from the same gap in the scanner: shell syntax
read as a filename. A redirect target (2>/dev/null) is stripped of its
operator and dropped as a device file, and the existing call-shape rule
only fired when the token ENDED with ")", so a wrapped "Bash(S=/x/y" line
put the hint on the B instead of the path.

An elided path ("/private/tmp/.../f647b92b-...8e797a...") named nothing
and could not be opened. The visible part is still an exact prefix, so it
is globbed and accepted when exactly one file or directory matches;
ambiguity is left alone rather than guessed at. It runs before handler
dispatch, so an elided directory still opens in the viewer.

Four vcs tests asserted argv by index from the front and broke on the new
-c flag. They assert the same property (the SHA is last, --end-of-options
immediately before it) counted from the END, so a prefix flag cannot
break them and a real ordering regression still fails them.
