### PR TITLE
fix: gate lesskey pshell for stock less 590

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preview `lesskey`: gate the `e`/`pshell` binding with `#version >= 632`. Stock less 590 (Ubuntu/Mint) has no `pshell` and used to reject the whole lesskey ("Press RETURN"); older less now loads `o`/`D`/quit cleanly, and newer less keeps `e` → `$EDITOR`.
+
 ## 0.7.0 (2026-07-27)
 
 - The data formats join the stack. csv, json, sqlite, plist, archives and

--- a/lesskey
+++ b/lesskey
@@ -31,7 +31,12 @@
 #command
 \e\e quit
 o visual
-e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n
+# `pshell` (less's `#` prompt-shell) exists from less ~632. Ubuntu/Mint still
+# ship less 590, which rejects unknown actions and then refuses the WHOLE
+# lesskey (preview pauses on "Press RETURN"). `#version` was added in 594 and
+# is ignored entirely on older less, so wrapping the binding keeps `e` on
+# modern less while stock 590 loads o/D/quit with no error.
+#version >= 632  e pshell \020"$QUICKLOOK_EDITOR_SCRIPT" ?lm+%lm. %g\n
 D shell \020"$(dirname "$QUICKLOOK_EDITOR_SCRIPT")/dirty-diff.sh" %\n
 
 # Stack pop. `,` and Backspace remove the current file from less's file list,

--- a/tests/pager-key-footer.bats
+++ b/tests/pager-key-footer.bats
@@ -38,8 +38,10 @@ teardown() {
 
 @test "the footer never advertises a key that is not bound" {
   # o / e / D come from ../lesskey; q and / are less's own built-ins.
+  # `e` is gated with `#version >= 632` so stock less 590 can load the file
+  # (pshell does not exist there); on modern less the binding is active.
   grep -qE '^o visual' "$LESSKEY"
-  grep -qE '^e pshell' "$LESSKEY"
+  grep -qE '^(#version >= 632[[:space:]]+)?e pshell' "$LESSKEY"
   grep -qE '^D shell' "$LESSKEY"
   for k in o e D; do
     [[ "$QUICKLOOK_KEY_HINT" == *"$k "* ]]


### PR DESCRIPTION
## Summary
- Stock Ubuntu/Mint `less` is **590**: it has no `pshell` lesskey action. Quicklook’s `e pshell …` line made less reject the **entire** lesskey and pause preview on `Press RETURN`.
- Gate that binding with `#version >= 632` (`pshell` exists from ~632; `#version` itself is ignored entirely on less &lt; 594, including 590).
- Result: less 590 loads `o` / `D` / quit with no error; less ≥ 632 keeps `e` → `$EDITOR`.

## Test plan
- [x] `less --lesskey-src=./lesskey -e /etc/hosts` on less 590: no `unknown action: pshell`
- [x] `bats tests/pager-key-footer.bats`
- [ ] In herdr on Ubuntu/Mint: `prefix+v` → open a file → preview appears **without** RETURN prompt; `o` and `D` still work (`e` unbound until less is upgraded)