### PR TITLE
fix(preview): measure the real pane width, rule markdown table rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+- Markdown previews use the pane's real width again. Every caller measured
+  with `tput cols` from inside a command substitution, where stdout is a
+  pipe, so tput answered with the terminfo default 80: prose re-wrapped into
+  a narrow ragged column and tables were squeezed into 80 columns of a much
+  wider pane. The width is now read off `/dev/tty` (the same way the
+  pane-height padding already did it), minus the left gutter, so a
+  full-width row no longer overflows and soft-wraps its own tail. Same fix
+  for the PR preview.
+- Markdown tables get a rule between rows. glamour draws only the header
+  rule and exposes no style key for the rest, so multi-line rows ran
+  together; the renderer now injects a marker row per gap and swaps each
+  rendered marker for a copy of that table's own header rule. Set
+  `QUICKLOOK_TABLE_RULES=0` to keep glow's bare tables.
+
 ## 0.6.0 (2026-07-26)
 
 - `git show` renders in colour again. git only colourises when stdout is a

--- a/config.example
+++ b/config.example
@@ -26,6 +26,11 @@
 # plugin is installed (so preview and viewer look identical), else "auto".
 #QUICKLOOK_GLOW_STYLE=
 
+# QUICKLOOK_TABLE_RULES: draw a horizontal rule between markdown table rows.
+# glamour draws only the header rule, so multi-line rows run together. Set 0
+# to leave tables exactly as glow renders them.
+#QUICKLOOK_TABLE_RULES=1
+
 # QUICKLOOK_BAT_THEME: bat theme override for code/text previews (and the
 # find pane's fzf preview). UNSET (the default), no --theme flag is passed
 # and your own bat config decides, exactly like herdr-file-viewer, so the

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -397,8 +397,35 @@ _pane_rows() {
 # pad_left: one gutter of breathing room between the pane border and the
 # text. Prefix-only, so ANSI colour runs are untouched, and rows are
 # unchanged so a `path:N` jump still lands on the same line.
+PAD_LEFT_COLS=2
 pad_left() {
   sed 's/^/  /'
+}
+
+# _pane_cols: the pane's real width, the column twin of _pane_rows and read
+# the same way and for the same reason. NOT `tput cols`: tput reads the size
+# off STDOUT, and every caller measures inside a command substitution (stdout
+# is a pipe by definition), so tput silently returns the terminfo default 80
+# no matter how wide the pane is. That was the whole "glow wraps at 80 in a
+# 200-column pane" bug.
+_pane_cols() {
+  local sz
+  { sz="$(stty size </dev/tty)"; } 2>/dev/null || sz=""
+  sz="${sz##* }"
+  case "$sz" in '' | *[!0-9]*) sz="${COLUMNS:-0}" ;; esac
+  case "$sz" in '' | *[!0-9]*) sz=0 ;; esac
+  printf '%s' "$sz"
+}
+
+# pane_cols: the width a formatter (glow, gh) may wrap to, i.e. the pane
+# minus the pad_left gutter , without that subtraction every full-width row
+# overflows by the gutter and less soft-wraps its tail onto the next line.
+# Floors at 80 when the size is unreadable, so a formatter never gets 0.
+pane_cols() {
+  local sz
+  sz="$(_pane_cols)"
+  [ "$sz" -gt $((PAD_LEFT_COLS + 20)) ] || sz=$((80 + PAD_LEFT_COLS))
+  printf '%s' "$((sz - PAD_LEFT_COLS))"
 }
 
 pad_to_pane_height() {

--- a/scripts/pr-view.sh
+++ b/scripts/pr-view.sh
@@ -38,7 +38,9 @@ if [ "$head_block" = "$out" ]; then
 fi
 body="${out#*$'\n'--$'\n'}"
 
-cols="$(tput cols 2>/dev/null)" || cols=100
+# pane_cols, not `tput cols`: this is a command substitution, so tput reads
+# the terminfo default 80 off a pipe instead of the pane's real width.
+cols="$(pane_cols)"
 case "$cols" in '' | *[!0-9]*) cols=100 ;; esac
 [ "$cols" -gt 120 ] && cols=120
 

--- a/scripts/renderers/markdown.sh
+++ b/scripts/renderers/markdown.sh
@@ -50,12 +50,65 @@ _markdown_glow_style() {
   printf 'auto'
 }
 
+# glamour draws a table's header rule and its column separators, but has no
+# per-row rule and no style key that turns one on (border_row / row_border /
+# border / table_border are all ignored by glow 2.1.2), so multi-line rows
+# run together , the readability complaint these two filters fix.
+#
+# _md_table_spacers (pre): inject a marker ROW between every pair of data
+# rows, so glamour lays it out with the table's real column geometry.
+# _md_table_rules (post): swap each rendered marker line for a copy of that
+# table's own header rule, which glamour already drew at exactly the right
+# width. Splitting it this way is what keeps the filter ANSI-safe , we never
+# parse styled output, we replace whole lines and reuse a line glamour made.
+MD_TABLE_MARK='⟦qlhr⟧'
+
+_md_table_spacers() {
+  awk -v mark="$MD_TABLE_MARK" '
+    /^[ \t]*(```|~~~)/ { fence = !fence; print; next }
+    fence { print; next }
+    $0 !~ /^[ \t]*\|/ { intable = 0; print; next }
+    # the |---|---| delimiter row opens the table and fixes its column count
+    $0 ~ /^[ \t]*\|[ \t:|-]+\|[ \t]*$/ {
+      intable = 1; seen = 0; pipes = gsub(/\|/, "|"); print; next
+    }
+    {
+      if (intable && seen) {
+        s = "|" mark
+        for (i = 1; i < pipes; i++) s = s "|"
+        print s
+      }
+      if (intable) seen = 1
+      print
+    }
+  '
+}
+
+# `┼` only ever appears in glamour's header rule, so it is the cheapest
+# byte-literal way to spot that line without decoding ANSI or multibyte
+# content. h stores it; g replays it over the marker line. The match is on
+# the marker's opening bracket alone, so a narrow first column that ellipses
+# the marker's tail still gets swapped.
+_md_table_rules() {
+  sed -e '/┼/h' -e '/⟦/{ g; }'
+}
+
+_md_glow() {
+  local target="$1" cols="$2" style
+  style="$(_markdown_glow_style)"
+  if [ "${QUICKLOOK_TABLE_RULES:-1}" = 0 ]; then
+    glow -s "$style" -w "$cols" -- "$target"
+    return
+  fi
+  _md_table_spacers <"$target" | glow -s "$style" -w "$cols" - | _md_table_rules
+}
+
 render_markdown() {
-  local target="$1" cols
+  local target="$1"
   # glow's stdout is a PIPE inside render_command_in_pager, so its auto
   # width is a hard 80 no matter how wide the pane is; source lines wider
-  # than 80 then double-wrap into ragged orphan fragments. stdout here is
-  # still the pane's TTY, so measure it and pass the width explicitly.
-  cols="$(tput cols 2>/dev/null)" || cols=80
-  render_command_in_pager glow -s "$(_markdown_glow_style)" -w "${cols:-80}" -- "$target"
+  # than 80 then double-wrap into ragged orphan fragments, and tables get
+  # squeezed into 80 columns of a much wider pane. pane_cols (lib.sh) reads
+  # the true width off /dev/tty and already subtracts the pad_left gutter.
+  render_command_in_pager _md_glow "$target" "$(pane_cols)"
 }

--- a/tests/renderers-markdown.bats
+++ b/tests/renderers-markdown.bats
@@ -90,9 +90,23 @@ SH
   [ "$status" -eq 0 ]
   [[ "$output" == *"GLOW_ARGS:"* ]]
   [[ "$output" == *"-s auto"* ]]
-  [[ "$output" == *"$FIX/doc.md"* ]]
   [[ "$output" == *"LESS_ARGS:"* ]]
   [[ "$output" == *"-R"* ]]
+}
+
+@test "render_markdown: table rules on (default) - the source is filtered into glow's stdin" {
+  stub_with_glow
+  run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GLOW_ARGS:"*" -"* ]]
+  [[ "$output" != *"$FIX/doc.md"* ]]
+}
+
+@test "render_markdown: QUICKLOOK_TABLE_RULES=0 hands glow the file directly" {
+  stub_with_glow
+  QUICKLOOK_TABLE_RULES=0 run render_markdown "$FIX/doc.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$FIX/doc.md"* ]]
 }
 
 @test "render_markdown: the line arg is accepted but ignored (best-effort, no error)" {
@@ -145,13 +159,52 @@ SH
   [[ "$output" =~ -w\ [0-9]+ ]]
 }
 
-@test "render_markdown: -w carries the measured TTY width (stubbed tput)" {
+# The pre-fix bug: `tput cols` reads the size off STDOUT, and render_markdown
+# measures inside a command substitution (a pipe), so glow got a hard -w 80 in
+# a 200-column pane. pane_cols reads /dev/tty instead, minus the pad_left
+# gutter, so glow's full-width rows do not then overflow and soft-wrap.
+@test "render_markdown: -w carries the measured pane width minus the gutter" {
   stub_with_glow
-  printf '#!/usr/bin/env bash\nprintf "132\\n"\n' > "$STUB/tput"
-  chmod +x "$STUB/tput"
-  run render_markdown "$FIX/doc.md"
+  run bash -c ". '$LIB'; _pane_cols() { printf '132'; }; render_markdown '$FIX/doc.md'"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"-w 132"* ]]
+  [[ "$output" == *"-w 130"* ]]
+}
+
+@test "render_markdown: an unmeasurable width floors at 80, never 0" {
+  stub_with_glow
+  run bash -c ". '$LIB'; _pane_cols() { printf '0'; }; render_markdown '$FIX/doc.md'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-w 80"* ]]
+}
+
+@test "_pane_cols is silent and numeric with no controlling tty" {
+  run bash -c ". '$LIB'; unset COLUMNS; _pane_cols" < /dev/null
+  [ "$status" -eq 0 ]
+  [ "$output" = "0" ]
+}
+
+# ---- table row rules (glamour draws no per-row rule of its own) ----
+
+@test "_md_table_spacers: inserts a marker row between data rows, never before the first" {
+  printf '| A | B |\n|---|---|\n| one | two |\n| three | four |\n' > "$FIX/tbl.md"
+  run _md_table_spacers < "$FIX/tbl.md"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c 'qlhr')" -eq 1 ]
+  [ "$(printf '%s\n' "$output" | sed -n '4p')" = "|⟦qlhr⟧||" ]
+}
+
+@test "_md_table_spacers: leaves a table inside a fenced code block alone" {
+  printf '```\n| A | B |\n|---|---|\n| one | two |\n| three | four |\n```\n' > "$FIX/fenced.md"
+  run _md_table_spacers < "$FIX/fenced.md"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *qlhr* ]]
+}
+
+@test "_md_table_rules: replaces the marker line with that table's own header rule" {
+  run bash -c ". '$LIB'; printf ' A   \xe2\x94\x82 B\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\xbc\xe2\x94\x80\xe2\x94\x80\n one \xe2\x94\x82 two\n \xe2\x9f\xa6qlhr\xe2\x9f\xa7 \xe2\x94\x82\n x   \xe2\x94\x82 y\n' | _md_table_rules"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *qlhr* ]]
+  [ "$(printf '%s\n' "$output" | sed -n '2p')" = "$(printf '%s\n' "$output" | sed -n '4p')" ]
 }
 
 # ---- render_any dispatch: glow-present renders, glow-absent degrades ----


### PR DESCRIPTION
Three reported symptoms in the markdown preview, two causes.

## Prose re-wrapped narrow, tables squeezed

Both width callers measured with `tput cols` from inside a command
substitution. tput reads the size off stdout, which is a pipe there, so it
answered with the terminfo default 80 no matter how wide the pane was:
prose reflowed into a narrow ragged column and glamour packed three columns
into 80 of a much wider pane.

`pane_cols` reads `/dev/tty` via `stty size` instead, the same way
`pad_to_pane_height` already read the height, and subtracts the `pad_left`
gutter so a full-width row no longer overflows and soft-wraps its own tail.
`scripts/pr-view.sh` had the identical bug and gets the same fix.

## Table rows run together

glamour draws a table's header rule and nothing between rows, and exposes no
style key for the rest: `border_row`, `row_border`, `border` and
`table_border` are all silently ignored (tested individually against glow
2.1.2). Multi-line rows therefore blur into each other.

The renderer now injects a marker row into each row gap before glow lays the
table out, then swaps each rendered marker line for a copy of that table's
own header rule. Splitting it that way keeps the filter ANSI-safe: nothing
parses styled output, whole lines are replaced with a line glamour itself
drew at exactly the right width. `QUICKLOOK_TABLE_RULES=0` opts out.

## Verification

- `bats tests/` — 499 passed, 0 failed
- `shellcheck -x` clean on `lib.sh`, `renderers/markdown.sh`, `pr-view.sh`
- 6 new tests: gutter arithmetic, the 80-column floor, no-tty behaviour,
  spacer injection, fenced-code immunity, the rule swap. Two existing tests
  updated for the new shape.

## Note

With table rules on, glow reads from stdin instead of the file path, so it
no longer sees the filename. Nothing in the render path uses it; the
`QUICKLOOK_TABLE_RULES=0` path still passes the file directly.
