### PR TITLE
fix: open paths with spaces and %20-encoded spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Hint scan rejoins whitespace-split path spans when they form a real file (e.g. `…/Tray status icon.plan.md`), and stops before trailing prose after an extension (`….plan.md please`). Bare filesystem paths containing `%XX` (e.g. `Tray%20status….md`) now decode the same way GitHub blob paths already did.
+
 ## 0.7.0 (2026-07-27)
 
 - The data formats join the stack. csv, json, sqlite, plist, archives and

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -883,6 +883,19 @@ resolve() {
       done
       ;;
   esac
+  # Agents and OSC-8 / file:// paste often leave %XX escapes in an otherwise
+  # absolute filesystem path (Tray%20status….md). GitHub blob paths already
+  # decode in map_*_url; bare paths need the same chance here.
+  case "$p" in
+    *%*)
+      local decoded
+      decoded="$(urldecode "$p")"
+      if [ -n "$decoded" ] && [ "$decoded" != "$p" ]; then
+        resolve "$decoded"
+        return $?
+      fi
+      ;;
+  esac
   return 1
 }
 
@@ -1496,6 +1509,16 @@ _pick_resolve_local() {
       done
       ;;
   esac
+  case "$p" in
+    *%*)
+      local decoded
+      decoded="$(urldecode "$p")"
+      if [ -n "$decoded" ] && [ "$decoded" != "$p" ]; then
+        _pick_resolve_local "$decoded"
+        return $?
+      fi
+      ;;
+  esac
   return 1
 }
 
@@ -1741,6 +1764,153 @@ _pick_classify_span() {
   esac
 }
 
+
+# ---- spaced-path rejoin (pick_scan_text Pass 1b) ----------------------------
+# Pass 1 awk whitespace-splits, so `/path/Tray status icon.plan.md` becomes
+# three spans. When a path-shaped prefix can grow into a real file by joining
+# the next words with spaces, emit the joined token instead. Stop when:
+#   - we already have a file match and the longer string is not a file, or
+#   - current basename already looks like name.ext and the next word has no
+#     '.' (trailing prose after an extension: `….plan.md please`), or
+#   - the partial is no longer under an existing directory.
+# %XX in a single span is handled by resolve/_pick_resolve_local decode; this
+# join only repairs whitespace splits.
+
+_pick_fs_is_file() {
+  local p="$1" d
+  case "$p" in
+    '~/'*) p="$HOME/${p#~/}" ;;
+  esac
+  [ -f "$p" ] && return 0
+  [ -f "$PWD/$p" ] && return 0
+  case "$1" in
+    *%*)
+      d="$(urldecode "$1")"
+      if [ -n "$d" ] && [ "$d" != "$1" ]; then
+        case "$d" in
+          '~/'*) d="$HOME/${d#~/}" ;;
+        esac
+        [ -f "$d" ] && return 0
+        [ -f "$PWD/$d" ] && return 0
+      fi
+      ;;
+  esac
+  return 1
+}
+
+_pick_plausible_partial_path() {
+  local p="$1" d parent
+  case "$p" in
+    *%*)
+      d="$(urldecode "$p")"
+      [ -n "$d" ] && [ "$d" != "$p" ] && p="$d"
+      ;;
+  esac
+  case "$p" in
+    '~/'*) p="$HOME/${p#~/}" ;;
+  esac
+  [ -d "$p" ] && return 0
+  [ -d "$PWD/$p" ] && return 0
+  parent="${p%/*}"
+  if [ -n "$parent" ] && [ "$parent" != "$p" ]; then
+    [ -d "$parent" ] && return 0
+    [ -d "$PWD/$parent" ] && return 0
+  fi
+  return 1
+}
+
+_pick_path_shaped_for_join() {
+  # shellcheck disable=SC2088
+  case "$1" in
+    '~/'* | ./* | ../* | /* | */*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_pick_basename_has_ext() {
+  local base="${1##*/}"
+  case "$base" in
+    *.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# stdin: ordered <line>\t<token> rows from awk (NOT yet deduped).
+# stdout: unique <line>\t<token> after spaced rejoin (bottom-most line wins).
+_pick_rejoin_spaced_paths() {
+  local ln tok cur=""
+  local -a spans=()
+  local out=""
+
+  _pick_flush_line_spans() {
+    local n=${#spans[@]} i=0
+    [ "$n" -eq 0 ] && return 0
+    while [ "$i" -lt "$n" ]; do
+      local s="${spans[$i]}"
+      if ! _pick_path_shaped_for_join "$s"; then
+        out+="$cur"$'\t'"$s"$'\n'
+        i=$((i + 1))
+        continue
+      fi
+      local cand="$s" best="" best_j=$i j=$i
+      while [ "$j" -lt "$n" ]; do
+        if _pick_fs_is_file "$cand"; then
+          best="$cand"
+          best_j=$j
+        elif [ -n "$best" ]; then
+          break
+        elif ! _pick_plausible_partial_path "$cand"; then
+          break
+        fi
+        j=$((j + 1))
+        [ "$j" -ge "$n" ] && break
+        local next="${spans[$j]}"
+        case "$next" in
+          http://* | https://* | \#*) break ;;
+        esac
+        # Extension stop: `….plan.md please` — do not glue prose.
+        if _pick_basename_has_ext "$cand"; then
+          case "$next" in
+            *.*) ;;
+            *) break ;;
+          esac
+        fi
+        cand="$cand $next"
+      done
+      if [ -n "$best" ]; then
+        out+="$cur"$'\t'"$best"$'\n'
+        i=$((best_j + 1))
+      else
+        out+="$cur"$'\t'"$s"$'\n'
+        i=$((i + 1))
+      fi
+    done
+  }
+
+  while IFS=$'\t' read -r ln tok || [ -n "${ln:-}" ]; do
+    [ -z "${tok:-}" ] && [ -z "${ln:-}" ] && continue
+    if [ -z "$cur" ]; then
+      cur="$ln"
+      spans=("$tok")
+      continue
+    fi
+    if [ "$ln" = "$cur" ]; then
+      spans+=("$tok")
+    else
+      _pick_flush_line_spans
+      cur="$ln"
+      spans=("$tok")
+    fi
+  done
+  [ -n "$cur" ] && _pick_flush_line_spans
+
+  # Dedup: bottom-most line wins (same as the former awk seen[] pass).
+  printf '%s' "$out" | awk -F'\t' -v OFS=$'\t' '
+    NF >= 2 { seen[$2] = $1 }
+    END { for (t in seen) print seen[t], t }
+  '
+}
+
 # pick_scan_text -> see the contract comment above. Pure and
 # side-effect-free beyond the read-only filesystem lookups the handler
 # registry already does; no clipboard read, no pane read, no fzf, no
@@ -1870,14 +2040,17 @@ pick_scan_text() {
         if (spans[i] == "") continue
         t = trim(spans[i])
         if (t == "") continue
-        seen[t] = line_no
+        # Ordered emission (no dedup here): Pass 1b rejoins spaced paths
+        # using neighboring spans on the same line, then dedups.
+        print line_no, t
       }
-    }
-    END {
-      for (tok in seen) print seen[tok], tok
     }
   ')"
 
+  [ -z "$dedup" ] && return 0
+
+  # Pass 1b: rejoin whitespace-split path spans when a real file matches.
+  dedup="$(_pick_rejoin_spaced_paths <<<"$dedup")"
   [ -z "$dedup" ] && return 0
 
   # Hoist repo state ONCE for the whole scan, not once per span (see the

--- a/tests/pick-scan.bats
+++ b/tests/pick-scan.bats
@@ -664,3 +664,45 @@ SCRIPT
   run bash -c ". '$LIB'; printf 'a\nb\n' | pad_left"
   [ "$output" = "$(printf '  a\n  b')" ]
 }
+
+# ---- spaced path tokens (whitespace-joined when a real file matches) ----
+
+@test "pick_scan_text: absolute path with spaces rejoins to one path token" {
+  mkdir -p "$FIX/spaced"
+  printf 'plan\n' >"$FIX/spaced/Tray status icon.plan.md"
+  run pick_scan_text <<<"open $FIX/spaced/Tray status icon.plan.md please"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf '%s\tpath\t1' "$FIX/spaced/Tray status icon.plan.md")" ]
+}
+
+@test "pick_scan_text: relative path with spaces rejoins under \$PWD" {
+  mkdir -p "$FIX/repo/docs"
+  printf 'ok\n' >"$FIX/repo/docs/my file.md"
+  git -C "$FIX/repo" add -A
+  git -C "$FIX/repo" -c user.email=t@t -c user.name=t commit -qm spaced
+  run pick_scan_text <<<'see docs/my file.md next'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$(printf 'docs/my file.md\tpath\t1')" ]
+}
+
+@test "pick_scan_text: trailing prose after an extension is not glued onto a spaced path" {
+  mkdir -p "$FIX/spaced"
+  printf 'plan\n' >"$FIX/spaced/Tray status icon.plan.md"
+  run pick_scan_text <<<"$FIX/spaced/Tray status icon.plan.md please read this"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'\tpath\t'* ]]
+  [[ "$output" != *"please"* ]]
+  [[ "$output" == *"$FIX/spaced/Tray status icon.plan.md"* ]]
+}
+
+@test "pick_scan_text: percent-encoded spaces in an absolute path resolve via decode" {
+  mkdir -p "$FIX/spaced"
+  printf 'plan\n' >"$FIX/spaced/Tray status icon.plan.md"
+  # single whitespace-free token (as agents sometimes print); classify after resolve/decode
+  run pick_scan_text <<<"open $FIX/spaced/Tray%20status%20icon.plan.md now"
+  [ "$status" -eq 0 ]
+  # On-screen token keeps %20 (so the hint can still match screen text); kind is path
+  # because resolve/decode finds the file during classify.
+  [[ "$output" == *"$FIX/spaced/Tray%20status%20icon.plan.md"$'\tpath\t'* ]] || \
+    [[ "$output" == *"$FIX/spaced/Tray status icon.plan.md"$'\tpath\t'* ]]
+}

--- a/tests/quicklook.bats
+++ b/tests/quicklook.bats
@@ -241,3 +241,29 @@ teardown() {
   [ "$rc" -eq 0 ]
   [ "$RESOLVED_MODE" = "browser" ]
 }
+
+# ---- urldecode bare filesystem paths (%20 etc.) ----
+
+@test "resolve: percent-encoded spaces decode to an existing file" {
+  mkdir -p "$FIX/repo/docs"
+  printf 'ok\n' >"$FIX/repo/docs/my file.md"
+  run resolve "$FIX/repo/docs/my%20file.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX/repo/docs/my file.md" ]
+}
+
+@test "resolve: path with real spaces still works" {
+  mkdir -p "$FIX/repo/docs"
+  printf 'ok\n' >"$FIX/repo/docs/my file.md"
+  run resolve "$FIX/repo/docs/my file.md"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$FIX/repo/docs/my file.md" ]
+}
+
+@test "resolve_any_token: percent-encoded absolute path opens as file" {
+  mkdir -p "$FIX/repo/docs"
+  printf 'ok\n' >"$FIX/repo/docs/my file.md"
+  resolve_any_token "$FIX/repo/docs/my%20file.md"
+  [ "$RESOLVED_MODE" = "file" ]
+  [ "$RESOLVED_TARGET" = "$FIX/repo/docs/my file.md" ]
+}


### PR DESCRIPTION
## Summary
- Hint scan used to whitespace-split tokens, so a path like `/home/…/.cursor/plans/Tray status icon-….plan.md` only highlighted `/…/Tray` and preview failed with “not a file I can find”.
- Pass 1b rejoins adjacent spans when they form a real file, and stops before trailing prose after an extension (`….plan.md please`).
- Bare filesystem paths with `%XX` (e.g. agent-printed `Tray%20status….md`) now URL-decode in `resolve` / `_pick_resolve_local`, matching GitHub blob path decoding.

## Test plan
- [x] `bats tests/pick-scan.bats -f 'spaces|percent-encoded|trailing prose'`
- [x] `bats tests/quicklook.bats -f 'percent-encoded|real spaces'`
- [x] Manual: `pick_scan_text` on a real `~/.cursor/plans/Tray status icon-….plan.md` line returns one `path` token; `resolve` on the `%20` form finds the file
- [x] In herdr with this branch installed: `prefix+v` on an agent pane showing a spaced plan path → preview opens