### PR TITLE
feat(preview): Ctrl+clickable paths and URLs in the pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Paths and URLs in a preview are Ctrl+clickable. The pager now wraps every
+  path/URL-shaped span in the same OSC-8 sentinel the hint overlay uses, so
+  a click routes through the `virtual-token` handler and opens that object.
+  Unlike the linkify pane removed in 0.4.0, this classifies nothing: it
+  matches on shape, never touches the filesystem, and leaves resolution to
+  the click path (which already resolves and already reports a miss), so a
+  whole document is linked in one pass with no forks. `QUICKLOOK_LINKIFY=0`
+  renders without links.
+
 - Markdown previews use the pane's real width again. Every caller measured
   with `tput cols` from inside a command substitution, where stdout is a
   pipe, so tput answered with the terminfo default 80: prose re-wrapped into

--- a/config.example
+++ b/config.example
@@ -31,6 +31,12 @@
 # to leave tables exactly as glow renders them.
 #QUICKLOOK_TABLE_RULES=1
 
+# QUICKLOOK_LINKIFY: wrap every path/URL-shaped span in the preview in an
+# OSC-8 link, so Ctrl+click opens it (same transport the hint overlay uses).
+# Matches on shape only and never touches the filesystem; resolution happens
+# at click time. Set 0 to render without links.
+#QUICKLOOK_LINKIFY=1
+
 # QUICKLOOK_BAT_THEME: bat theme override for code/text previews (and the
 # find pane's fzf preview). UNSET (the default), no --theme flag is passed
 # and your own bat config decides, exactly like herdr-file-viewer, so the

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -428,6 +428,97 @@ pane_cols() {
   printf '%s' "$((sz - PAD_LEFT_COLS))"
 }
 
+# linkify: stdin -> stdout, wrapping every path/URL-shaped span in the
+# OSC-8 sentinel URI the `virtual-token` handler already understands, so a
+# Ctrl+click inside the preview opens that object. Same transport hint-pane
+# uses (quicklook_link_uri / open-link); this is the pager-side emitter.
+#
+# WHY this is not the linkify pane that PR #23 deleted: that one CLASSIFIED
+# every span (resolve + git lookups per token), which is why it had to be
+# scoped to one visible screen and still ran in a background subshell. This
+# one classifies NOTHING. It matches on SHAPE only, never touches the
+# filesystem, and leaves resolution to the click path, which already
+# resolves and already reports a miss ("not a file I can find"). A
+# false-positive link that fails on click is a far cheaper mistake than a
+# preview that takes a second to paint, so the whole document can be linked
+# in one awk pass with zero forks.
+#
+# Encoding must be byte-identical to jq's @uri (quicklook_token_from_link
+# re-encodes and demands a byte-for-byte match before it returns a token),
+# i.e. RFC 3986 unreserved [A-Za-z0-9._~-] verbatim, everything else %XX in
+# UPPERCASE hex. Verified against `jq -rn '$t|@uri'`.
+#
+# ANSI safety: bytes inside an escape sequence are copied through untouched
+# (only the plain-text runs between them are scanned), and a line that
+# already carries an OSC-8 link is passed through whole - glow emits its own
+# hyperlinks for markdown link syntax and nesting them would corrupt both.
+linkify() {
+  [ "${QUICKLOOK_LINKIFY:-1}" = 0 ] && { cat; return 0; }
+  awk -v prefix="$QUICKLOOK_LINK_PREFIX" '
+    BEGIN {
+      esc = sprintf("%c", 27)
+      for (i = 0; i < 256; i++) ord[sprintf("%c", i)] = i
+      unreserved = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._~-"
+      for (i = 1; i <= length(unreserved); i++) safe[substr(unreserved, i, 1)] = 1
+      # Leftmost-longest over: a URL, a slashed path with an extension, or a
+      # bare filename with a known extension. Each may carry a :LINE suffix.
+      ext = "(md|markdown|sh|bash|go|rs|py|ts|tsx|js|jsx|json|toml|yaml|yml|txt|c|h|cpp|rb|sql|css|html|bats)"
+      url = "https?://[^[:space:]<>\"]+"
+      # The leading `/` MUST be inside the start class: without it an absolute
+      # path matches from its second character, the link carries a relative
+      # `var/folders/...`, and the click resolves against the wrong root.
+      path = "[A-Za-z0-9_~/][A-Za-z0-9_./~+-]*/[A-Za-z0-9_.+-]+\\.[A-Za-z0-9]+(:[0-9]+)?"
+      bare = "[A-Za-z0-9_][A-Za-z0-9_.+-]*\\." ext "(:[0-9]+)?"
+      pat = "(" url ")|(" path ")|(" bare ")"
+    }
+    function encode(s,   i, c, out) {
+      out = ""
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        out = out (c in safe ? c : sprintf("%%%02X", ord[c]))
+      }
+      return out
+    }
+    function wrap(tok) {
+      return esc "]8;;" prefix encode(tok) esc "\\" tok esc "]8;;" esc "\\"
+    }
+    # scan(text): link every match in one plain-text run.
+    function scan(t,   out, m, l) {
+      out = ""
+      while (match(t, pat)) {
+        m = substr(t, RSTART, RLENGTH); l = RLENGTH
+        out = out substr(t, 1, RSTART - 1) wrap(m)
+        t = substr(t, RSTART + l)
+      }
+      return out t
+    }
+    {
+      if (index($0, esc "]8;")) { print; next }        # already hyperlinked
+      if (index($0, esc) == 0) { print scan($0); next } # fast path: no ANSI
+      # Mixed line: copy escape sequences verbatim, scan only the text runs.
+      line = $0; out = ""; run = ""
+      while (length(line) > 0) {
+        if (substr(line, 1, 1) == esc) {
+          # SGR/CSI (ESC[...letter) or a short 2-char escape; copy verbatim.
+          # seqlen is captured BEFORE scan() runs: scan calls match(), which
+          # clobbers RLENGTH, and a no-match leaves it -1, so reading RLENGTH
+          # afterwards makes substr(line, 0) return the whole line and this
+          # loop never terminates.
+          if (match(line, /^.\[[0-9;?]*[A-Za-z]/)) {
+            seqlen = RLENGTH
+            out = out scan(run) substr(line, 1, seqlen); run = ""
+            line = substr(line, seqlen + 1); continue
+          }
+          out = out scan(run) substr(line, 1, 2); run = ""
+          line = substr(line, 3); continue
+        }
+        run = run substr(line, 1, 1); line = substr(line, 2)
+      }
+      print out scan(run)
+    }
+  '
+}
+
 pad_to_pane_height() {
   local rows
   rows="$(_pane_rows)"
@@ -810,7 +901,7 @@ render_command_in_pager() {
   # `printf | less` in a fresh pane, so this is the pane's behaviour, not
   # ours). Padding at END keeps the stream streaming: nothing is buffered,
   # the blank rows are only appended once the real output has ended.
-  CLICOLOR_FORCE=1 "$@" 2>&1 | pad_left | pad_to_pane_height \
+  CLICOLOR_FORCE=1 "$@" 2>&1 | linkify | pad_left | pad_to_pane_height \
     | less -R "${lesskey_args[@]}" "${PAGER_PROMPT_ARGS[@]}"
 }
 

--- a/tests/linkify.bats
+++ b/tests/linkify.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Tests for lib.sh's `linkify`: the pager-side OSC-8 emitter that makes every
+# path/URL-shaped span in a preview Ctrl+clickable through the same
+# virtual-token transport hint-pane uses.
+#
+# The load-bearing property is the ENCODING: quicklook_token_from_link
+# re-encodes and demands a byte-for-byte match before it hands a token back,
+# so linkify's inline awk encoder must agree with jq's @uri exactly. Anything
+# else silently refuses every link at click time.
+
+setup() {
+  LIB="$BATS_TEST_DIRNAME/../scripts/lib.sh"
+  # shellcheck disable=SC1090
+  . "$LIB"
+  ESC=$'\033'
+}
+
+# uri_of <text> -> the first sentinel URI linkify emits for that text.
+uri_of() {
+  printf 'x %s x\n' "$1" | linkify \
+    | awk -v esc="$ESC" '{
+        s = index($0, esc "]8;;")
+        if (!s) exit 1
+        rest = substr($0, s + 5)
+        print substr(rest, 1, index(rest, esc) - 1)
+      }'
+}
+
+# ---- encoding parity with jq @uri (the click-path gate) ----
+
+@test "linkify: the inline encoder is byte-identical to jq @uri" {
+  for t in 'scripts/lib.sh' 'a/b.md:12' '~/x/y.md' 'docs/a+b.md'; do
+    [ "$(uri_of "$t")" = "$(quicklook_link_uri "$t")" ]
+  done
+}
+
+@test "linkify: an emitted link decodes back to the exact token" {
+  for t in 'scripts/lib.sh' 'docs/x.md:9'; do
+    [ "$(quicklook_token_from_link "$(uri_of "$t")")" = "$t" ]
+  done
+}
+
+# The regression this guards: with `/` missing from the pattern's start class
+# an absolute path matched from its SECOND character, so the link carried a
+# relative `var/folders/...` and the click resolved against the wrong root.
+@test "linkify: an absolute path is linked whole, leading slash included" {
+  [ "$(quicklook_token_from_link "$(uri_of /var/folders/x/T/doc.md)")" = "/var/folders/x/T/doc.md" ]
+}
+
+# ---- pass-through safety ----
+
+@test "linkify: prose with nothing openable is byte-identical" {
+  run bash -c ". '$LIB'; printf 'just some words, nothing openable\n' | linkify"
+  [ "$output" = "just some words, nothing openable" ]
+}
+
+@test "linkify: a line glow already hyperlinked is never nested into" {
+  local already="${ESC}]8;;https://x.test${ESC}\\see docs/a.md${ESC}]8;;${ESC}\\"
+  [ "$(printf '%s\n' "$already" | linkify)" = "$already" ]
+}
+
+@test "linkify: an SGR-coloured path keeps its colour and gains a link" {
+  local out
+  out="$(printf '%s\n' "${ESC}[31mscripts/lib.sh${ESC}[0m" | linkify)"
+  [[ "$out" == *"${ESC}[31m"* ]]
+  [[ "$out" == *"]8;;"* ]]
+  [[ "$out" == *"${ESC}[0m"* ]]
+}
+
+# A text run holding no token leaves RLENGTH at -1; reading it after scan()
+# made substr(line, 0) return the whole line and the awk loop never ended.
+@test "linkify: an ANSI line whose text has no token terminates" {
+  run timeout 20 bash -c ". '$LIB'; printf '${ESC}[1mplain words here${ESC}[0m\n' | linkify"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"plain words here"* ]]
+}
+
+@test "linkify: QUICKLOOK_LINKIFY=0 is a pure pass-through" {
+  run bash -c ". '$LIB'; printf 'see scripts/lib.sh\n' | QUICKLOOK_LINKIFY=0 linkify"
+  [ "$output" = "see scripts/lib.sh" ]
+}
+
+# ---- no filesystem access (the perf contract that PR #23's linkify broke) ----
+
+@test "linkify: links a path that does not exist (shape only, no resolve)" {
+  run bash -c ". '$LIB'; printf 'see totally/absent/file.md\n' | linkify"
+  [[ "$output" == *"]8;;"* ]]
+}

--- a/tests/renderers-markdown.bats
+++ b/tests/renderers-markdown.bats
@@ -139,7 +139,10 @@ printf '%s\n' "$STUB/vroot"
 SH
   chmod +x "$STUB/herdr" "$STUB/jq"
   unset QUICKLOOK_GLOW_STYLE HERDR_BIN_PATH
-  run render_markdown "$FIX/doc.md"
+  # linkify off: this asserts what glow was INVOKED with, and the linkifier
+  # legitimately wraps the style path in an OSC-8 link on the way to the
+  # pager, which splits the literal "-s <path>" run.
+  QUICKLOOK_LINKIFY=0 run render_markdown "$FIX/doc.md"
   [ "$status" -eq 0 ]
   [[ "$output" == *"-s $STUB/vroot/assets/markdown-style.json"* ]]
 }


### PR DESCRIPTION
Stacked on #71.

Half one of the click-through preview: make the pager emit links. The stack
(replace-in-place, pop back on exit) lands in a follow-up.

## Why nothing was clickable

`less` was never the obstacle: it passes OSC-8 through byte-for-byte under
`-R` (verified with `od -c` on a piped hyperlink). The preview simply never
emitted links of its own. glow hyperlinks markdown *link syntax*, which is
why URLs in a rendered `.md` are already clickable, but a bare
`scripts/lib.sh` is not a link to glow, so no path in a document was.

## Why this is not the pane 0.4.0 deleted

That linkify pane CLASSIFIED every span (resolve + git lookups per token).
That is why it had to be scoped to one visible screen and still ran its scan
in a background subshell to keep the paint instant.

This one classifies nothing. It matches on shape, never touches the
filesystem, and leaves resolution to the click path, which already resolves
and already reports a miss ("not a file I can find"). A false-positive link
that fails on click is a far cheaper mistake than a preview that takes a
second to paint, so the whole document is linked in one awk pass with no
forks.

## Encoding

The encoder is inline rather than `quicklook_link_uri`, which forks `jq` per
token. It has to agree with jq's `@uri` byte-for-byte, because
`quicklook_token_from_link` re-encodes and demands an exact match before it
returns a token; disagreement would silently refuse every link at click
time. RFC 3986 unreserved verbatim, everything else `%XX` uppercase. Parity
is pinned by a test rather than asserted.

## Two bugs found while building it

- `match()` leaves `RLENGTH` at -1 on a no-match. Reading it after a nested
  `scan()` made `substr(line, 0)` return the whole line, so any coloured line
  whose text held no token looped forever. Caught by a hung awk process.
- Omitting `/` from the pattern's start class matched an absolute path from
  its second character, so the link carried a relative `var/folders/...` that
  would resolve against the wrong root. Caught by two existing tests.

## Verification

- `bats tests/` — 508 passed, 0 failed
- `shellcheck -x scripts/lib.sh` clean
- 9 new tests in `tests/linkify.bats`: jq parity, decode round-trip, the
  absolute-path regression, no-nesting into glow's own links, SGR
  preservation, the infinite-loop regression, opt-out, and shape-only
  matching (links a path that does not exist, proving no filesystem access)
- End to end on `CHANGELOG.md` through the real glow pipeline: `vcs.sh`,
  `lib.sh` and `assets/markdown-style.json` all wrapped, slash encoded `%2F`

One existing test now runs with `QUICKLOOK_LINKIFY=0`: it asserts glow's
argv, and linkify legitimately splits the literal `-s <path>` run by linking
the path.

## Not verified here

The click itself needs a human in the terminal. The transport is the one
hint-pane already uses in production, and the preview opens as an overlay,
which `DESIGN.md` says participates in Ctrl+click resolution.
